### PR TITLE
feat: selection UI — element thumbnails + simplified context

### DIFF
--- a/core/types/viewer-contract.ts
+++ b/core/types/viewer-contract.ts
@@ -20,6 +20,14 @@ export interface ViewerSelectionContext {
   content: string;
   file?: string;
   level?: number;
+  /** HTML tag name (e.g. "div", "section", "h2") */
+  tag?: string;
+  /** CSS class list (e.g. "card bg-white rounded-lg") */
+  classes?: string;
+  /** Unique CSS selector path (e.g. "section.hero > div.card:nth-child(2)") */
+  selector?: string;
+  /** SVG data URL thumbnail of the selected element (null if capture failed or element too large) */
+  thumbnail?: string;
 }
 
 /** 预览组件的 Props */

--- a/modes/slide/pneuma-mode.ts
+++ b/modes/slide/pneuma-mode.ts
@@ -54,11 +54,17 @@ const slideMode: ModeDefinition = {
       }
 
       // Include element selection (skip for "viewing" pseudo-selection)
-      if (selection && selection.type !== "viewing" && selection.content) {
-        const desc = selection.level
-          ? `${selection.type} (level ${selection.level})`
-          : selection.type;
-        parts.push(`[User selected: ${desc} "${selection.content}"]`);
+      if (selection && selection.type !== "viewing" && (selection.selector || selection.content)) {
+        if (selection.selector) {
+          // Concise format — Claude Code reads the HTML file anyway
+          parts.push(`[User selected: ${selection.selector}]`);
+        } else {
+          // Fallback for old selections without selector
+          const desc = selection.level
+            ? `${selection.type} (level ${selection.level})`
+            : selection.type;
+          parts.push(`[User selected: ${desc} "${selection.content}"]`);
+        }
       }
 
       return parts.join("\n");

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -66,7 +66,16 @@ function useViewerProps(): ViewerPreviewProps {
   return {
     files: files.map((f) => ({ path: f.path, content: f.content })),
     selection: selection
-      ? { type: selection.type, content: selection.content, level: selection.level }
+      ? {
+          type: selection.type,
+          content: selection.content,
+          level: selection.level,
+          file: selection.file,
+          tag: selection.tag,
+          classes: selection.classes,
+          selector: selection.selector,
+          thumbnail: selection.thumbnail,
+        }
       : null,
     onSelect: (sel) => {
       if (!sel) {
@@ -75,7 +84,16 @@ function useViewerProps(): ViewerPreviewProps {
       }
       // Use file from the viewer component (e.g. current slide), fallback to first file
       const file = sel.file || files[0]?.path || "";
-      setSelection({ type: sel.type as SelectionType, content: sel.content, level: sel.level, file });
+      setSelection({
+        type: sel.type as SelectionType,
+        content: sel.content,
+        level: sel.level,
+        file,
+        tag: sel.tag,
+        classes: sel.classes,
+        selector: sel.selector,
+        thumbnail: sel.thumbnail,
+      });
     },
     mode: previewMode,
     imageVersion: imageTick,

--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -14,7 +14,11 @@ interface ImageAttachment {
 }
 
 /** Format selection info for display in the chip */
-function formatSelectionLabel(sel: { type: string; content: string; level?: number; file: string }): string {
+function formatSelectionLabel(sel: { type: string; content: string; level?: number; file: string; tag?: string; classes?: string; selector?: string }): string {
+  if (sel.selector) {
+    const preview = sel.content.length > 40 ? sel.content.slice(0, 37) + "..." : sel.content;
+    return preview ? `${sel.selector}  "${preview}"` : sel.selector;
+  }
   const typeLabels: Record<string, string> = {
     heading: `h${sel.level || 1}`,
     paragraph: "paragraph",
@@ -24,6 +28,10 @@ function formatSelectionLabel(sel: { type: string; content: string; level?: numb
     image: "image",
     table: "table",
     "text-range": "text",
+    section: "section",
+    link: "link",
+    container: "container",
+    interactive: "interactive",
   };
   const type = typeLabels[sel.type] || sel.type;
   const preview = sel.content.length > 60 ? sel.content.slice(0, 57) + "..." : sel.content;
@@ -248,17 +256,22 @@ export default function ChatInput() {
       {/* Selection chip */}
       {selection && (
         <div className="flex items-center gap-2 mb-2 px-1">
-          <div className="flex items-center gap-1.5 px-2.5 py-1 rounded-md bg-cc-primary/15 text-cc-primary text-xs max-w-full overflow-hidden">
-            <PinIcon />
-            <span className="truncate">{formatSelectionLabel(selection)}</span>
-            <span className="shrink-0 text-cc-muted mx-0.5">in {selection.file}</span>
-            <button
-              onClick={() => setSelection(null)}
-              className="shrink-0 ml-0.5 hover:text-cc-fg transition-colors cursor-pointer"
-              title="Clear selection"
-            >
-              <CloseIcon />
-            </button>
+          <div className="rounded-md bg-cc-primary/15 text-cc-primary text-xs max-w-full overflow-hidden">
+            {selection.thumbnail && (
+              <img src={selection.thumbnail} alt="" className="mx-2 mt-2 max-h-16 max-w-[calc(100%-1rem)] rounded border border-cc-border/30 bg-white" />
+            )}
+            <div className="flex items-center gap-1.5 px-2.5 py-1.5">
+              <PinIcon />
+              <span className="truncate">{formatSelectionLabel(selection)}</span>
+              <span className="shrink-0 text-cc-muted text-[11px]">{selection.file}</span>
+              <button
+                onClick={() => setSelection(null)}
+                className="shrink-0 ml-0.5 hover:text-cc-fg transition-colors cursor-pointer"
+                title="Clear selection"
+              >
+                <CloseIcon />
+              </button>
+            </div>
           </div>
         </div>
       )}

--- a/src/components/MessageBubble.tsx
+++ b/src/components/MessageBubble.tsx
@@ -88,17 +88,27 @@ function SelectionCard({ sel, interactive }: { sel: SelectionContext; interactiv
   const setSelection = useStore((s) => s.setSelection);
   const setPreviewMode = useStore((s) => s.setPreviewMode);
 
-  const typeLabels: Record<string, string> = {
-    heading: `h${sel.level || 1}`,
-    paragraph: "paragraph",
-    list: "list",
-    code: "code block",
-    blockquote: "blockquote",
-    image: "image",
-    table: "table",
-    "text-range": "selected text",
-  };
-  const typeLabel = typeLabels[sel.type] || sel.type;
+  // Build a label: prefer CSS selector, fallback to type-based labels
+  let typeLabel: string;
+  if (sel.selector) {
+    typeLabel = sel.selector;
+  } else {
+    const typeLabels: Record<string, string> = {
+      heading: `h${sel.level || 1}`,
+      paragraph: "paragraph",
+      list: "list",
+      code: "code block",
+      blockquote: "blockquote",
+      image: "image",
+      table: "table",
+      "text-range": "selected text",
+      section: "section",
+      link: "link",
+      container: "container",
+      interactive: "interactive",
+    };
+    typeLabel = typeLabels[sel.type] || sel.type;
+  }
   const preview = sel.content.length > 80 ? sel.content.slice(0, 77) + "..." : sel.content;
 
   const handleClick = () => {
@@ -114,6 +124,9 @@ function SelectionCard({ sel, interactive }: { sel: SelectionContext; interactiv
       }`}
       onClick={interactive ? handleClick : undefined}
     >
+      {sel.thumbnail && (
+        <img src={sel.thumbnail} alt="" className="mb-1.5 max-h-24 max-w-full rounded border border-cc-border/30 bg-white" />
+      )}
       <div className="flex items-start gap-2 text-xs">
         <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" className="w-3.5 h-3.5 text-cc-primary shrink-0 mt-0.5">
           <path d="M3 2l4 12 2-5 5-2L3 2z" strokeLinejoin="round" />

--- a/src/store.ts
+++ b/src/store.ts
@@ -65,6 +65,8 @@ interface AppState {
 
   // Element selection
   selection: ElementSelection | null;
+  /** Incremented every time setSelection is called with a non-null value — used to detect genuine selection changes */
+  selectionStamp: number;
   previewMode: "view" | "edit" | "select";
   /** Currently viewed file path (e.g. current slide), independent of element selection */
   activeFile: string | null;
@@ -203,6 +205,7 @@ export const useStore = create<AppState>((set) => ({
   tasks: [],
   terminalId: null,
   selection: null,
+  selectionStamp: 0,
   previewMode: "view",
   activeFile: null,
   modeViewer: null,
@@ -281,7 +284,7 @@ export const useStore = create<AppState>((set) => ({
 
   setTerminalId: (terminalId) => set({ terminalId }),
 
-  setSelection: (selection) => set({ selection }),
+  setSelection: (selection) => set((s) => ({ selection, selectionStamp: selection ? s.selectionStamp + 1 : s.selectionStamp })),
   setPreviewMode: (previewMode) => set({ previewMode, ...(previewMode !== "select" ? { selection: null } : {}) }),
   setActiveFile: (activeFile) => set({ activeFile }),
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,13 +8,23 @@ import type {
 
 export type { SessionState, PermissionRequest, ContentBlock, BrowserIncomingMessage, BrowserOutgoingMessage };
 
-export type SelectionType = "heading" | "paragraph" | "list" | "code" | "blockquote" | "image" | "table" | "text-range";
+export type SelectionType =
+  | "heading" | "paragraph" | "list" | "code" | "blockquote" | "image" | "table" | "text-range"
+  | "section" | "link" | "container" | "interactive";
 
 export interface SelectionContext {
   file: string;
   type: SelectionType;
   content: string;
   level?: number;
+  /** HTML tag name (e.g. "div", "section", "h2") */
+  tag?: string;
+  /** CSS class list (e.g. "card bg-white rounded-lg") */
+  classes?: string;
+  /** Unique CSS selector path (e.g. "section.hero > div.card:nth-child(2)") */
+  selector?: string;
+  /** SVG data URL thumbnail of the selected element */
+  thumbnail?: string;
 }
 
 export interface ChatMessage {

--- a/src/ws.ts
+++ b/src/ws.ts
@@ -619,6 +619,9 @@ export function sendUserMessage(content: string, selection?: ElementSelection | 
       content: selection.content,
       file: selection.file,
       level: selection.level,
+      tag: selection.tag,
+      classes: selection.classes,
+      selector: selection.selector,
     } : null;
     // Even without element selection, provide active file as viewing context
     if (!viewerSelection && store.activeFile) {


### PR DESCRIPTION
## Summary

- **Element thumbnails**: Capture selected element as SVG data URL thumbnail, display in ChatInput chip and SelectionCard (chat history). Uses SVG foreignObject with off-screen fit-content measurement for tight content bounds.
- **Simplified context for Claude Code**: Send just `[User selected: section.hero > div.card:nth-child(2)]` instead of 4-line verbose format. Claude Code reads the HTML file anyway.
- **CSS selector in UI**: Show full CSS selector path in ChatInput chip and SelectionCard labels instead of `<tag.class>`.
- **Better small element selection**: SVG icons now directly selectable (added to SEMANTIC_RE), bubble-up threshold lowered from 150×80 to 40×40.
- **Highlight clearing fix**: Clicking X on selection chip now sends `pneuma:clearHighlight` to iframe. Fixes #13.

## Files changed (10)

| File | Change |
|------|--------|
| `core/types/viewer-contract.ts` | Add `thumbnail?: string` to ViewerSelectionContext |
| `src/types.ts` | Add `thumbnail?: string` to SelectionContext |
| `modes/slide/components/SlidePreview.tsx` | `captureElementThumbnail()` in SELECTION_SCRIPT, SVG in SEMANTIC_RE, lower bubble-up threshold, clear highlight on selection removed |
| `modes/slide/components/SlideIframePool.tsx` | Pass `thumbnail` from postMessage, send `clearHighlight` when selector is null |
| `src/App.tsx` | Pass `thumbnail` through selection prop and onSelect |
| `modes/slide/pneuma-mode.ts` | Simplify extractContext to just CSS selector |
| `src/components/MessageBubble.tsx` | Show thumbnail + CSS selector in SelectionCard |
| `src/components/ChatInput.tsx` | Show thumbnail + CSS selector in selection chip |
| `src/ws.ts` | Pass `tag`, `classes`, `selector` to extractContext |
| `src/store.ts` | Include `thumbnail` in selection type |

## Test plan

- [ ] `bun run dev slide` → select mode → click element → thumbnail appears in ChatInput chip
- [ ] Send message → SelectionCard in chat shows thumbnail + CSS selector + file
- [ ] Claude Code receives: `[User selected: section > div.card:nth-child(2)]`
- [ ] Click X on selection chip → iframe highlight clears
- [ ] Click historical SelectionCard → navigates to slide, highlights element
- [ ] Select SVG icon → directly selected (no bubble-up to parent)
- [ ] `npx tsc --noEmit` + `bun test` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)