### PR TITLE
feat: v1.3.0 — snapshot distribution, layout fixes, keyboard fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Pneuma Skills is an extensible delivery platform for filesystem-based Agent capa
 
 **Formula:** `ModeManifest(skill + viewer + agent_config) × AgentBackend × RuntimeShell`
 
-**Version:** 1.2.2
+**Version:** 1.3.0
 **Runtime:** Bun >= 1.3.5 (required, not Node.js)
 **Available Modes:** `doc` (markdown editing), `slide` (presentation editing)
 

--- a/core/types/mode-manifest.ts
+++ b/core/types/mode-manifest.ts
@@ -64,6 +64,8 @@ export interface InitParam {
   type: "number" | "string";
   /** 默认值 */
   defaultValue: number | string;
+  /** 标记为敏感值 (API key 等)，snapshot 打包时会被清空 */
+  sensitive?: boolean;
 }
 
 /** 工作区初始化配置 — 描述空 workspace 时的初始化行为 */

--- a/modes/slide/manifest.ts
+++ b/modes/slide/manifest.ts
@@ -82,8 +82,8 @@ You are a presentation expert running inside Pneuma Slide Mode. The user views y
     params: [
       { name: "slideWidth", label: "Slide width", description: "pixels", type: "number", defaultValue: 1280 },
       { name: "slideHeight", label: "Slide height", description: "pixels", type: "number", defaultValue: 720 },
-      { name: "openrouterApiKey", label: "OpenRouter API Key", description: "for AI image generation, leave blank to skip", type: "string", defaultValue: "" },
-      { name: "falApiKey", label: "fal.ai API Key", description: "for AI image generation, leave blank to skip", type: "string", defaultValue: "" },
+      { name: "openrouterApiKey", label: "OpenRouter API Key", description: "for AI image generation, leave blank to skip", type: "string", defaultValue: "", sensitive: true },
+      { name: "falApiKey", label: "fal.ai API Key", description: "for AI image generation, leave blank to skip", type: "string", defaultValue: "", sensitive: true },
     ],
     deriveParams: (params) => ({
       ...params,

--- a/modes/slide/skill/SKILL.md
+++ b/modes/slide/skill/SKILL.md
@@ -125,10 +125,14 @@ After all slides are generated:
 
 When the user asks to modify existing slides:
 
-1. **Read context**: The system provides which slide the user is viewing and what element they selected
-2. **Read the target file(s)**: Always read the current HTML before editing
-3. **Make focused edits**: Use the `Edit` tool for surgical changes, `Write` for full rewrites
-4. **One operation at a time**: Apply the change, let the user see the result in real-time
+1. **Determine scope first**: Decide whether the request targets a single slide or the entire deck
+   - **Deck-wide** if the request involves: style/theme changes, language translation, tone transformation, restructuring, or any request that logically applies to all slides (e.g. "make it tech-style", "translate to English", "change the color scheme")
+   - **Single slide** if the request references a specific slide by number/title, or describes a localized content change (e.g. "fix the typo on this slide", "add a chart here")
+   - When in doubt, prefer deck-wide — it's easier for the user to say "only this slide" than to re-request for every slide
+2. **Read context**: The system provides which slide the user is viewing and what element they selected
+3. **Read the target file(s)**: Always read the current HTML before editing. For deck-wide changes, read manifest.json first to get the full slide list, then read all slides
+4. **Make focused edits**: Use the `Edit` tool for surgical changes, `Write` for full rewrites
+5. **One operation at a time**: Apply the change, let the user see the result in real-time
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pneuma-skills",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "type": "module",
   "description": "Framework for Code Agents to do WYSIWYG editing on HTML-based content",
   "license": "MIT",
@@ -13,6 +13,7 @@
     "backends/",
     "core/",
     "modes/",
+    "snapshot/",
     "dist/",
     "index.html",
     "README.md"

--- a/snapshot/archive.ts
+++ b/snapshot/archive.ts
@@ -1,0 +1,131 @@
+/**
+ * Archive creation and extraction via system `tar` command.
+ */
+
+import { join } from "node:path";
+
+const BASE_EXCLUDES = [
+  ".git",
+  "node_modules",
+  ".pneuma/session.json",
+  ".pneuma/history.json",
+  ".DS_Store",
+];
+
+/** Extra excludes when including .claude/ skills — only keep .claude/skills/ (minus .env) */
+const CLAUDE_DIR_EXCLUDES = [
+  ".claude/settings.json",
+  ".claude/projects",
+  ".claude/credentials",
+  ".claude/statsig",
+  ".claude/todos",
+  ".claude/mcp.json",
+  ".claude/skills/*/.env",   // generated env files contain API keys
+];
+
+export interface ArchiveOptions {
+  includeSkills?: boolean;
+  /** Param names declared as sensitive in ModeManifest — stripped from config.json */
+  sensitiveKeys?: string[];
+}
+
+/**
+ * Create a tar.gz archive of the workspace directory.
+ *
+ * - Default: excludes .claude/ entirely
+ * - includeSkills: includes .claude/skills/ only (strips settings, projects, .env files)
+ * - sensitiveKeys: param names from manifest (sensitive: true) — cleared in config.json
+ */
+export async function createArchive(
+  workspace: string,
+  outputPath: string,
+  options?: ArchiveOptions,
+): Promise<string> {
+  const { existsSync, readFileSync, writeFileSync, renameSync } = await import("node:fs");
+
+  // Sanitize config.json — strip manifest-declared sensitive fields
+  const configPath = join(workspace, ".pneuma", "config.json");
+  let configBackupPath: string | null = null;
+  const sensitiveKeys = options?.sensitiveKeys ?? [];
+
+  if (sensitiveKeys.length > 0 && existsSync(configPath)) {
+    try {
+      const raw = readFileSync(configPath, "utf-8");
+      const config = JSON.parse(raw);
+      const sanitized = sanitizeConfig(config, sensitiveKeys);
+      if (JSON.stringify(config) !== JSON.stringify(sanitized)) {
+        configBackupPath = configPath + ".bak";
+        renameSync(configPath, configBackupPath);
+        writeFileSync(configPath, JSON.stringify(sanitized, null, 2));
+      }
+    } catch {}
+  }
+
+  const excludes = [...BASE_EXCLUDES];
+  if (options?.includeSkills) {
+    excludes.push(...CLAUDE_DIR_EXCLUDES);
+  } else {
+    excludes.push(".claude");
+  }
+  const excludeArgs = excludes.flatMap((p) => ["--exclude", p]);
+
+  const proc = Bun.spawn(["tar", "czf", outputPath, ...excludeArgs, "."], {
+    cwd: workspace,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const exitCode = await proc.exited;
+
+  // Restore original config.json
+  if (configBackupPath) {
+    const { unlinkSync } = await import("node:fs");
+    try { unlinkSync(configPath); } catch {}
+    renameSync(configBackupPath, configPath);
+  }
+
+  if (exitCode !== 0) {
+    const stderr = await new Response(proc.stderr).text();
+    throw new Error(`tar create failed (exit ${exitCode}): ${stderr}`);
+  }
+
+  return outputPath;
+}
+
+/**
+ * Strip sensitive values from config. Only clears keys explicitly declared
+ * as sensitive in the ModeManifest — no guessing.
+ */
+function sanitizeConfig(
+  config: Record<string, unknown>,
+  sensitiveKeys: string[],
+): Record<string, unknown> {
+  const keySet = new Set(sensitiveKeys);
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(config)) {
+    result[key] = keySet.has(key) ? "" : value;
+  }
+  return result;
+}
+
+/**
+ * Extract a tar.gz archive into the target directory.
+ */
+export async function extractArchive(
+  archivePath: string,
+  targetDir: string,
+): Promise<void> {
+  const { mkdirSync } = await import("node:fs");
+  mkdirSync(targetDir, { recursive: true });
+
+  const proc = Bun.spawn(["tar", "xzf", archivePath, "-C", targetDir], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const exitCode = await proc.exited;
+  if (exitCode !== 0) {
+    const stderr = await new Response(proc.stderr).text();
+    throw new Error(`tar extract failed (exit ${exitCode}): ${stderr}`);
+  }
+}

--- a/snapshot/index.ts
+++ b/snapshot/index.ts
@@ -1,0 +1,86 @@
+/**
+ * Snapshot CLI entry: parse args and dispatch to push/pull/list.
+ */
+
+import { resolve } from "node:path";
+import { push } from "./push.js";
+import { pull } from "./pull.js";
+import { getCredentials, listSnapshots } from "./r2.js";
+
+function printUsage(): void {
+  console.log(`Usage:
+  bunx pneuma-skills snapshot push [--workspace .] [--mode doc|slide] [--include-skills]
+  bunx pneuma-skills snapshot pull <url> [--workspace /tmp/pneuma-slide]
+  bunx pneuma-skills snapshot list`);
+}
+
+function parseSnapshotArgs(args: string[]): {
+  subcommand: string;
+  workspace: string;
+  mode?: string;
+  url?: string;
+  includeSkills: boolean;
+} {
+  const subcommand = args[0] ?? "";
+  let workspace = process.cwd();
+  let mode: string | undefined;
+  let url: string | undefined;
+  let includeSkills = false;
+
+  for (let i = 1; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--workspace" && i + 1 < args.length) {
+      workspace = args[++i];
+    } else if (arg === "--mode" && i + 1 < args.length) {
+      mode = args[++i];
+    } else if (arg === "--include-skills") {
+      includeSkills = true;
+    } else if (!arg.startsWith("--")) {
+      url = arg;
+    }
+  }
+
+  return { subcommand, workspace: resolve(workspace), mode, url, includeSkills };
+}
+
+export async function runSnapshot(args: string[]): Promise<void> {
+  const { subcommand, workspace, mode, url, includeSkills } = parseSnapshotArgs(args);
+
+  switch (subcommand) {
+    case "push":
+      await push(workspace, mode, includeSkills);
+      break;
+
+    case "pull":
+      if (!url) {
+        console.error("[snapshot] Missing URL argument.");
+        printUsage();
+        process.exit(1);
+      }
+      await pull(url, workspace);
+      break;
+
+    case "list": {
+      const creds = await getCredentials();
+      const snapshots = await listSnapshots(creds);
+      if (snapshots.length === 0) {
+        console.log("[snapshot] No snapshots found.");
+      } else {
+        console.log(`[snapshot] ${snapshots.length} snapshot(s):\n`);
+        for (const s of snapshots) {
+          const sizeMB = (s.size / 1024 / 1024).toFixed(2);
+          const date = new Date(s.lastModified).toLocaleString();
+          const pullUrl = `${creds.publicUrl}/${s.key}`;
+          console.log(`  ${s.key}`);
+          console.log(`    Size: ${sizeMB} MB | Uploaded: ${date}`);
+          console.log(`    Pull: bunx pneuma-skills snapshot pull ${pullUrl} --workspace /tmp/pneuma-slide\n`);
+        }
+      }
+      break;
+    }
+
+    default:
+      printUsage();
+      process.exit(1);
+  }
+}

--- a/snapshot/pull.ts
+++ b/snapshot/pull.ts
@@ -1,0 +1,94 @@
+/**
+ * Snapshot pull: download from URL + extract to workspace.
+ */
+
+import { join, basename, resolve, dirname } from "node:path";
+import { mkdirSync, readFileSync, existsSync, readdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import * as readline from "node:readline";
+import { extractArchive } from "./archive.js";
+import type { SnapshotMetadata } from "./types.js";
+
+function ask(question: string): Promise<string> {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise((r) => {
+    rl.question(question, (answer) => { rl.close(); r(answer.trim()); });
+  });
+}
+
+/**
+ * Pull a snapshot from a URL and extract to workspace directory.
+ */
+export async function pull(url: string, workspace: string): Promise<void> {
+  console.log(`[snapshot] Pulling from: ${url}`);
+  console.log(`[snapshot] Target workspace: ${workspace}`);
+
+  // 1. Check if workspace already exists and has files
+  if (existsSync(workspace)) {
+    try {
+      const entries = readdirSync(workspace);
+      if (entries.length > 0) {
+        const answer = await ask(
+          `[snapshot] Directory already exists and is not empty: ${workspace}\n` +
+          `  Extracting will overwrite existing files. Continue? [y/N] `,
+        );
+        if (answer.toLowerCase() !== "y") {
+          console.log("[snapshot] Aborted.");
+          process.exit(0);
+        }
+      }
+    } catch {}
+  }
+
+  // 2. Download the archive
+  const response = await fetch(url);
+  if (!response.ok) {
+    console.error(`[snapshot] Download failed: ${response.status} ${response.statusText}`);
+    process.exit(1);
+  }
+
+  const archiveName = basename(new URL(url).pathname) || "snapshot.tar.gz";
+  const archivePath = join(tmpdir(), archiveName);
+
+  const data = await response.arrayBuffer();
+  await Bun.write(archivePath, data);
+
+  const sizeMB = (data.byteLength / 1024 / 1024).toFixed(2);
+  console.log(`[snapshot] Downloaded: ${sizeMB} MB`);
+
+  // 2. Extract
+  mkdirSync(workspace, { recursive: true });
+  console.log("[snapshot] Extracting...");
+  await extractArchive(archivePath, workspace);
+
+  // 3. Clean up temp file
+  const { unlinkSync } = await import("node:fs");
+  try { unlinkSync(archivePath); } catch {}
+
+  // 4. Read snapshot metadata to determine mode
+  let mode = "<mode>";
+  try {
+    const meta: SnapshotMetadata = JSON.parse(
+      readFileSync(join(workspace, ".pneuma-snapshot.json"), "utf-8"),
+    );
+    mode = meta.mode;
+  } catch {}
+
+  const runCmd = `bunx pneuma-skills ${mode} --workspace ${workspace}`;
+  console.log(`[snapshot] Extracted to: ${workspace}`);
+  console.log(`\n  Run later with:\n    ${runCmd}`);
+
+  // Offer to launch immediately
+  if (mode !== "<mode>") {
+    const answer = await ask("\nLaunch now? [Y/n] ");
+    if (answer.toLowerCase() !== "n") {
+      const binPath = resolve(dirname(import.meta.path), "..", "bin", "pneuma.ts");
+      const proc = Bun.spawn(["bun", binPath, mode, "--workspace", workspace], {
+        stdin: "inherit",
+        stdout: "inherit",
+        stderr: "inherit",
+      });
+      await proc.exited;
+    }
+  }
+}

--- a/snapshot/push.ts
+++ b/snapshot/push.ts
@@ -1,0 +1,111 @@
+/**
+ * Snapshot push: archive workspace + upload to R2.
+ */
+
+import { join, basename } from "node:path";
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { createArchive } from "./archive.js";
+import { getCredentials, uploadToR2 } from "./r2.js";
+import { loadModeManifest } from "../core/mode-loader.js";
+import type { SnapshotMetadata } from "./types.js";
+
+/**
+ * Detect mode from .pneuma/session.json in workspace.
+ */
+function detectMode(workspace: string): string | null {
+  try {
+    const content = readFileSync(join(workspace, ".pneuma", "session.json"), "utf-8");
+    const session = JSON.parse(content);
+    return session.mode ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read project version from package.json.
+ */
+function getVersion(): string {
+  try {
+    const pkg = readFileSync(join(import.meta.dir, "..", "package.json"), "utf-8");
+    return JSON.parse(pkg).version ?? "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
+/**
+ * Push a workspace snapshot to R2.
+ */
+export async function push(workspace: string, modeArg?: string, includeSkills?: boolean): Promise<void> {
+  // 1. Determine mode
+  const mode = modeArg ?? detectMode(workspace);
+  if (!mode) {
+    console.error(
+      "[snapshot] Cannot determine mode. Either run from a workspace with .pneuma/session.json " +
+      "or pass --mode <doc|slide>.",
+    );
+    process.exit(1);
+  }
+
+  console.log(`[snapshot] Pushing workspace: ${workspace}`);
+  console.log(`[snapshot] Mode: ${mode}`);
+  if (includeSkills) {
+    console.log("[snapshot] Including .claude/ skills in archive");
+  }
+
+  // 2. Write snapshot metadata into workspace
+  const metadata: SnapshotMetadata = {
+    mode,
+    version: getVersion(),
+    createdAt: new Date().toISOString(),
+    workspace: basename(workspace),
+    ...(includeSkills ? { includeSkills: true } : {}),
+  };
+
+  const metadataPath = join(workspace, ".pneuma-snapshot.json");
+  writeFileSync(metadataPath, JSON.stringify(metadata, null, 2));
+  console.log("[snapshot] Created .pneuma-snapshot.json");
+
+  // 3. Load manifest to find sensitive param names
+  let sensitiveKeys: string[] = [];
+  try {
+    const manifest = await loadModeManifest(mode);
+    sensitiveKeys = (manifest.init?.params ?? [])
+      .filter((p) => p.sensitive)
+      .map((p) => p.name);
+    if (sensitiveKeys.length > 0) {
+      console.log(`[snapshot] Stripping sensitive config keys: ${sensitiveKeys.join(", ")}`);
+    }
+  } catch {}
+
+  // 4. Create archive
+  const now = new Date();
+  const timestamp = now.toISOString().replace(/[-:T]/g, "").replace(/\.\d+Z/, "").slice(0, 15);
+  const archiveName = `${mode}-${basename(workspace)}-${timestamp}.tar.gz`;
+  const archivePath = join(tmpdir(), archiveName);
+
+  console.log(`[snapshot] Creating archive: ${archiveName}`);
+  await createArchive(workspace, archivePath, { includeSkills, sensitiveKeys });
+
+  const file = Bun.file(archivePath);
+  const sizeMB = (file.size / 1024 / 1024).toFixed(2);
+  console.log(`[snapshot] Archive size: ${sizeMB} MB`);
+
+  // 4. Get credentials and upload
+  const creds = await getCredentials();
+  const key = `snapshots/${archiveName}`;
+
+  console.log("[snapshot] Uploading to R2...");
+  const publicUrl = await uploadToR2(archivePath, key, creds);
+
+  // 5. Clean up temp file and metadata in workspace
+  const { unlinkSync } = await import("node:fs");
+  try { unlinkSync(archivePath); } catch {}
+  try { unlinkSync(metadataPath); } catch {}
+
+  console.log(`\n[snapshot] Uploaded successfully!`);
+  console.log(`[snapshot] URL: ${publicUrl}`);
+  console.log(`\n  Pull with:\n    bunx pneuma-skills snapshot pull ${publicUrl} --workspace /tmp/pneuma-slide`);
+}

--- a/snapshot/r2.ts
+++ b/snapshot/r2.ts
@@ -1,0 +1,227 @@
+/**
+ * R2 credential management and S3 client wrapper using Bun.S3Client.
+ */
+
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
+import * as readline from "node:readline";
+import type { R2Credentials } from "./types.js";
+
+const CREDENTIALS_PATH = join(homedir(), ".pneuma", "r2.json");
+
+function ask(question: string): Promise<string> {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+  return new Promise((resolve) => {
+    rl.question(question, (answer) => {
+      rl.close();
+      resolve(answer.trim());
+    });
+  });
+}
+
+/**
+ * Load R2 credentials from ~/.pneuma/r2.json.
+ * Returns null if not found.
+ */
+export function loadCredentials(): R2Credentials | null {
+  try {
+    const content = readFileSync(CREDENTIALS_PATH, "utf-8");
+    return JSON.parse(content);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Save R2 credentials to ~/.pneuma/r2.json.
+ */
+export function saveCredentials(creds: R2Credentials): void {
+  const dir = join(homedir(), ".pneuma");
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(CREDENTIALS_PATH, JSON.stringify(creds, null, 2));
+  console.log(`[snapshot] Credentials saved to ${CREDENTIALS_PATH}`);
+}
+
+/**
+ * Prompt the user for R2 credentials interactively.
+ */
+export async function promptCredentials(): Promise<R2Credentials> {
+  console.log("[snapshot] R2 credentials not found. Please provide them:");
+  const accountId = await ask("  Account ID: ");
+  const accessKeyId = await ask("  Access Key ID: ");
+  const secretAccessKey = await ask("  Secret Access Key: ");
+  const bucket = await ask("  Bucket name [pneuma-playground]: ");
+  const publicUrl = await ask("  Public URL (e.g. https://pub-xxx.r2.dev): ");
+
+  const creds: R2Credentials = {
+    accountId,
+    accessKeyId,
+    secretAccessKey,
+    bucket: bucket || "pneuma-playground",
+    publicUrl: publicUrl.replace(/\/$/, ""), // strip trailing slash
+  };
+
+  saveCredentials(creds);
+  return creds;
+}
+
+/**
+ * Load credentials or prompt if not found.
+ */
+export async function getCredentials(): Promise<R2Credentials> {
+  const existing = loadCredentials();
+  if (existing) return existing;
+  return promptCredentials();
+}
+
+/**
+ * Upload a file to R2 using Bun.S3Client.
+ * Returns the public URL of the uploaded object.
+ */
+export async function uploadToR2(
+  filePath: string,
+  key: string,
+  creds: R2Credentials,
+): Promise<string> {
+  const endpoint = `https://${creds.accountId}.r2.cloudflarestorage.com`;
+
+  const client = new Bun.S3Client({
+    endpoint,
+    accessKeyId: creds.accessKeyId,
+    secretAccessKey: creds.secretAccessKey,
+    bucket: creds.bucket,
+  });
+
+  const file = Bun.file(filePath);
+  const body = await file.arrayBuffer();
+
+  const s3File = client.file(key);
+  await s3File.write(body, { type: "application/gzip" });
+
+  return `${creds.publicUrl}/${key}`;
+}
+
+/**
+ * List snapshot objects in R2.
+ * Returns an array of { key, size, lastModified }.
+ */
+export async function listSnapshots(
+  creds: R2Credentials,
+): Promise<Array<{ key: string; size: number; lastModified: string }>> {
+  // Use S3 ListObjectsV2 via fetch since Bun.S3Client doesn't expose list
+  const endpoint = `https://${creds.accountId}.r2.cloudflarestorage.com`;
+
+  // Sign a simple GET request for listing
+  // We'll use the S3 REST API with query auth
+  const url = `${endpoint}/${creds.bucket}?list-type=2&prefix=snapshots/`;
+
+  // Use AWS Signature V4 — leverage Bun's built-in fetch with S3
+  // Since Bun.S3Client doesn't have list, we do a manual S3 list via signed request
+  const { S3Client: BunS3 } = await import("bun");
+
+  // Alternative: use a raw HTTP request with AWS4 signing
+  // For simplicity, parse the bucket contents using Bun.S3Client's presign or direct API
+  // Actually, let's just use the @aws-sdk pattern with fetch + AWS4 signing
+
+  // Simpler approach: spawn aws CLI or use a minimal signing implementation
+  // For now, use a lightweight approach with Bun's native capabilities
+
+  const response = await signedS3Request("GET", `/${creds.bucket}?list-type=2&prefix=snapshots/`, creds);
+  const text = await response.text();
+
+  // Parse XML response
+  const results: Array<{ key: string; size: number; lastModified: string }> = [];
+  const contentRegex = /<Contents>([\s\S]*?)<\/Contents>/g;
+  let match;
+  while ((match = contentRegex.exec(text)) !== null) {
+    const block = match[1];
+    const key = block.match(/<Key>(.*?)<\/Key>/)?.[1] ?? "";
+    const size = parseInt(block.match(/<Size>(.*?)<\/Size>/)?.[1] ?? "0", 10);
+    const lastModified = block.match(/<LastModified>(.*?)<\/LastModified>/)?.[1] ?? "";
+    results.push({ key, size, lastModified });
+  }
+
+  return results;
+}
+
+/**
+ * Minimal AWS Signature V4 signed request for S3-compatible APIs.
+ */
+async function signedS3Request(
+  method: string,
+  path: string,
+  creds: R2Credentials,
+): Promise<Response> {
+  const endpoint = `https://${creds.accountId}.r2.cloudflarestorage.com`;
+  const url = `${endpoint}${path}`;
+
+  const now = new Date();
+  const dateStamp = now.toISOString().replace(/[-:]/g, "").slice(0, 8);
+  const amzDate = now.toISOString().replace(/[-:]/g, "").replace(/\.\d{3}/, "");
+  const region = "auto";
+  const service = "s3";
+
+  const host = `${creds.accountId}.r2.cloudflarestorage.com`;
+
+  // Parse path and query
+  const [canonicalPath, queryString] = path.split("?");
+  const canonicalQueryString = (queryString ?? "")
+    .split("&")
+    .filter(Boolean)
+    .sort()
+    .join("&");
+
+  const payloadHash = Bun.CryptoHasher.hash("sha256", "").toString("hex");
+
+  const canonicalHeaders = `host:${host}\nx-amz-content-sha256:${payloadHash}\nx-amz-date:${amzDate}\n`;
+  const signedHeaders = "host;x-amz-content-sha256;x-amz-date";
+
+  const canonicalRequest = [
+    method,
+    canonicalPath,
+    canonicalQueryString,
+    canonicalHeaders,
+    signedHeaders,
+    payloadHash,
+  ].join("\n");
+
+  const credentialScope = `${dateStamp}/${region}/${service}/aws4_request`;
+  const stringToSign = [
+    "AWS4-HMAC-SHA256",
+    amzDate,
+    credentialScope,
+    Bun.CryptoHasher.hash("sha256", canonicalRequest).toString("hex"),
+  ].join("\n");
+
+  // Derive signing key
+  const hmac = (key: Uint8Array | string, data: string): Uint8Array => {
+    const hasher = new Bun.CryptoHasher("sha256", typeof key === "string" ? new TextEncoder().encode(key) : key);
+    hasher.update(data);
+    return new Uint8Array(hasher.digest());
+  };
+
+  const kDate = hmac(`AWS4${creds.secretAccessKey}`, dateStamp);
+  const kRegion = hmac(kDate, region);
+  const kService = hmac(kRegion, service);
+  const kSigning = hmac(kService, "aws4_request");
+
+  const signatureHasher = new Bun.CryptoHasher("sha256", kSigning);
+  signatureHasher.update(stringToSign);
+  const signature = Buffer.from(signatureHasher.digest()).toString("hex");
+
+  const authorization = `AWS4-HMAC-SHA256 Credential=${creds.accessKeyId}/${credentialScope}, SignedHeaders=${signedHeaders}, Signature=${signature}`;
+
+  return fetch(url, {
+    method,
+    headers: {
+      Host: host,
+      "x-amz-date": amzDate,
+      "x-amz-content-sha256": payloadHash,
+      Authorization: authorization,
+    },
+  });
+}

--- a/snapshot/types.ts
+++ b/snapshot/types.ts
@@ -1,0 +1,19 @@
+/**
+ * Snapshot feature type definitions.
+ */
+
+export interface SnapshotMetadata {
+  mode: string;
+  version: string;
+  createdAt: string;
+  workspace: string;
+  includeSkills?: boolean;
+}
+
+export interface R2Credentials {
+  accountId: string;
+  accessKeyId: string;
+  secretAccessKey: string;
+  bucket: string;
+  publicUrl: string;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,5 +13,5 @@
     "isolatedModules": true,
     "noEmit": true
   },
-  "include": ["src", "server", "bin", "core", "modes", "backends"]
+  "include": ["src", "server", "bin", "core", "modes", "backends", "snapshot"]
 }


### PR DESCRIPTION
## Summary

### Workspace Snapshot & Distribution
- Add `pneuma snapshot push/pull/list` CLI commands for sharing workspace snapshots via Cloudflare R2
- Push archives workspace content (tar.gz), uploads to R2, outputs a public URL anyone can pull
- Pull downloads, extracts, and offers to launch immediately — no credentials needed
- `--include-skills` flag optionally bundles `.claude/skills/` (excluding `.env`, settings, credentials)
- Manifest-driven sensitive field stripping: `InitParam.sensitive` controls which config values get cleared
- Pull checks for existing directory before overwriting

### Server & UX Improvements
- Auto port retry on `EADDRINUSE` — tries up to 10 consecutive ports instead of crashing
- Default slide outline position changed from left sidebar to bottom (better for narrow screens)
- Chat panel narrowed from 45% to 40%, preview widened to 60%

### Bug Fixes
- Fix arrow keys captured by slide navigation when typing in input fields (Closes #7)

### Skill Prompt
- Editing workflow now determines scope (deck-wide vs single slide) before acting

### Version
- Bump to 1.3.0

## New files

```
snapshot/
  types.ts       — SnapshotMetadata, R2Credentials interfaces
  archive.ts     — tar.gz create/extract, manifest-driven config sanitization
  r2.ts          — credential management + Bun.S3Client upload + AWS4 signed list
  push.ts        — full push workflow (detect mode, archive, upload)
  pull.ts        — full pull workflow (download, extract, optional launch)
  index.ts       — CLI arg parsing + dispatch
```

## Test plan

- [x] `pneuma snapshot push` uploads and prints public URL
- [x] `pneuma snapshot pull <url>` downloads, extracts, offers to launch
- [x] Pull prompts before overwriting existing directory
- [x] Sensitive config keys stripped from archived config.json
- [x] Port auto-retry works when default port is occupied
- [x] Arrow keys work in chat input without triggering slide navigation
- [x] Slide outline defaults to bottom position

🤖 Generated with [Claude Code](https://claude.com/claude-code)