### PR TITLE
feat: add Focus mode for simplified slide creation UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -302,8 +302,91 @@ On startup, skills are copied to the backend-appropriate directory:
 - Codex: `<workspace>/.agents/skills/<installName>/` + `AGENTS.md`
 
 Template params (`{{key}}`, `{{viewerCapabilities}}`) are applied. Two sections are injected into the instructions file:
-- `<!-- pneuma:start -->` / `<!-- pneuma:end -->` — Skill prompt
-- `<!-- pneuma:viewer-api:start -->` / `<!-- pneuma:viewer-api:end -->` — Viewer API description
+- `<!-- pneuma:start -->
+## Pneuma Slide Mode
+
+You are running inside **Pneuma**, a co-creation workspace where you and the user build content together — you edit files, the user sees live results in a browser preview panel.
+
+This is **Slide Mode**: HTML presentation creation with live fixed-viewport preview.
+
+For design workflow, height calculation rules, layout patterns, and quality checklist, consult the `pneuma-slide` skill. Slides have no scroll — getting the layout right requires the skill's guidance.
+
+### Architecture
+- `slides/*.html` — HTML fragments per slide (no `<html>`/`<body>` tags)
+- `manifest.json` — Slide ordering (always update when adding/removing slides)
+- `theme.css` — Shared CSS theme via custom properties
+- Canvas: 1280×720px fixed viewport — content beyond this is invisible
+- **Content sets**: Each top-level directory (e.g. `en-dark/`, `my-deck/`) is a switchable content set with its own slides, manifest, and theme
+
+### Core Rules
+- Content must fit within 1280×720px — overflow is the #1 quality issue (no scroll)
+- No CSS animations — they break snapshot-based export and print
+- **New task → new content set**: When the user asks for a completely new presentation, create a new top-level directory (content set) rather than overwriting existing content — this preserves seed templates and prior work
+- **Importing external content → new content set**: When the user provides original content (uploaded files, pasted slides, or a URL), always create a new content set for it. Place imported files inside the new directory with a proper `manifest.json` and `theme.css`. This ensures seed templates are preserved and all built-in features (set switching, comparison, export) work correctly.
+- For new decks: design outline first → theme → scaffold → fill content
+- Do not ask for confirmation on simple edits — just do them
+
+<!-- pneuma:end -->` — Skill prompt
+- `<!-- pneuma:viewer-api:start -->
+## Viewer API
+
+### Viewer Context
+
+Each user message may be prefixed with a `<viewer-context>` block.
+It describes what the user is currently seeing — the active file, viewport position, and selected elements.
+Use this to resolve references like "this page", "here", "this section" in user messages.
+
+### User Actions
+
+Messages may include a `<user-actions>` block listing significant actions
+the user performed in the viewer since the last message.
+Use this to understand workspace state changes that happened outside of your edits.
+
+### Workspace
+- Type: manifest (ordered, multi-file, active file tracking)
+- Index file: manifest.json
+
+### Content Sets
+This workspace may contain multiple content sets as top-level directories (e.g. en-dark/, ja-light/).
+The `<viewer-context>` includes a `content-set` attribute. File paths include the content set prefix.
+Always edit files within the active content set's directory unless asked to work across content sets.
+
+### Actions
+
+The viewer supports these operations. Invoke via Bash:
+`curl -s -X POST $PNEUMA_API/api/viewer/action -H 'Content-Type: application/json' -d '{"actionId":"<id>","params":{...}}'`
+
+| Action | Description | Params |
+|--------|-------------|--------|
+| `navigate-to` | Navigate to a specific slide | file: string |
+
+### Scaffold
+
+Initialize workspace with slide scaffolding from a structure spec. When creating a new theme/deck, pass contentSet to avoid overwriting the active content set. **Requires user confirmation in browser.**
+
+Invoke via the viewer action API:
+`curl -s -X POST $PNEUMA_API/api/viewer/action -H 'Content-Type: application/json' -d '{"actionId":"scaffold","params":{...}}'`
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `title` | string | yes | Presentation title |
+| `slides` | string | yes | JSON array of {title, subtitle?} |
+| `contentSet` | string | no | Target content set name (e.g. 'my-theme'). If omitted, overwrites the active content set. |
+
+Clears: `slides/*.html`, `manifest.json`
+
+### Locator Cards
+
+You may embed clickable navigation cards in your messages using this tag:
+`<viewer-locator label="Display Label" data='{"key":"value"}' />`
+
+After creating or editing slides, embed locator cards so the user can jump to them. Navigate by file: `data='{"file":"slides/slide-03.html"}'`. Navigate by number: `data='{"index":3}'`. Switch content set: `data='{"contentSet":"deck-2"}'`. Switch content set and slide: `data='{"contentSet":"deck-2","index":1}'`.
+
+When the user clicks a locator card, the viewer navigates to that location.
+
+**Always** embed locator cards at the end of your response when you create or edit content. The user may have navigated away while you were working — locators let them jump directly to what changed.
+
+<!-- pneuma:viewer-api:end -->` — Viewer API description
 
 A third optional section is injected by the evolution system:
 - `<!-- pneuma:evolved:start -->` / `<!-- pneuma:evolved:end -->` — Learned preferences summary (inside pneuma:start/end block)

--- a/modes/slide/viewer/SlidePreview.tsx
+++ b/modes/slide/viewer/SlidePreview.tsx
@@ -36,6 +36,8 @@ import HighlighterCanvas from "./HighlighterCanvas.js";
 import { captureSlideRegion } from "./captureSlideRegion.js";
 import { generateSlideScaffold, type SlideSpec, type ScaffoldFile } from "./scaffold.js";
 import ScaffoldConfirm from "../../../src/components/ScaffoldConfirm.js";
+import ContentSetSelector from "../../../src/components/ContentSetSelector.js";
+import ShareDropdown from "../../../src/components/ShareDropdown.js";
 
 
 // ── Types ────────────────────────────────────────────────────────────────────
@@ -1965,10 +1967,104 @@ function SlideToolbar({
         ? "Navigator: bottom (click to hide)"
         : "Navigator: hidden (click to show)";
 
+  const focusMode = useStore((s) => s.focusMode);
+  const setFocusMode = useStore((s) => s.setFocusMode);
+  const contentSets = useStore((s) => s.contentSets);
+  const activeContentSet = useStore((s) => s.activeContentSet);
+  const contentSetUnread = useStore((s) => s.contentSetUnread);
+  const workspaceItems = useStore((s) => s.workspaceItems);
+  const activeFile = useStore((s) => s.activeFile);
+  const topBarNav = useStore((s) => s.modeViewer?.workspace?.topBarNavigation);
+  const createEmpty = useStore((s) => s.modeViewer?.workspace?.createEmpty);
+  const showItemSelector = topBarNav && contentSets.length <= 1 && workspaceItems.length > 1;
+
+  const handleCreateEmpty = useCallback(async () => {
+    if (!createEmpty) return;
+    const store = useStore.getState();
+    const rawFiles = store.files;
+    const hasContentSets = store.contentSets.length >= 1;
+    const prefix = hasContentSets ? null : store.activeContentSet;
+    const files = prefix
+      ? rawFiles.filter((f) => f.path.startsWith(prefix + "/")).map((f) => ({ path: f.path.slice(prefix.length + 1), content: f.content }))
+      : rawFiles.map((f) => ({ path: f.path, content: f.content }));
+    const result = createEmpty(files);
+    if (!result || result.length === 0) return;
+    const diskFiles = prefix
+      ? result.map((f) => ({ path: `${prefix}/${f.path}`, content: f.content }))
+      : result;
+    try {
+      const apiBase = import.meta.env.DEV ? `http://${location.hostname}:${import.meta.env.VITE_API_PORT || "17007"}` : "";
+      const res = await fetch(`${apiBase}/api/workspace/scaffold`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ clear: [], files: diskFiles }),
+      });
+      const data = await res.json();
+      if (data.success) {
+        setTimeout(() => {
+          if (hasContentSets) {
+            const firstPath = result[0].path;
+            const slashIdx = firstPath.indexOf("/");
+            if (slashIdx > 0) store.setActiveContentSet(firstPath.slice(0, slashIdx));
+          } else {
+            store.setActiveFile(result[0].path);
+          }
+        }, 300);
+      }
+    } catch { /* ignore */ }
+  }, [createEmpty]);
+
   return (
     <div className="flex items-center justify-between px-3 py-1.5 border-b border-cc-border bg-cc-card/50 shrink-0">
-      {/* Left: nav toggle + slide navigation */}
+      {/* Left: focus mode items + nav toggle + slide navigation */}
       <div className="flex items-center gap-1.5">
+        {focusMode && (
+          <>
+            <div className="flex items-center gap-1.5 mr-1">
+              <img src="/logo.png" alt="" className="w-4 h-4 rounded" />
+              <span className="font-logo text-xs text-cc-fg tracking-tight">Pneuma</span>
+            </div>
+            {contentSets.length > 1 && (
+              <ContentSetSelector
+                items={contentSets.map((cs: { prefix: string; label: string }) => ({ id: cs.prefix, label: cs.label }))}
+                activeId={activeContentSet}
+                onSelect={(id: string) => useStore.getState().setActiveContentSet(id)}
+                unread={contentSetUnread}
+              />
+            )}
+            {showItemSelector && (
+              <ContentSetSelector
+                items={workspaceItems.map((wi: { path: string; label: string }) => ({ id: wi.path, label: wi.label }))}
+                activeId={activeFile}
+                onSelect={(id: string) => useStore.getState().setActiveFile(id)}
+                icon="file"
+              />
+            )}
+            {createEmpty && (
+              <button
+                onClick={handleCreateEmpty}
+                title="New empty content"
+                className="flex items-center justify-center w-5 h-5 rounded text-cc-muted hover:text-cc-fg hover:bg-cc-hover transition-colors cursor-pointer"
+              >
+                <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" className="w-3.5 h-3.5">
+                  <path d="M8 3v10M3 8h10" />
+                </svg>
+              </button>
+            )}
+            <div className="w-px h-4 bg-cc-border mx-0.5" />
+            <button
+              onClick={() => setFocusMode(false)}
+              title="Switch to full view"
+              className="flex items-center gap-1.5 px-1 py-0.5 rounded-md text-xs cursor-pointer hover:bg-cc-hover transition-colors"
+            >
+              <div className="relative w-7 h-4 rounded-full bg-cc-primary transition-colors duration-200">
+                <div className="absolute top-0.5 w-3 h-3 rounded-full bg-white shadow-sm translate-x-3.5 transition-transform duration-200" />
+              </div>
+              <span className="font-medium text-cc-fg">Focus</span>
+            </button>
+            <div className="w-px h-4 bg-cc-border mx-0.5" />
+          </>
+        )}
         <button
           onClick={onCycleNav}
           className="flex items-center justify-center w-7 h-7 rounded text-cc-muted hover:text-cc-fg hover:bg-cc-hover transition-colors cursor-pointer"
@@ -2099,6 +2195,7 @@ function SlideToolbar({
         >
           <ExportIcon />
         </button>
+        {focusMode && <ShareDropdown />}
         {onScaffold && (
           <>
             <div className="w-px h-4 bg-cc-border" />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -328,6 +328,7 @@ export default function App() {
   const viewerProps = useViewerProps();
   const layout = useStore((s) => s.layout);
   const replayMode = useStore((s) => s.replayMode);
+  const focusMode = useStore((s) => s.focusMode);
 
   // Thumbnail capture — snapshot the preview panel periodically
   const previewRef = useRef<HTMLDivElement>(null);
@@ -368,8 +369,8 @@ export default function App() {
 
       <div className="relative z-10 flex flex-col flex-1 border border-cc-primary/20 rounded-2xl overflow-hidden shadow-[0_0_40px_rgba(249,115,22,0.15)] ring-1 ring-white/5 before:absolute before:inset-0 before:bg-cc-surface/40 before:backdrop-blur-3xl before:-z-10">
         <TopBar />
-        <Group orientation="horizontal" className="flex-1 min-h-0">
-          <Panel defaultSize={65} minSize={30}>
+        <Group key={focusMode ? "focus" : "full"} orientation="horizontal" className="flex-1 min-h-0">
+          <Panel defaultSize={focusMode ? 75 : 65} minSize={30}>
             <div ref={previewRef} className="h-full w-full">
               {PreviewComponent ? (
                 <PreviewComponent {...viewerProps} />
@@ -379,7 +380,7 @@ export default function App() {
             </div>
           </Panel>
           <Separator className="w-[1px] bg-cc-border/40 hover:w-1 hover:bg-cc-primary/40 transition-all duration-300 cursor-col-resize z-10" />
-          <Panel defaultSize={35} minSize={20}>
+          <Panel defaultSize={focusMode ? 25 : 35} minSize={15}>
             <RightPanel />
           </Panel>
         </Group>

--- a/src/components/AgentBubble.tsx
+++ b/src/components/AgentBubble.tsx
@@ -53,6 +53,7 @@ export default function AgentBubble() {
           </div>
           <button
             onClick={close}
+            title="Close chat"
             className="w-6 h-6 rounded-full bg-cc-surface/60 border border-white/10
                        flex items-center justify-center text-cc-muted
                        hover:text-cc-fg hover:border-cc-primary/30 transition-all text-xs"
@@ -74,6 +75,7 @@ export default function AgentBubble() {
   return (
     <button
       onClick={open}
+      title="Open agent chat"
       className="fixed bottom-6 right-6 z-50 w-14 h-14 rounded-full
                  bg-cc-surface border-2
                  flex items-center justify-center

--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -86,6 +86,7 @@ export default function ChatInput() {
   const updateAnnotationComment = useStore((s) => s.updateAnnotationComment);
   const clearAnnotations = useStore((s) => s.clearAnnotations);
   const previewMode = useStore((s) => s.previewMode);
+  const focusMode = useStore((s) => s.focusMode);
   const slashCommands = useStore((s) => s.session?.slash_commands ?? EMPTY_STRINGS);
   const skills = useStore((s) => s.session?.skills ?? EMPTY_STRINGS);
 
@@ -296,6 +297,7 @@ export default function ChatInput() {
             </span>
             <button
               onClick={clearAnnotations}
+              title="Remove all annotations"
               className="text-[11px] text-cc-muted hover:text-cc-fg transition-colors cursor-pointer"
             >
               Clear all
@@ -442,7 +444,7 @@ export default function ChatInput() {
                     ? "Tell Claude what to change..."
                     : previewMode === "annotate"
                       ? "Click elements to annotate, then send..."
-                      : "Send a message... (drop files, paste images, type / for commands)"
+                      : "Send a message... (drop files, paste images, / for commands)"
           }
           disabled={!cliConnected}
           rows={1}
@@ -453,7 +455,7 @@ export default function ChatInput() {
       {/* Action bar: model switcher + file picker | send/stop */}
       <div className="flex items-center justify-between mt-2">
         <div className="flex items-center gap-2">
-          <ModelSwitcher />
+          {!focusMode && <ModelSwitcher />}
           <button
             onClick={handleFilePickerClick}
             className="flex items-center gap-1 px-2 py-1 text-xs text-cc-muted hover:text-cc-fg bg-cc-card hover:bg-cc-hover rounded transition-colors"
@@ -477,6 +479,7 @@ export default function ChatInput() {
           {isBusy && (
             <button
               onClick={sendInterrupt}
+              title="Stop agent execution"
               className="px-5 py-2 bg-red-600 hover:bg-red-500 text-white font-medium text-xs rounded-full transition-all shadow-[0_0_12px_rgba(220,38,38,0.4)]"
             >
               Stop
@@ -485,6 +488,7 @@ export default function ChatInput() {
           <button
             onClick={handleSubmit}
             disabled={(!text.trim() && attachments.length === 0 && !hasAnnotations) || !cliConnected}
+            title={isBusy ? "Queue message for when agent finishes" : "Send message"}
             className="px-5 py-2 bg-cc-primary hover:bg-cc-primary-hover text-cc-bg font-medium text-xs rounded-full transition-all duration-300 shadow-[0_0_12px_rgba(249,115,22,0.4)] disabled:shadow-none disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {isBusy ? "Queue" : "Send"}

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -101,6 +101,7 @@ export default function ChatPanel() {
   const activity = useStore((s) => s.activity);
   const cliConnected = useStore((s) => s.cliConnected);
   const replayMode = useStore((s) => s.replayMode);
+  const focusMode = useStore((s) => s.focusMode);
   const permSize = useStore((s) => s.pendingPermissions.size);
   const bottomRef = useRef<HTMLDivElement>(null);
 
@@ -111,14 +112,14 @@ export default function ChatPanel() {
 
   return (
     <div className="flex flex-col h-full relative">
-      {/* Agent status bar (floating pill) — hide in replay mode */}
-      {!replayMode && (
+      {/* Agent status bar (floating pill) — hide in replay and focus modes */}
+      {!replayMode && !focusMode && (
         <div className="absolute top-4 right-4 z-10 flex items-center gap-3 px-4 py-1.5 bg-cc-surface/60 backdrop-blur-md border border-white/5 rounded-full shadow-sm">
           <StatusDot />
           <SessionInfo />
         </div>
       )}
-      <div className="flex-1 overflow-y-auto bg-grid-pattern p-4 pt-16 space-y-4 pb-36">
+      <div className={`flex-1 overflow-y-auto bg-grid-pattern p-4 space-y-4 pb-36 ${focusMode ? "pt-4" : "pt-16"}`}>
         {messages.length === 0 && !streaming && !activity && !replayMode && (
           <div className="text-cc-muted text-sm text-center mt-8">
             {cliConnected ? "Send a message to start editing" : "Connecting to Claude..."}

--- a/src/components/ProcessPanel.tsx
+++ b/src/components/ProcessPanel.tsx
@@ -62,7 +62,7 @@ function ProcessRow({ proc, onKill }: { proc: ProcessItem; onKill: () => void })
         {proc.status === "running" ? formatDuration(elapsed) : proc.status}
       </span>
       {proc.status === "running" && (
-        <button onClick={onKill} className="shrink-0 text-red-400 hover:text-red-300 px-1">
+        <button onClick={onKill} title="Kill this process" className="shrink-0 text-red-400 hover:text-red-300 px-1">
           Kill
         </button>
       )}
@@ -92,7 +92,7 @@ function SystemProcessRow({ proc, onKill }: { proc: SystemProcess; onKill: () =>
           </a>
         ))}
         <span className="text-neutral-600">PID {proc.pid}</span>
-        <button onClick={onKill} className="text-red-400 hover:text-red-300 px-1">
+        <button onClick={onKill} title="Kill this process" className="text-red-400 hover:text-red-300 px-1">
           Kill
         </button>
       </div>
@@ -166,6 +166,7 @@ export default function ProcessPanel() {
           <button
             onClick={scanSystemProcesses}
             disabled={scanning}
+            title="Scan for running dev servers"
             className="text-[10px] px-1.5 py-0.5 rounded bg-neutral-800 text-neutral-400 hover:text-neutral-200"
           >
             {scanning ? "Scanning..." : "Scan"}

--- a/src/components/ReplayPlayer.tsx
+++ b/src/components/ReplayPlayer.tsx
@@ -97,6 +97,7 @@ export function ReplayPlayer() {
           </button>
           <button
             onClick={() => isPlaying ? stopPlayback() : startPlayback()}
+            title={isPlaying ? "Pause replay" : "Play replay"}
             className="w-7 h-7 flex items-center justify-center rounded-full bg-cc-primary text-white hover:brightness-110 transition-all cursor-pointer"
           >
             {isPlaying ? (
@@ -110,7 +111,7 @@ export function ReplayPlayer() {
           </button>
         </div>
 
-        <button onClick={nextSpeed} className="px-2 py-1 rounded-full border border-cc-border text-cc-muted hover:text-cc-fg hover:border-cc-muted transition-colors cursor-pointer tabular-nums text-[10px] font-medium">
+        <button onClick={nextSpeed} title="Change playback speed" className="px-2 py-1 rounded-full border border-cc-border text-cc-muted hover:text-cc-fg hover:border-cc-muted transition-colors cursor-pointer tabular-nums text-[10px] font-medium">
           {playbackSpeed}x
         </button>
 

--- a/src/components/SchedulePanel.tsx
+++ b/src/components/SchedulePanel.tsx
@@ -78,6 +78,7 @@ export default function SchedulePanel() {
         <button
           onClick={handleRefresh}
           disabled={turnInProgress || needsUpgrade || !isClaudeBackend}
+          title="Refresh scheduled jobs list"
           className="text-[10px] px-1.5 py-0.5 rounded bg-neutral-800 text-neutral-400
             hover:text-neutral-200 disabled:opacity-40 disabled:cursor-not-allowed"
         >

--- a/src/components/ShareDropdown.tsx
+++ b/src/components/ShareDropdown.tsx
@@ -1,0 +1,184 @@
+import { useEffect, useRef, useState } from "react";
+import { getApiBase } from "../utils/api.js";
+
+export default function ShareDropdown() {
+  const [open, setOpen] = useState(false);
+  const [r2Status, setR2Status] = useState<{ configured: boolean; publicUrl: string | null } | null>(null);
+  const [shareStatus, setShareStatus] = useState<"idle" | "sharing" | "done" | "error">("idle");
+  const [shareUrl, setShareUrl] = useState<string | null>(null);
+  const [shareError, setShareError] = useState<string | null>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  // Check R2 status when dropdown opens
+  useEffect(() => {
+    if (open && !r2Status) {
+      fetch(`${getApiBase()}/api/r2/status`)
+        .then((r) => r.json())
+        .then(setR2Status)
+        .catch(() => setR2Status({ configured: false, publicUrl: null }));
+    }
+  }, [open]);
+
+  // Close on click outside
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [open]);
+
+  const handleShare = async (type: "result" | "process") => {
+    setShareStatus("sharing");
+    setShareError(null);
+    try {
+      const resp = await fetch(`${getApiBase()}/api/share/${type}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ title: `Shared ${type}` }),
+      });
+      const data = await resp.json();
+      if (data.error) throw new Error(data.error);
+      setShareUrl(data.url);
+      setShareStatus("done");
+    } catch (err: any) {
+      setShareError(err.message || "Share failed");
+      setShareStatus("error");
+    }
+  };
+
+  const handleExportLocal = async () => {
+    setShareStatus("sharing");
+    try {
+      const resp = await fetch(`${getApiBase()}/api/history/export`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      });
+      const data = await resp.json();
+      if (data.error) throw new Error(data.error);
+      setShareUrl(data.outputPath);
+      setShareStatus("done");
+    } catch (err: any) {
+      setShareError(err.message || "Export failed");
+      setShareStatus("error");
+    }
+  };
+
+  const copyUrl = () => {
+    if (shareUrl) navigator.clipboard.writeText(shareUrl);
+  };
+
+  const reset = () => {
+    setShareStatus("idle");
+    setShareUrl(null);
+    setShareError(null);
+  };
+
+  return (
+    <div className="relative shrink-0" ref={dropdownRef}>
+      <button
+        onClick={() => { setOpen(!open); if (!open) reset(); }}
+        title="Share"
+        className="flex items-center justify-center w-7 h-7 rounded text-cc-muted hover:text-cc-primary hover:bg-cc-hover transition-colors cursor-pointer"
+      >
+        <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" className="w-4 h-4">
+          <circle cx="4" cy="8" r="2" />
+          <circle cx="12" cy="4" r="2" />
+          <circle cx="12" cy="12" r="2" />
+          <path d="M6 7l4-2M6 9l4 2" />
+        </svg>
+      </button>
+
+      {open && (
+        <div className="absolute right-0 top-full mt-1 w-72 rounded-lg border border-cc-border bg-cc-surface shadow-xl z-[100] overflow-hidden">
+          <div className="px-3 py-2 border-b border-cc-border">
+            <div className="text-xs font-semibold text-cc-fg">Share</div>
+          </div>
+
+          {shareStatus === "idle" && (
+            <div className="p-2 space-y-1">
+              {r2Status?.configured ? (
+                <>
+                  <button
+                    onClick={() => handleShare("result")}
+                    className="w-full px-3 py-2.5 text-left rounded hover:bg-cc-hover transition-colors group"
+                  >
+                    <div className="text-xs font-medium text-cc-fg group-hover:text-cc-primary">Share Result</div>
+                    <div className="text-[10px] text-cc-muted mt-0.5">Upload current files (no history)</div>
+                  </button>
+                  <button
+                    onClick={() => handleShare("process")}
+                    className="w-full px-3 py-2.5 text-left rounded hover:bg-cc-hover transition-colors group"
+                  >
+                    <div className="text-xs font-medium text-cc-fg group-hover:text-cc-primary">Share Process</div>
+                    <div className="text-[10px] text-cc-muted mt-0.5">Upload with chat history & checkpoints</div>
+                  </button>
+                  <div className="border-t border-cc-border my-1" />
+                  <button
+                    onClick={handleExportLocal}
+                    className="w-full px-3 py-2 text-left rounded hover:bg-cc-hover transition-colors"
+                  >
+                    <div className="text-xs text-cc-muted">Export to local file</div>
+                  </button>
+                </>
+              ) : (
+                <div className="px-3 py-3 space-y-2">
+                  <div className="text-xs text-cc-muted">Cloud sharing requires R2 storage configuration.</div>
+                  <div className="text-[10px] text-cc-muted/60">Configure R2 credentials in the Launcher settings to enable cloud sharing.</div>
+                  <div className="border-t border-cc-border my-2" />
+                  <button
+                    onClick={handleExportLocal}
+                    className="w-full px-3 py-2 text-left rounded hover:bg-cc-hover transition-colors"
+                  >
+                    <div className="text-xs text-cc-fg">Export to local file</div>
+                    <div className="text-[10px] text-cc-muted mt-0.5">Save as .tar.gz without cloud upload</div>
+                  </button>
+                </div>
+              )}
+            </div>
+          )}
+
+          {shareStatus === "sharing" && (
+            <div className="px-3 py-4 text-center">
+              <div className="text-xs text-cc-muted animate-pulse">Sharing...</div>
+            </div>
+          )}
+
+          {shareStatus === "done" && shareUrl && (
+            <div className="p-3 space-y-2">
+              <div className="text-xs text-cc-primary font-medium">Shared successfully!</div>
+              <div className="flex items-center gap-1">
+                <input
+                  readOnly
+                  value={shareUrl}
+                  className="flex-1 text-[10px] bg-cc-bg border border-cc-border rounded px-2 py-1 text-cc-muted truncate"
+                  onClick={(e) => (e.target as HTMLInputElement).select()}
+                />
+                <button
+                  onClick={copyUrl}
+                  className="px-2 py-1 text-[10px] rounded border border-cc-border hover:border-cc-primary hover:text-cc-primary text-cc-muted transition-colors"
+                >
+                  Copy
+                </button>
+              </div>
+              <button onClick={reset} className="text-[10px] text-cc-muted/50 hover:text-cc-fg">
+                Share again
+              </button>
+            </div>
+          )}
+
+          {shareStatus === "error" && (
+            <div className="p-3 space-y-2">
+              <div className="text-xs text-red-400">{shareError || "Share failed"}</div>
+              <button onClick={reset} className="text-[10px] text-cc-muted/50 hover:text-cc-fg">
+                Try again
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/TerminalPanel.tsx
+++ b/src/components/TerminalPanel.tsx
@@ -185,6 +185,7 @@ export default function TerminalPanel() {
         {terminalId && (
           <button
             onClick={killTerminal}
+            title="Kill terminal session"
             className="text-xs px-2 py-0.5 rounded bg-cc-hover hover:bg-cc-active text-cc-muted hover:text-cc-error transition-colors"
           >
             Kill
@@ -192,6 +193,7 @@ export default function TerminalPanel() {
         )}
         <button
           onClick={spawnTerminal}
+          title="Open new terminal"
           className="text-xs px-2 py-0.5 rounded bg-cc-hover hover:bg-cc-active text-cc-muted hover:text-cc-fg transition-colors"
         >
           New

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -2,188 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useStore } from "../store.js";
 import { getApiBase } from "../utils/api.js";
 import ContentSetSelector from "./ContentSetSelector.js";
-
-function ShareDropdown() {
-  const [open, setOpen] = useState(false);
-  const [r2Status, setR2Status] = useState<{ configured: boolean; publicUrl: string | null } | null>(null);
-  const [shareStatus, setShareStatus] = useState<"idle" | "sharing" | "done" | "error">("idle");
-  const [shareUrl, setShareUrl] = useState<string | null>(null);
-  const [shareError, setShareError] = useState<string | null>(null);
-  const dropdownRef = useRef<HTMLDivElement>(null);
-
-  // Check R2 status when dropdown opens
-  useEffect(() => {
-    if (open && !r2Status) {
-      fetch(`${getApiBase()}/api/r2/status`)
-        .then((r) => r.json())
-        .then(setR2Status)
-        .catch(() => setR2Status({ configured: false, publicUrl: null }));
-    }
-  }, [open]);
-
-  // Close on click outside
-  useEffect(() => {
-    if (!open) return;
-    const handler = (e: MouseEvent) => {
-      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) setOpen(false);
-    };
-    document.addEventListener("mousedown", handler);
-    return () => document.removeEventListener("mousedown", handler);
-  }, [open]);
-
-  const handleShare = async (type: "result" | "process") => {
-    setShareStatus("sharing");
-    setShareError(null);
-    try {
-      const resp = await fetch(`${getApiBase()}/api/share/${type}`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ title: `Shared ${type}` }),
-      });
-      const data = await resp.json();
-      if (data.error) throw new Error(data.error);
-      setShareUrl(data.url);
-      setShareStatus("done");
-    } catch (err: any) {
-      setShareError(err.message || "Share failed");
-      setShareStatus("error");
-    }
-  };
-
-  const handleExportLocal = async () => {
-    setShareStatus("sharing");
-    try {
-      const resp = await fetch(`${getApiBase()}/api/history/export`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({}),
-      });
-      const data = await resp.json();
-      if (data.error) throw new Error(data.error);
-      setShareUrl(data.outputPath);
-      setShareStatus("done");
-    } catch (err: any) {
-      setShareError(err.message || "Export failed");
-      setShareStatus("error");
-    }
-  };
-
-  const copyUrl = () => {
-    if (shareUrl) navigator.clipboard.writeText(shareUrl);
-  };
-
-  const reset = () => {
-    setShareStatus("idle");
-    setShareUrl(null);
-    setShareError(null);
-  };
-
-  return (
-    <div className="relative shrink-0" ref={dropdownRef}>
-      <button
-        onClick={() => { setOpen(!open); if (!open) reset(); }}
-        title="Share"
-        className="flex items-center justify-center w-7 h-7 rounded text-cc-muted hover:text-cc-primary hover:bg-cc-hover transition-colors cursor-pointer"
-      >
-        <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" className="w-4 h-4">
-          <circle cx="4" cy="8" r="2" />
-          <circle cx="12" cy="4" r="2" />
-          <circle cx="12" cy="12" r="2" />
-          <path d="M6 7l4-2M6 9l4 2" />
-        </svg>
-      </button>
-
-      {open && (
-        <div className="absolute right-0 top-full mt-1 w-72 rounded-lg border border-cc-border bg-cc-surface shadow-xl z-[100] overflow-hidden">
-          <div className="px-3 py-2 border-b border-cc-border">
-            <div className="text-xs font-semibold text-cc-fg">Share</div>
-          </div>
-
-          {shareStatus === "idle" && (
-            <div className="p-2 space-y-1">
-              {r2Status?.configured ? (
-                <>
-                  <button
-                    onClick={() => handleShare("result")}
-                    className="w-full px-3 py-2.5 text-left rounded hover:bg-cc-hover transition-colors group"
-                  >
-                    <div className="text-xs font-medium text-cc-fg group-hover:text-cc-primary">Share Result</div>
-                    <div className="text-[10px] text-cc-muted mt-0.5">Upload current files (no history)</div>
-                  </button>
-                  <button
-                    onClick={() => handleShare("process")}
-                    className="w-full px-3 py-2.5 text-left rounded hover:bg-cc-hover transition-colors group"
-                  >
-                    <div className="text-xs font-medium text-cc-fg group-hover:text-cc-primary">Share Process</div>
-                    <div className="text-[10px] text-cc-muted mt-0.5">Upload with chat history & checkpoints</div>
-                  </button>
-                  <div className="border-t border-cc-border my-1" />
-                  <button
-                    onClick={handleExportLocal}
-                    className="w-full px-3 py-2 text-left rounded hover:bg-cc-hover transition-colors"
-                  >
-                    <div className="text-xs text-cc-muted">Export to local file</div>
-                  </button>
-                </>
-              ) : (
-                <div className="px-3 py-3 space-y-2">
-                  <div className="text-xs text-cc-muted">Cloud sharing requires R2 storage configuration.</div>
-                  <div className="text-[10px] text-cc-muted/60">Configure R2 credentials in the Launcher settings to enable cloud sharing.</div>
-                  <div className="border-t border-cc-border my-2" />
-                  <button
-                    onClick={handleExportLocal}
-                    className="w-full px-3 py-2 text-left rounded hover:bg-cc-hover transition-colors"
-                  >
-                    <div className="text-xs text-cc-fg">Export to local file</div>
-                    <div className="text-[10px] text-cc-muted mt-0.5">Save as .tar.gz without cloud upload</div>
-                  </button>
-                </div>
-              )}
-            </div>
-          )}
-
-          {shareStatus === "sharing" && (
-            <div className="px-3 py-4 text-center">
-              <div className="text-xs text-cc-muted animate-pulse">Sharing...</div>
-            </div>
-          )}
-
-          {shareStatus === "done" && shareUrl && (
-            <div className="p-3 space-y-2">
-              <div className="text-xs text-cc-primary font-medium">Shared successfully!</div>
-              <div className="flex items-center gap-1">
-                <input
-                  readOnly
-                  value={shareUrl}
-                  className="flex-1 text-[10px] bg-cc-bg border border-cc-border rounded px-2 py-1 text-cc-muted truncate"
-                  onClick={(e) => (e.target as HTMLInputElement).select()}
-                />
-                <button
-                  onClick={copyUrl}
-                  className="px-2 py-1 text-[10px] rounded border border-cc-border hover:border-cc-primary hover:text-cc-primary text-cc-muted transition-colors"
-                >
-                  Copy
-                </button>
-              </div>
-              <button onClick={reset} className="text-[10px] text-cc-muted/50 hover:text-cc-fg">
-                Share again
-              </button>
-            </div>
-          )}
-
-          {shareStatus === "error" && (
-            <div className="p-3 space-y-2">
-              <div className="text-xs text-red-400">{shareError || "Share failed"}</div>
-              <button onClick={reset} className="text-[10px] text-cc-muted/50 hover:text-cc-fg">
-                Try again
-              </button>
-            </div>
-          )}
-        </div>
-      )}
-    </div>
-  );
-}
+import ShareDropdown from "./ShareDropdown.js";
 
 type Tab = "chat" | "editor" | "diff" | "terminal" | "processes" | "context" | "schedules";
 
@@ -212,8 +31,11 @@ export default function TopBar() {
   const createEmpty = useStore((s) => s.modeViewer?.workspace?.createEmpty);
   const replayMode = useStore((s) => s.replayMode);
   const replayMetadata = useStore((s) => s.replayMetadata);
+  const focusMode = useStore((s) => s.focusMode);
+  const setFocusMode = useStore((s) => s.setFocusMode);
   const scheduleAvailable = !backendType || backendType === "claude-code";
-  const visibleTabs = scheduleAvailable ? TABS : TABS.filter((tab) => tab.id !== "schedules");
+  const allTabs = scheduleAvailable ? TABS : TABS.filter((tab) => tab.id !== "schedules");
+  const visibleTabs = focusMode ? allTabs.filter((tab) => tab.id === "chat") : allTabs;
 
   const showItemSelector = topBarNav && contentSets.length <= 1 && workspaceItems.length > 1;
 
@@ -275,6 +97,10 @@ export default function TopBar() {
     }
   }, [createEmpty]);
 
+  // ── Focus mode: TopBar hidden — items rendered inside viewer toolbar ───
+  if (focusMode && !replayMode) return null;
+
+  // ── Normal mode: full TopBar with tabs ────────────────────────────────
   return (
     <div className="flex items-center px-4 pt-4 pb-2 bg-transparent text-sm select-none z-20 relative">
       {/* Left: logo + selectors */}
@@ -313,6 +139,20 @@ export default function TopBar() {
         )}
       </div>
 
+      {/* Focus toggle — standalone, right of the left pill */}
+      {!replayMode && (
+        <button
+          onClick={() => setFocusMode(true)}
+          title="Switch to focus mode"
+          className="flex items-center gap-2 ml-3 px-1.5 py-1 rounded-md text-xs cursor-pointer hover:bg-cc-hover transition-colors shrink-0"
+        >
+          <div className="relative w-7 h-4 rounded-full bg-cc-muted/30 transition-colors duration-200">
+            <div className="absolute top-0.5 w-3 h-3 rounded-full bg-white shadow-sm translate-x-0.5 transition-transform duration-200" />
+          </div>
+          <span className="font-medium text-cc-muted">Focus</span>
+        </button>
+      )}
+
       {/* Center: tabs */}
       <div className="flex items-center gap-1 mx-auto bg-cc-bg/80 border border-cc-border/50 rounded-full p-1 shadow-inner">
         {visibleTabs.map((tab) => {
@@ -344,21 +184,23 @@ export default function TopBar() {
       </div>
 
       {/* Right: share dropdown or replay badge */}
-      {replayMode ? (
-        <div className="flex items-center gap-2 shrink-0">
-          <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full bg-cc-primary/10 border border-cc-primary/20 text-cc-primary text-xs font-medium">
-            <svg viewBox="0 0 16 16" fill="currentColor" className="w-3 h-3">
-              <path d="M4 2l10 6-10 6V2z"/>
-            </svg>
-            Replay
-          </span>
-          {replayMetadata?.title && (
-            <span className="text-cc-muted/60 text-xs truncate max-w-[200px]">{replayMetadata.title}</span>
-          )}
-        </div>
-      ) : (
-        <ShareDropdown />
-      )}
+      <div className="flex items-center gap-2 shrink-0">
+        {replayMode ? (
+          <>
+            <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full bg-cc-primary/10 border border-cc-primary/20 text-cc-primary text-xs font-medium">
+              <svg viewBox="0 0 16 16" fill="currentColor" className="w-3 h-3">
+                <path d="M4 2l10 6-10 6V2z"/>
+              </svg>
+              Replay
+            </span>
+            {replayMetadata?.title && (
+              <span className="text-cc-muted/60 text-xs truncate max-w-[200px]">{replayMetadata.title}</span>
+            )}
+          </>
+        ) : (
+          <ShareDropdown />
+        )}
+      </div>
     </div>
   );
 }

--- a/src/store/ui-slice.ts
+++ b/src/store/ui-slice.ts
@@ -5,18 +5,25 @@ export interface UiSlice {
   activeTab: "chat" | "editor" | "diff" | "terminal" | "processes" | "context" | "schedules";
   terminalId: string | null;
   debugMode: boolean;
+  focusMode: boolean;
 
   setActiveTab: (tab: "chat" | "editor" | "diff" | "terminal" | "processes" | "context" | "schedules") => void;
   setTerminalId: (id: string | null) => void;
   setDebugMode: (v: boolean) => void;
+  setFocusMode: (v: boolean) => void;
 }
 
 export const createUiSlice: StateCreator<AppState, [], [], UiSlice> = (set) => ({
   activeTab: "chat",
   terminalId: null,
   debugMode: false,
+  focusMode: typeof localStorage === "undefined" || localStorage.getItem("pneuma:focusMode") !== "false",
 
   setActiveTab: (activeTab) => set({ activeTab }),
   setTerminalId: (terminalId) => set({ terminalId }),
   setDebugMode: (debugMode) => set({ debugMode }),
+  setFocusMode: (focusMode) => {
+    try { localStorage.setItem("pneuma:focusMode", String(focusMode)); } catch {}
+    set({ focusMode, ...(focusMode ? { activeTab: "chat" as const } : {}) });
+  },
 });


### PR DESCRIPTION
## Summary
- Adds a **Focus mode** toggle (default on) that strips developer-facing UI for a clean deck creation experience
- Merges TopBar items into the slide toolbar as a **single unified bar** in focus mode
- Hides dev tabs, session metrics, model selector; shifts panel ratio to 75/25
- Moves Share button to right side of toolbar next to Export
- Adds missing hover tooltips across ~13 buttons
- Extracts `ShareDropdown` to a shared component

## Changes
| File | Change |
|------|--------|
| `src/store/ui-slice.ts` | Add `focusMode` state + `setFocusMode` action, default `true`, persisted in localStorage |
| `src/components/TopBar.tsx` | Return `null` in focus mode; show focus toggle in normal mode |
| `modes/slide/viewer/SlidePreview.tsx` | SlideToolbar absorbs TopBar items (logo, selectors, toggle, share) in focus mode |
| `src/components/ShareDropdown.tsx` | **New** — extracted from TopBar so both TopBar and SlideToolbar can import it |
| `src/App.tsx` | Panel ratio 75/25 in focus mode (vs 65/35 normal) |
| `src/components/ChatPanel.tsx` | Hide status pill entirely in focus mode, reduce top padding |
| `src/components/ChatInput.tsx` | Hide model selector in focus mode, shorten placeholder text |
| `src/components/{AgentBubble,ProcessPanel,ReplayPlayer,SchedulePanel,TerminalPanel}.tsx` | Add missing `title` tooltips |

## Test plan
- [ ] Run `bun run dev slide`, verify Focus mode is on by default with single toolbar row
- [ ] Toggle Focus off, verify full TopBar with all tabs reappears
- [ ] Verify content set selector, file selector, and + button work in both modes
- [ ] Verify Share dropdown works from the right side of the toolbar in focus mode
- [ ] Verify Export button still works next to Share
- [ ] Check localStorage persistence — reload page, focus mode should persist
- [ ] Hover over buttons to verify new tooltips appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)