### PR TITLE
feat(source): Source<T> abstraction — viewer-as-player contract across all modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,48 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.29.0] - 2026-04-13
+
+### Added
+- **`Source<T>` data-channel abstraction** — viewer-contract-layer infrastructure that realizes the "viewer is the whole app UI" vision from `docs/design/pneuma-3.0-design.md`. Every mode viewer now consumes typed, origin-aware, subscription-shaped data channels via `props.sources` instead of a raw `files: ViewerFileContent[]` prop
+- **Four built-in source providers** in `core/sources/`:
+  - `memory` — ephemeral in-process state
+  - `file-glob` — multi-file aggregate read (domain is files)
+  - `json-file` — single structured file with parse/serialize + self-echo drop
+  - `aggregate-file` — multi-file domain aggregate with user-supplied `load(files) → T` + `save(T, current) → { writes, deletes }` pure functions
+- **`BaseSource` abstract class** enforcing four invariants via TDD: single writer (Promise queue serialization), change-read-via-subscription, time-locked write Promises (await returns only after the `origin: "self"` event has been delivered to all subscribers), origin-tagged events. 46 bun:test cases pin the contract
+- **Server-side origin tagging** — `pendingSelfWrites` + `pendingSelfDeletes` TTL maps in `server/file-watcher.ts` identify self-origin chokidar echoes at the source. The only place self/external origin is determined; viewers never reverse-engineer it
+- **`DELETE /api/files?path=...`** route — symmetric with POST, wired to `pendingSelfDeletes` so unlink events are origin-tagged
+- **`BrowserFileChannel`** in `src/runtime/file-channel.ts` — bridges the Zustand store + WebSocket + `/api/files` into the `FileChannel` interface that providers consume via `SourceContext.files`
+- **`SourceRegistry`** + **`useSourceInstances`** React hook — builds `{sources, fileChannel}` per active mode with proper lifecycle cleanup on mode switch
+- **`useSource<T>`** React hook wrapping `useSyncExternalStore` — returns `{value, write, status}` with `status.lastOrigin` tracking. StrictMode-safe
+- **`PluginManifest.sources`** — extension point for third-party source providers; `PluginRegistry.collectSourceProviders()` flattens them
+- **Domain types for Pattern C modes** — `modes/slide/domain.ts` defining `Deck`, `modes/webcraft/domain.ts` defining `Site`, `modes/illustrate/domain.ts` defining `Studio`. Each ships with `load`/`save` pure functions that the aggregate-file provider calls. Viewers consume `Source<Deck>` / `Source<Site>` / `Source<Studio>` directly — zero `files.find()` or inline JSON.stringify in viewer code
+- **Migration documentation**:
+  - `docs/migration/2.29-source-abstraction.md` — decision tree + 4 patterns (A read-only, B headless opt-out, C typed aggregate, D dynamic write target) + common pitfalls + escape hatch for staying on 2.28.x
+  - `docs/superpowers/plans/2026-04-13-source-abstraction.md` — 5768-line implementation plan
+  - `docs/superpowers/plans/clipcraft-source-migration.md` — focused guide for the ClipCraft mode author
+  - `docs/reference/viewer-agent-protocol.md` gained a new "Sources — Viewer 的数据通道" section + design principle 7 "Files 归 agent, Domain 归 viewer" + new `基本立场` three-layer framing (Layer 1 = files for agents, Layer 2 = runtime transport, Layer 3 = `Source<T>` for viewers)
+- **`viewer-as-player` framing pass** across README, CLAUDE.md, viewer-agent-protocol.md, pneuma-3.0-design.md, ADR-007
+
+### Changed — ⚠️ Breaking for external mode authors
+- **`ViewerPreviewProps.files` is removed.** Every viewer now receives `props.sources: Record<string, Source<unknown>>` + `props.fileChannel: FileChannel` instead. Viewers destructure `sources` and derive their file list via `useSource(sources.files as Source<ViewerFileContent[]>)`. Local variable `files` inside the component works identically to the old prop after one line of setup.
+- **`ModeManifest.sources` is required.** Every manifest must declare a `sources` field (possibly `{}` for headless modes like evolve). The synthesis fallback that auto-generated a `sources.files` file-glob from `viewer.watchPatterns` has been removed. Any external mode without a `sources` field will throw on load with a clear error message pointing at the migration guide.
+- **Error message for pre-2.29 modes** is extensively self-documenting: it prints which mode is broken, shows the 4-line fix inline, points at `docs/migration/2.29-source-abstraction.md` for the full guide, and tells users how to pin to `pneuma-skills@2.28` as an escape hatch. No guessing required.
+- **`FileUpdate` (server-side)** gained required `origin: "self" | "external"` and optional `deleted?: boolean` fields. The WebSocket `content_update` message shape is unchanged at the protocol level but the per-file entries now carry `origin`
+- **All 10 in-repo builtin modes migrated** to the new contract. 29-file diff across `modes/doc/`, `modes/diagram/`, `modes/draw/`, `modes/evolve/`, `modes/gridboard/`, `modes/illustrate/`, `modes/mode-maker/`, `modes/remotion/`, `modes/slide/`, `modes/webcraft/`. Deleted echo-detection refs: `lastExternalRef` (doc), `lastSavedContentRef` + `isUpdatingFromFileRef` + load-bearing ref-before-fetch ordering (draw), `lastFileContentRef` + `currentFilePathRef` skip-guard (diagram). Deleted 6 inline `saveFile` helpers + ~8 inline `fetch('/api/files')` call sites.
+- **CLAUDE.md builtin modes list** no longer mentions `clipcraft` (it was stale — clipcraft lives in the `feat/clipcraft-by-pneuma-craft` branch, not as a builtin)
+
+### Migration path for external mode authors
+
+If you maintain a mode that's installed via `pneuma mode add github:...` or similar, you have three options:
+
+1. **Migrate (recommended).** Follow `docs/migration/2.29-source-abstraction.md`. 4–15 minutes for most modes. Add a `sources` field to your manifest, destructure `sources` instead of `files` in your viewer, optionally use `fileChannel.write` for dynamic-target saves.
+2. **Pin to 2.28.x.** `npm install -g pneuma-skills@2.28` or download the last 2.28.x desktop installer. Your mode keeps working unchanged. 2.28 is the last release with the pre-Source contract.
+3. **For ClipCraft-class modes** (typed single-file aggregate with echo-loop concerns): follow `docs/superpowers/plans/clipcraft-source-migration.md` — it covers the three-ref dance → single `json-file` source migration with before/after code.
+
+No intermediate compat layer ships — the new contract is the only contract going forward. The error message at `SourceRegistry.effectiveSources` walks you through the fix the first time it fires.
+
 ## [2.28.0] - 2026-04-08
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,13 +2,13 @@
 
 ## Project Overview
 
-Pneuma Skills is co-creation infrastructure for humans and code agents. It provides four pillars for isomorphic collaboration: a **visual environment** (live bidirectional workspace), **skills** (domain knowledge + seed templates + session persistence), **continuous learning** (evolution agent for cross-session preference extraction and skill augmentation), and **distribution** (mode marketplace, publishing, sharing). The runtime supports multiple agent backends (Claude Code, Codex) selected at startup.
+Pneuma Skills is co-creation infrastructure for humans and code agents. The underlying bet: **coding agents already do the actual work against a directory of files; the system's job is to make human observation and optional participation intuitive**. Agents edit files directly through their native tools (Read/Edit/Write) — files remain the canonical collaboration surface and are not abstracted away. Viewers are live **players** for agent output, rendering the work in domain terms (a deck, a board, a project) so humans can watch what's happening, make direct decisions in the UI when needed, and reach for structured command suggestions when deeper guidance helps. Four pillars for isomorphic collaboration: a **visual environment** (live players for agent work with optional human participation), **skills** (domain knowledge + seed templates + session persistence), **continuous learning** (evolution agent for cross-session preference extraction and skill augmentation), and **distribution** (mode marketplace, publishing, sharing). The runtime supports multiple agent backends (Claude Code, Codex) selected at startup.
 
 **Formula:** `ModeManifest(skill + viewer + agent_config) × AgentBackend × RuntimeShell`
 
-**Version:** 2.28.0
+**Version:** 2.29.0
 **Runtime:** Bun >= 1.3.5 (required, not Node.js)
-**Builtin Modes:** `webcraft`, `doc`, `slide`, `draw`, `diagram`, `illustrate`, `remotion`, `gridboard`, `clipcraft`, `mode-maker`, `evolve`
+**Builtin Modes:** `webcraft`, `doc`, `slide`, `draw`, `diagram`, `illustrate`, `remotion`, `gridboard`, `mode-maker`, `evolve`
 
 ## Tech Stack
 

--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@
 
 > **"pneuma"** — Greek *pneuma*, meaning soul, breath, life force.
 
-When humans and code agents co-create content, they need more than a chat window — they need shared infrastructure. Pneuma provides four pillars for **isomorphic collaboration**, built atop mainstream code agents. Today the production path is [Claude Code](https://docs.anthropic.com/en/docs/claude-code); the runtime now exposes a startup-selectable backend layer so additional agents can be integrated without rewriting the UI shell.
+When humans and code agents co-create content, they need more than a chat window — they need shared infrastructure. Pneuma's bet is simple: **coding agents already do the work; what's missing is a way for people to watch them and participate at the right moments**. Agents live in files on disk — that's their native habitat and we don't try to abstract it away. Instead, we give each task a live player that renders the work in domain terms (a deck of slides, a board of tiles, a project) and let humans drop in direct edits or structured suggestions without breaking the agent's flow. Four pillars for **isomorphic collaboration**, built atop mainstream code agents. Today the production path is [Claude Code](https://docs.anthropic.com/en/docs/claude-code); the runtime now exposes a startup-selectable backend layer so additional agents can be integrated without rewriting the UI shell.
 
 | Pillar | What it does |
 |--------|-------------|
-| **Visual Environment** | Agent edits files on disk; you see, select, and guide the rendered result in a live, bidirectional workspace |
+| **Visual Environment** | Agent works directly in files on disk — its native surface. Viewers are live players for agent output rendered in domain terms, with optional human participation directly in the UI. |
 | **Skills** | Domain-specific knowledge and seed templates injected per mode. Sessions persist across runs — the agent picks up where it left off |
 | **User Preferences** | The agent builds and maintains a persistent portrait of your aesthetics, collaboration style, and per-mode habits — preferences survive across sessions, workspaces, and modes |
 | **Continuous Learning** | Evolution Agent mines conversation history to extract preferences, then augments skills with learned knowledge |

--- a/core/__tests__/plugin-registry.test.ts
+++ b/core/__tests__/plugin-registry.test.ts
@@ -159,4 +159,79 @@ describe("PluginRegistry", () => {
       expect(entries).toEqual([]);
     });
   });
+
+  describe("collectSourceProviders", () => {
+    test("flattens providers from loaded plugins", async () => {
+      // Write a manifest.ts that exports real SourceProvider objects
+      // (JSON.stringify would strip the .create functions).
+      const pluginADir = join(PLUGINS_DIR, "plugin-a");
+      mkdirSync(pluginADir, { recursive: true });
+      writeFileSync(
+        join(pluginADir, "manifest.ts"),
+        `const make = (kind) => ({
+          kind,
+          create: () => ({
+            id: "x",
+            kind,
+            current: () => null,
+            subscribe: () => () => {},
+            write: async () => {},
+            dispose: async () => {},
+          }),
+        });
+        export default {
+          name: "plugin-a",
+          version: "1.0.0",
+          displayName: "A",
+          description: "A",
+          scope: "global",
+          sources: [make("acme-x"), make("acme-y")],
+        };`,
+      );
+
+      const pluginBDir = join(PLUGINS_DIR, "plugin-b");
+      mkdirSync(pluginBDir, { recursive: true });
+      writeFileSync(
+        join(pluginBDir, "manifest.ts"),
+        `const make = (kind) => ({
+          kind,
+          create: () => ({
+            id: "x",
+            kind,
+            current: () => null,
+            subscribe: () => () => {},
+            write: async () => {},
+            dispose: async () => {},
+          }),
+        });
+        export default {
+          name: "plugin-b",
+          version: "1.0.0",
+          displayName: "B",
+          description: "B",
+          scope: "global",
+          sources: [make("acme-z")],
+        };`,
+      );
+
+      settings.setEnabled("plugin-a", true);
+      settings.setEnabled("plugin-b", true);
+
+      const discovered = await registry.discover();
+      await registry.activateAll(discovered, {
+        sessionId: "test",
+        mode: "slide",
+        workspace: "/tmp",
+        backendType: "claude-code",
+      });
+
+      const providers = registry.collectSourceProviders();
+      const kinds = providers.map((p) => p.kind).sort();
+      expect(kinds).toEqual(["acme-x", "acme-y", "acme-z"]);
+    });
+
+    test("returns empty array when no plugins contribute sources", () => {
+      expect(registry.collectSourceProviders()).toEqual([]);
+    });
+  });
 });

--- a/core/__tests__/source-registry.test.ts
+++ b/core/__tests__/source-registry.test.ts
@@ -1,0 +1,134 @@
+import { describe, test, expect } from "bun:test";
+import { SourceRegistry } from "../source-registry.js";
+import { BUILT_IN_PROVIDERS } from "../sources/index.js";
+import type {
+  SourceProvider,
+  SourceContext,
+  FileChannel,
+} from "../types/source.js";
+import type { ModeManifest } from "../types/mode-manifest.js";
+
+function noopCtx(files?: FileChannel): SourceContext {
+  return {
+    workspace: "/tmp/test",
+    log: () => {},
+    signal: new AbortController().signal,
+    files,
+  };
+}
+
+describe("SourceRegistry", () => {
+  test("registers built-in providers and looks them up by kind", () => {
+    const reg = new SourceRegistry();
+    for (const p of BUILT_IN_PROVIDERS) reg.register(p);
+    expect(reg.has("memory")).toBe(true);
+    expect(reg.has("file-glob")).toBe(true);
+    expect(reg.has("json-file")).toBe(true);
+    expect(reg.has("aggregate-file")).toBe(true);
+    expect(reg.has("redis")).toBe(false);
+  });
+
+  test("instantiates a memory source from a manifest declaration", async () => {
+    const reg = new SourceRegistry();
+    for (const p of BUILT_IN_PROVIDERS) reg.register(p);
+    const manifest: Pick<ModeManifest, "sources"> = {
+      sources: {
+        state: { kind: "memory", config: { initial: 42 } },
+      },
+    };
+    const instances = reg.instantiateAll(manifest.sources ?? {}, noopCtx());
+    expect(instances.state).toBeDefined();
+    await Promise.resolve();
+    expect(instances.state.current()).toBe(42);
+  });
+
+  test("instantiateAll throws if an unknown kind is declared", () => {
+    const reg = new SourceRegistry();
+    for (const p of BUILT_IN_PROVIDERS) reg.register(p);
+    expect(() =>
+      reg.instantiateAll(
+        { x: { kind: "does-not-exist", config: {} } },
+        noopCtx(),
+      ),
+    ).toThrow(/does-not-exist/);
+  });
+
+  test("destroyAll destroys every instance", async () => {
+    const reg = new SourceRegistry();
+    for (const p of BUILT_IN_PROVIDERS) reg.register(p);
+    const instances = reg.instantiateAll(
+      { a: { kind: "memory" }, b: { kind: "memory" } },
+      noopCtx(),
+    );
+    reg.destroyAll(instances);
+    // After destroy, current() is null even if an initial was queued
+    await Promise.resolve();
+    expect(instances.a.current()).toBeNull();
+    expect(instances.b.current()).toBeNull();
+  });
+
+  test("registering a provider with a duplicate kind throws", () => {
+    const reg = new SourceRegistry();
+    const p: SourceProvider = {
+      kind: "memory",
+      create: () => ({
+        current: () => null,
+        subscribe: () => () => {},
+        write: async () => {},
+        destroy: () => {},
+      }),
+    };
+    reg.register(p);
+    expect(() => reg.register(p)).toThrow(/memory/);
+  });
+
+  test("effectiveSources throws if manifest.sources is absent", () => {
+    const manifestLike = {
+      name: "legacy-external-mode",
+      viewer: { watchPatterns: ["**/*.md"], ignorePatterns: [] },
+      sources: undefined,
+    };
+    expect(() =>
+      SourceRegistry.effectiveSources(manifestLike as unknown as ModeManifest),
+    ).toThrow(/not compatible with pneuma-skills 2\.29\.0/);
+  });
+
+  test("effectiveSources error message includes the mode name and migration pointers", () => {
+    const manifestLike = {
+      name: "my-broken-mode",
+      viewer: { watchPatterns: ["**/*.md"], ignorePatterns: [] },
+      sources: undefined,
+    };
+    let captured: Error | null = null;
+    try {
+      SourceRegistry.effectiveSources(manifestLike as unknown as ModeManifest);
+    } catch (e) {
+      captured = e as Error;
+    }
+    expect(captured).not.toBeNull();
+    const msg = captured!.message;
+    // Mode name appears in the error
+    expect(msg).toContain("my-broken-mode");
+    // Version pivot is called out
+    expect(msg).toContain("2.29.0");
+    // Migration doc is referenced
+    expect(msg).toContain("docs/migration/2.29-source-abstraction.md");
+    // Escape hatch is documented
+    expect(msg).toContain("pneuma-skills@2.28");
+    // Common fix (file-glob snippet) is inline
+    expect(msg).toContain("file-glob");
+    // Headless opt-out is mentioned
+    expect(msg).toContain("sources: {}");
+  });
+
+  test("effectiveSources preserves an explicit sources block unchanged", () => {
+    const manifestLike = {
+      viewer: { watchPatterns: ["**/*.md"], ignorePatterns: [] },
+      sources: { custom: { kind: "memory", config: { initial: 1 } } },
+    };
+    const effective = SourceRegistry.effectiveSources(manifestLike as unknown as ModeManifest);
+    expect(effective).toEqual({
+      custom: { kind: "memory", config: { initial: 1 } },
+    });
+  });
+});

--- a/core/__tests__/source-types.test.ts
+++ b/core/__tests__/source-types.test.ts
@@ -1,0 +1,112 @@
+import { describe, test, expect } from "bun:test";
+import type {
+  Source,
+  SourceEvent,
+  SourceProvider,
+  SourceContext,
+  SourceDescriptor,
+  FileChannel,
+  FileChangeEvent,
+} from "../types/source.js";
+import type { ModeManifest } from "../types/mode-manifest.js";
+
+describe("Source contract shape", () => {
+  test("SourceEvent discriminates on kind", () => {
+    // Compile-time exhaustiveness check: if a new kind is added without
+    // updating this function, tsc will complain about the unreachable case.
+    function assertNever(x: never): never {
+      throw new Error(`Unexpected: ${String(x)}`);
+    }
+    function reduce<T>(e: SourceEvent<T>): string {
+      switch (e.kind) {
+        case "value":
+          return e.origin;
+        case "error":
+          return e.code;
+        default:
+          return assertNever(e);
+      }
+    }
+    expect(
+      reduce<number>({ kind: "value", value: 1, origin: "initial" }),
+    ).toBe("initial");
+    expect(
+      reduce<number>({ kind: "error", code: "E_PARSE", message: "bad" }),
+    ).toBe("E_PARSE");
+  });
+
+  test("Source<T> has the four required methods", () => {
+    const stub: Source<number> = {
+      current: () => null,
+      subscribe: () => () => {},
+      write: async () => {},
+      destroy: () => {},
+    };
+    expect(typeof stub.current).toBe("function");
+    expect(typeof stub.subscribe).toBe("function");
+    expect(typeof stub.write).toBe("function");
+    expect(typeof stub.destroy).toBe("function");
+  });
+
+  test("SourceProvider.create takes config and context, returns Source", () => {
+    const provider: SourceProvider = {
+      kind: "test",
+      create<T>(_config: unknown, _ctx: SourceContext): Source<T> {
+        return {
+          current: () => null,
+          subscribe: () => () => {},
+          write: async () => {},
+          destroy: () => {},
+        };
+      },
+    };
+    expect(provider.kind).toBe("test");
+  });
+
+  test("SourceContext exposes workspace, log, signal, optional files", () => {
+    const ctx: SourceContext = {
+      workspace: "/tmp/ws",
+      log: () => {},
+      signal: new AbortController().signal,
+    };
+    expect(ctx.workspace).toBe("/tmp/ws");
+    expect(ctx.files).toBeUndefined();
+  });
+
+  test("FileChannel has snapshot, subscribe, write, delete", () => {
+    const channel: FileChannel = {
+      snapshot: () => [],
+      subscribe: () => () => {},
+      write: async () => {},
+      delete: async () => {},
+    };
+    expect(channel.snapshot()).toEqual([]);
+  });
+
+  test("FileChangeEvent origin is one of initial|self|external", () => {
+    const events: FileChangeEvent[] = [
+      { path: "a.md", content: "x", origin: "initial" },
+      { path: "a.md", content: "y", origin: "self" },
+      { path: "a.md", content: "z", origin: "external" },
+    ];
+    expect(events).toHaveLength(3);
+  });
+
+  test("SourceDescriptor is assignable from manifest.sources entry", () => {
+    const d: SourceDescriptor = {
+      kind: "file-glob",
+      config: { patterns: ["**/*.md"] },
+    };
+    expect(d.kind).toBe("file-glob");
+  });
+
+  test("ModeManifest.sources is optional and takes SourceDescriptors", () => {
+    // Compile-time: this must typecheck without errors.
+    const partial: Pick<ModeManifest, "sources"> = {
+      sources: {
+        files: { kind: "file-glob", config: { patterns: ["**/*.md"] } },
+      },
+    };
+    expect(partial.sources?.files.kind).toBe("file-glob");
+  });
+});

--- a/core/__tests__/viewer-contract.test.ts
+++ b/core/__tests__/viewer-contract.test.ts
@@ -96,7 +96,13 @@ describe("ViewerContract", () => {
 describe("ViewerPreviewProps shape", () => {
   test("contains all required fields", () => {
     const props: ViewerPreviewProps = {
-      files: [],
+      sources: {},
+      fileChannel: {
+        snapshot: () => [],
+        subscribe: () => () => {},
+        write: async () => {},
+        delete: async () => {},
+      },
       selection: null,
       onSelect: () => {},
       mode: "view",
@@ -104,7 +110,7 @@ describe("ViewerPreviewProps shape", () => {
       imageVersion: 0,
     };
 
-    expect(props.files).toEqual([]);
+    expect(props.sources).toEqual({});
     expect(props.selection).toBeNull();
     expect(typeof props.onSelect).toBe("function");
     expect(["view", "edit", "select"]).toContain(props.mode);
@@ -327,7 +333,13 @@ describe("Backward compatibility", () => {
 
   test("ViewerPreviewProps with new optional fields", () => {
     const props: ViewerPreviewProps = {
-      files: [],
+      sources: {},
+      fileChannel: {
+        snapshot: () => [],
+        subscribe: () => () => {},
+        write: async () => {},
+        delete: async () => {},
+      },
       selection: null,
       onSelect: () => {},
       mode: "view",

--- a/core/plugin-registry.ts
+++ b/core/plugin-registry.ts
@@ -13,6 +13,7 @@ import type {
 } from "./types/plugin.js";
 import type { HookBus } from "./hook-bus.js";
 import type { SettingsManager } from "./settings-manager.js";
+import type { SourceProvider } from "./types/source.js";
 
 export interface PluginRegistryOptions {
   builtinDir: string;
@@ -132,7 +133,14 @@ export class PluginRegistry {
       }
 
       const slots = manifest.slots ?? {};
-      const plugin: LoadedPlugin = { manifest, basePath, hooks, slots, routes };
+      const plugin: LoadedPlugin = {
+        manifest,
+        basePath,
+        hooks,
+        slots,
+        routes,
+        sources: manifest.sources ?? [],
+      };
       this.loaded.set(manifest.name, plugin);
       return plugin;
     } catch (err: unknown) {
@@ -186,6 +194,21 @@ export class PluginRegistry {
 
   getLoadedList(): LoadedPlugin[] {
     return [...this.loaded.values()];
+  }
+
+  /**
+   * Collect every source provider contributed by currently-loaded plugins.
+   * The runtime calls this when building a per-mode SourceRegistry to
+   * register plugin providers alongside the built-ins. Duplicate kinds
+   * across plugins cause SourceRegistry.register to throw — plugins must
+   * namespace their kinds.
+   */
+  collectSourceProviders(): SourceProvider[] {
+    const out: SourceProvider[] = [];
+    for (const plugin of this.loaded.values()) {
+      out.push(...plugin.sources);
+    }
+    return out;
   }
 
   /** Get all slot declarations for a given slot name across all loaded plugins */

--- a/core/source-registry.ts
+++ b/core/source-registry.ts
@@ -1,0 +1,128 @@
+import type {
+  Source,
+  SourceProvider,
+  SourceContext,
+  SourceDescriptor,
+} from "./types/source.js";
+import type { ModeManifest } from "./types/mode-manifest.js";
+
+export class SourceRegistry {
+  private providers = new Map<string, SourceProvider>();
+
+  register(provider: SourceProvider): void {
+    if (this.providers.has(provider.kind)) {
+      throw new Error(
+        `SourceRegistry: provider kind "${provider.kind}" is already registered`,
+      );
+    }
+    this.providers.set(provider.kind, provider);
+  }
+
+  has(kind: string): boolean {
+    return this.providers.has(kind);
+  }
+
+  instantiate(
+    descriptor: SourceDescriptor,
+    ctx: SourceContext,
+  ): Source<unknown> {
+    const provider = this.providers.get(descriptor.kind);
+    if (!provider) {
+      throw new Error(
+        `SourceRegistry: no provider registered for kind "${descriptor.kind}"`,
+      );
+    }
+    return provider.create<unknown>(descriptor.config, ctx);
+  }
+
+  instantiateAll(
+    descriptors: Record<string, SourceDescriptor>,
+    ctx: SourceContext,
+  ): Record<string, Source<unknown>> {
+    const out: Record<string, Source<unknown>> = {};
+    for (const [id, desc] of Object.entries(descriptors)) {
+      out[id] = this.instantiate(desc, ctx);
+    }
+    return out;
+  }
+
+  destroyAll(instances: Record<string, Source<unknown>>): void {
+    for (const instance of Object.values(instances)) {
+      try {
+        instance.destroy();
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error("[source-registry] destroy threw", err);
+      }
+    }
+  }
+
+  /**
+   * Compute the effective `sources` declaration for a manifest. Since
+   * pneuma-skills 2.29.0 every ModeManifest must declare `sources`
+   * explicitly (use `sources: {}` for headless modes like evolve).
+   * An absent `sources` field means the mode was authored against
+   * the pre-2.29 contract and needs to be migrated.
+   */
+  static effectiveSources(
+    manifest: ModeManifest,
+  ): Record<string, SourceDescriptor> {
+    if (!manifest.sources) {
+      throw new Error(
+        `\n` +
+          `╔═══════════════════════════════════════════════════════════════╗\n` +
+          `║  Mode "${manifest.name}" is not compatible with pneuma-skills 2.29.0+\n` +
+          `╚═══════════════════════════════════════════════════════════════╝\n` +
+          `\n` +
+          `pneuma-skills 2.29.0 introduced the Source<T> abstraction. Every\n` +
+          `ModeManifest must now declare a \`sources\` field describing the\n` +
+          `data channels its viewer consumes. This mode's manifest does not.\n` +
+          `\n` +
+          `➤ TO FIX (most modes, 4 lines): add this to your manifest.ts\n` +
+          `  alongside the existing \`viewer\` field:\n` +
+          `\n` +
+          `    sources: {\n` +
+          `      files: {\n` +
+          `        kind: "file-glob",\n` +
+          `        config: { patterns: [/* copy from viewer.watchPatterns */] },\n` +
+          `      },\n` +
+          `    },\n` +
+          `\n` +
+          `  Then in your viewer component, replace the deprecated\n` +
+          `  \`files: ViewerFileContent[]\` prop with \`sources\` +\n` +
+          `  \`useSource(sources.files)\`. Full 5-minute guide:\n` +
+          `    docs/migration/2.29-source-abstraction.md\n` +
+          `\n` +
+          `➤ TO FIX (viewers that write back to files): additionally\n` +
+          `  destructure \`fileChannel\` from props and replace inline\n` +
+          `  \`fetch('/api/files', ...)\` calls with\n` +
+          `  \`fileChannel.write(path, content)\`. See the migration guide\n` +
+          `  Pattern D section.\n` +
+          `\n` +
+          `➤ TO FIX (viewers that consume typed domain aggregates like\n` +
+          `  slide/webcraft/illustrate): define a domain.ts with load/save\n` +
+          `  pure functions and declare a \`kind: "aggregate-file"\` source.\n` +
+          `  See modes/slide/domain.ts and modes/slide/manifest.ts as a\n` +
+          `  working example. Migration guide Pattern C section.\n` +
+          `\n` +
+          `➤ IF YOU CANNOT MIGRATE NOW: pin the runtime to the previous\n` +
+          `  minor version:\n` +
+          `\n` +
+          `    npm install -g pneuma-skills@2.28\n` +
+          `\n` +
+          `  or edit this mode's workspace using any 2.28.x release.\n` +
+          `  Pneuma 2.28 remains the last release compatible with the\n` +
+          `  pre-Source contract.\n` +
+          `\n` +
+          `➤ HEADLESS MODE (no viewer, agent-only): use \`sources: {}\`\n` +
+          `  to explicitly opt out of file channels. See modes/evolve/\n` +
+          `  manifest.ts.\n` +
+          `\n` +
+          `Full design rationale:\n` +
+          `  docs/reference/viewer-agent-protocol.md (see "Sources" section)\n` +
+          `  docs/superpowers/plans/2026-04-13-source-abstraction.md\n`,
+      );
+    }
+    return manifest.sources;
+  }
+}

--- a/core/sources/__tests__/aggregate-file.test.ts
+++ b/core/sources/__tests__/aggregate-file.test.ts
@@ -1,0 +1,190 @@
+import { describe, test, expect, beforeEach } from "bun:test";
+import { AggregateFileSource } from "../aggregate-file.js";
+import type {
+  FileChannel,
+  FileChangeEvent,
+  SourceEvent,
+} from "../../types/source.js";
+import type { ViewerFileContent } from "../../types/viewer-contract.js";
+
+// A tiny toy domain: a "Deck" of slides where each slide is a file
+// at `slides/slide-<id>.html` and the deck order lives in `manifest.json`.
+interface Slide { id: string; html: string }
+interface Deck { order: string[]; slides: Record<string, Slide> }
+
+function loadDeck(files: ReadonlyArray<ViewerFileContent>): Deck | null {
+  const manifest = files.find((f) => f.path === "manifest.json");
+  if (!manifest) return null;
+  const parsed = JSON.parse(manifest.content) as { order: string[] };
+  const slides: Record<string, Slide> = {};
+  for (const id of parsed.order) {
+    const f = files.find((x) => x.path === `slides/slide-${id}.html`);
+    if (f) slides[id] = { id, html: f.content };
+  }
+  return { order: parsed.order, slides };
+}
+
+function saveDeck(
+  next: Deck,
+  current: ReadonlyArray<ViewerFileContent>,
+): { writes: Array<{ path: string; content: string }>; deletes: string[] } {
+  const writes: Array<{ path: string; content: string }> = [
+    { path: "manifest.json", content: JSON.stringify({ order: next.order }) },
+  ];
+  for (const id of next.order) {
+    const slide = next.slides[id];
+    if (slide) writes.push({ path: `slides/slide-${id}.html`, content: slide.html });
+  }
+  // Delete any slide file whose id is no longer in next.order
+  const keep = new Set(next.order.map((id) => `slides/slide-${id}.html`));
+  const deletes: string[] = [];
+  for (const f of current) {
+    if (f.path.startsWith("slides/slide-") && f.path.endsWith(".html") && !keep.has(f.path)) {
+      deletes.push(f.path);
+    }
+  }
+  return { writes, deletes };
+}
+
+class MockFileChannel implements FileChannel {
+  public handlers = new Set<(batch: FileChangeEvent[]) => void>();
+  public files: ViewerFileContent[] = [];
+  public writes: Array<{ path: string; content: string }> = [];
+  public deletes: string[] = [];
+
+  snapshot() { return this.files; }
+  subscribe(h: (b: FileChangeEvent[]) => void) {
+    this.handlers.add(h);
+    return () => { this.handlers.delete(h); };
+  }
+  async write(path: string, content: string) {
+    this.writes.push({ path, content });
+    const existing = this.files.find((f) => f.path === path);
+    if (existing) existing.content = content;
+    else this.files.push({ path, content });
+  }
+  async delete(path: string) {
+    this.deletes.push(path);
+    this.files = this.files.filter((f) => f.path !== path);
+  }
+  push(batch: FileChangeEvent[]) { for (const h of this.handlers) h(batch); }
+}
+
+describe("AggregateFileSource", () => {
+  let ch: MockFileChannel;
+
+  beforeEach(() => {
+    ch = new MockFileChannel();
+    ch.files = [
+      { path: "manifest.json", content: '{"order":["a","b"]}' },
+      { path: "slides/slide-a.html", content: "<p>A</p>" },
+      { path: "slides/slide-b.html", content: "<p>B</p>" },
+    ];
+  });
+
+  test("initial load reconstructs the domain aggregate from files", async () => {
+    const s = new AggregateFileSource<Deck>(
+      { patterns: ["manifest.json", "slides/**/*.html"], load: loadDeck, save: saveDeck },
+      ch,
+    );
+    const events: SourceEvent<Deck>[] = [];
+    s.subscribe((e) => events.push(e));
+    await Promise.resolve();
+    expect(events).toHaveLength(1);
+    if (events[0].kind !== "value") throw new Error("expected value");
+    expect(events[0].origin).toBe("initial");
+    expect(events[0].value.order).toEqual(["a", "b"]);
+    expect(events[0].value.slides.a.html).toBe("<p>A</p>");
+  });
+
+  test("external file change re-runs load and emits external", async () => {
+    const s = new AggregateFileSource<Deck>(
+      { patterns: ["manifest.json", "slides/**/*.html"], load: loadDeck, save: saveDeck },
+      ch,
+    );
+    await Promise.resolve();
+    const events: SourceEvent<Deck>[] = [];
+    s.subscribe((e) => events.push(e));
+
+    ch.files = ch.files.map((f) =>
+      f.path === "slides/slide-a.html" ? { ...f, content: "<p>A edited by agent</p>" } : f,
+    );
+    ch.push([{ path: "slides/slide-a.html", content: "<p>A edited by agent</p>", origin: "external" }]);
+
+    expect(events).toHaveLength(1);
+    if (events[0].kind !== "value") throw new Error("expected value");
+    expect(events[0].origin).toBe("external");
+    expect(events[0].value.slides.a.html).toBe("<p>A edited by agent</p>");
+  });
+
+  test("write decomposes the aggregate via save() and produces channel writes + deletes", async () => {
+    const s = new AggregateFileSource<Deck>(
+      { patterns: ["manifest.json", "slides/**/*.html"], load: loadDeck, save: saveDeck },
+      ch,
+    );
+    await Promise.resolve();
+
+    const events: SourceEvent<Deck>[] = [];
+    s.subscribe((e) => events.push(e));
+
+    // Delete slide "b", add a new slide "c"
+    const next: Deck = {
+      order: ["a", "c"],
+      slides: {
+        a: { id: "a", html: "<p>A</p>" },
+        c: { id: "c", html: "<p>C (new)</p>" },
+      },
+    };
+    await s.write(next);
+
+    // save() should produce: write manifest.json, write slide-a (unchanged),
+    // write slide-c (new), delete slide-b
+    const writePaths = ch.writes.map((w) => w.path).sort();
+    expect(writePaths).toContain("manifest.json");
+    expect(writePaths).toContain("slides/slide-c.html");
+    expect(ch.deletes).toEqual(["slides/slide-b.html"]);
+
+    // And a self-origin event fires with the new aggregate
+    expect(events).toHaveLength(1);
+    if (events[0].kind !== "value") throw new Error("expected value");
+    expect(events[0].origin).toBe("self");
+    expect(events[0].value.order).toEqual(["a", "c"]);
+  });
+
+  test("load failure emits error, source stays live for future events", async () => {
+    ch.files = [{ path: "manifest.json", content: "{not json" }];
+    const s = new AggregateFileSource<Deck>(
+      { patterns: ["manifest.json", "slides/**/*.html"], load: loadDeck, save: saveDeck },
+      ch,
+    );
+    const events: SourceEvent<Deck>[] = [];
+    s.subscribe((e) => events.push(e));
+    await Promise.resolve();
+    expect(events).toHaveLength(1);
+    expect(events[0].kind).toBe("error");
+
+    // Recover with a valid manifest
+    ch.files = [
+      { path: "manifest.json", content: '{"order":["a"]}' },
+      { path: "slides/slide-a.html", content: "<p>A</p>" },
+    ];
+    ch.push([
+      { path: "manifest.json", content: '{"order":["a"]}', origin: "external" },
+    ]);
+    // First successful load post-error still fires as "initial"
+    const valueEvents = events.filter((e) => e.kind === "value");
+    expect(valueEvents).toHaveLength(1);
+    if (valueEvents[0].kind !== "value") throw new Error("expected value");
+    expect(valueEvents[0].origin).toBe("initial");
+  });
+
+  test("destroy unsubscribes from channel", () => {
+    const s = new AggregateFileSource<Deck>(
+      { patterns: ["manifest.json", "slides/**/*.html"], load: loadDeck, save: saveDeck },
+      ch,
+    );
+    expect(ch.handlers.size).toBe(1);
+    s.destroy();
+    expect(ch.handlers.size).toBe(0);
+  });
+});

--- a/core/sources/__tests__/base.test.ts
+++ b/core/sources/__tests__/base.test.ts
@@ -1,0 +1,211 @@
+import { describe, test, expect } from "bun:test";
+import { BaseSource } from "../base.js";
+import type { SourceEvent } from "../../types/source.js";
+
+// A minimal concrete subclass for testing BaseSource directly.
+// doWrite() just echoes the value back as a "self" event and resolves.
+class TestSource<T> extends BaseSource<T> {
+  public doWriteCalls: T[] = [];
+  public doWriteDelay = 0;
+  public doWriteError: Error | null = null;
+
+  protected async doWrite(value: T): Promise<void> {
+    this.doWriteCalls.push(value);
+    if (this.doWriteDelay > 0) {
+      await new Promise((r) => setTimeout(r, this.doWriteDelay));
+    }
+    if (this.doWriteError) throw this.doWriteError;
+    this.emit({ kind: "value", value, origin: "self" });
+  }
+
+  // Test hooks for driving events from outside
+  public testEmitInitial(value: T): void {
+    this.emit({ kind: "value", value, origin: "initial" });
+  }
+  public testEmitExternal(value: T): void {
+    this.emit({ kind: "value", value, origin: "external" });
+  }
+  public testEmitError(code: string, message: string): void {
+    this.emit({ kind: "error", code, message });
+  }
+}
+
+describe("BaseSource", () => {
+  test("current() returns null before any event", () => {
+    const s = new TestSource<number>();
+    expect(s.current()).toBeNull();
+  });
+
+  test("emit updates current() synchronously", () => {
+    const s = new TestSource<number>();
+    s.testEmitInitial(42);
+    expect(s.current()).toBe(42);
+  });
+
+  test("subscribe receives future events, not a synthetic initial", () => {
+    const s = new TestSource<number>();
+    s.testEmitInitial(1);
+    const events: SourceEvent<number>[] = [];
+    s.subscribe((e) => events.push(e));
+    expect(events).toHaveLength(0);  // no synthetic on subscribe
+    s.testEmitExternal(2);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({ kind: "value", value: 2, origin: "external" });
+  });
+
+  test("multiple subscribers all receive the same event", () => {
+    const s = new TestSource<number>();
+    const a: SourceEvent<number>[] = [];
+    const b: SourceEvent<number>[] = [];
+    s.subscribe((e) => a.push(e));
+    s.subscribe((e) => b.push(e));
+    s.testEmitExternal(7);
+    expect(a).toHaveLength(1);
+    expect(b).toHaveLength(1);
+  });
+
+  test("unsubscribe stops that listener only", () => {
+    const s = new TestSource<number>();
+    const a: SourceEvent<number>[] = [];
+    const b: SourceEvent<number>[] = [];
+    const offA = s.subscribe((e) => a.push(e));
+    s.subscribe((e) => b.push(e));
+    offA();
+    s.testEmitExternal(7);
+    expect(a).toHaveLength(0);
+    expect(b).toHaveLength(1);
+  });
+
+  test("write calls doWrite and emits self event", async () => {
+    const s = new TestSource<string>();
+    const events: SourceEvent<string>[] = [];
+    s.subscribe((e) => events.push(e));
+    await s.write("hello");
+    expect(s.doWriteCalls).toEqual(["hello"]);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({ kind: "value", value: "hello", origin: "self" });
+    expect(s.current()).toBe("hello");
+  });
+
+  test("write Promise resolves AFTER the self event is delivered", async () => {
+    const s = new TestSource<string>();
+    s.doWriteDelay = 20;
+    let eventSeenAt = 0;
+    let writeResolvedAt = 0;
+    s.subscribe((e) => {
+      if (e.kind === "value" && e.origin === "self") {
+        eventSeenAt = performance.now();
+      }
+    });
+    const before = performance.now();
+    await s.write("x");
+    writeResolvedAt = performance.now();
+    // Event must be delivered before or at the same instant write resolves
+    expect(eventSeenAt).toBeGreaterThan(0);
+    expect(eventSeenAt).toBeLessThanOrEqual(writeResolvedAt);
+    // And the write took roughly the doWriteDelay
+    expect(writeResolvedAt - before).toBeGreaterThanOrEqual(15);
+  });
+
+  test("concurrent write calls are serialized in call order", async () => {
+    const s = new TestSource<number>();
+    s.doWriteDelay = 10;
+    const writes = [s.write(1), s.write(2), s.write(3)];
+    await Promise.all(writes);
+    expect(s.doWriteCalls).toEqual([1, 2, 3]);
+    expect(s.current()).toBe(3);
+  });
+
+  test("a failed write propagates its error to the caller", async () => {
+    const s = new TestSource<number>();
+    s.doWriteError = new Error("disk full");
+    await expect(s.write(1)).rejects.toThrow("disk full");
+  });
+
+  test("a failed write does not block subsequent writes", async () => {
+    const s = new TestSource<number>();
+    s.doWriteError = new Error("first fails");
+    await expect(s.write(1)).rejects.toThrow("first fails");
+    s.doWriteError = null;
+    await s.write(2);
+    expect(s.current()).toBe(2);
+  });
+
+  test("destroy() is idempotent and makes write a no-op", async () => {
+    const s = new TestSource<number>();
+    s.destroy();
+    s.destroy();  // second call is safe
+    await s.write(1);  // resolves without calling doWrite
+    expect(s.doWriteCalls).toEqual([]);
+    expect(s.current()).toBeNull();
+  });
+
+  test("current() returns null after destroy even if a value was previously written", async () => {
+    const s = new TestSource<number>();
+    await s.write(42);
+    expect(s.current()).toBe(42);
+    s.destroy();
+    expect(s.current()).toBeNull();
+  });
+
+  test("destroy while a write is queued prevents doWrite from running", async () => {
+    const s = new TestSource<number>();
+    s.doWriteDelay = 30;
+    // Start write 1 (takes 30ms); queue write 2 behind it.
+    const w1 = s.write(1);
+    const w2 = s.write(2);
+    // Destroy after w1 starts but before w1 finishes (and thus before w2 runs).
+    // Give the first doWrite a chance to begin by yielding once.
+    await new Promise((r) => setTimeout(r, 5));
+    s.destroy();
+    // Both promises settle without throwing.
+    await w1;
+    await w2;
+    // doWrite for w1 already started before destroy (it's running concurrently),
+    // so it's in doWriteCalls. But doWrite for w2 should NOT have been called.
+    expect(s.doWriteCalls).toContain(1);
+    expect(s.doWriteCalls).not.toContain(2);
+  });
+
+  test("destroy() removes all subscribers", () => {
+    const s = new TestSource<number>();
+    const events: SourceEvent<number>[] = [];
+    s.subscribe((e) => events.push(e));
+    s.destroy();
+    s.testEmitExternal(1);  // after destroy, emit is a no-op
+    expect(events).toHaveLength(0);
+  });
+
+  test("subscribe after destroy returns a no-op unsubscribe", () => {
+    const s = new TestSource<number>();
+    s.destroy();
+    const off = s.subscribe(() => {});
+    expect(typeof off).toBe("function");
+    off();  // must not throw
+  });
+
+  test("error events do not update current()", () => {
+    const s = new TestSource<number>();
+    s.testEmitInitial(10);
+    s.testEmitError("E_X", "bad");
+    expect(s.current()).toBe(10);
+  });
+
+  test("error event is delivered to all subscribers", () => {
+    const s = new TestSource<number>();
+    const events: SourceEvent<number>[] = [];
+    s.subscribe((e) => events.push(e));
+    s.testEmitError("E_X", "bad");
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({ kind: "error", code: "E_X", message: "bad" });
+  });
+
+  test("a listener that throws does not prevent other listeners from running", () => {
+    const s = new TestSource<number>();
+    s.subscribe(() => { throw new Error("boom"); });
+    const events: SourceEvent<number>[] = [];
+    s.subscribe((e) => events.push(e));
+    s.testEmitExternal(1);
+    expect(events).toHaveLength(1);
+  });
+});

--- a/core/sources/__tests__/file-glob.test.ts
+++ b/core/sources/__tests__/file-glob.test.ts
@@ -1,0 +1,152 @@
+import { describe, test, expect, beforeEach } from "bun:test";
+import { FileGlobSource } from "../file-glob.js";
+import type {
+  FileChannel,
+  FileChangeEvent,
+  SourceEvent,
+} from "../../types/source.js";
+import type { ViewerFileContent } from "../../types/viewer-contract.js";
+
+// In-memory FileChannel for testing — lets the test drive file events
+// directly without a real server.
+class MockFileChannel implements FileChannel {
+  public handlers = new Set<(batch: FileChangeEvent[]) => void>();
+  public files: ViewerFileContent[] = [];
+  public writes: Array<{ path: string; content: string }> = [];
+  public writeError: Error | null = null;
+
+  snapshot(): ReadonlyArray<ViewerFileContent> {
+    return this.files;
+  }
+
+  subscribe(handler: (batch: FileChangeEvent[]) => void): () => void {
+    this.handlers.add(handler);
+    return () => { this.handlers.delete(handler); };
+  }
+
+  async write(path: string, content: string): Promise<void> {
+    if (this.writeError) throw this.writeError;
+    this.writes.push({ path, content });
+  }
+
+  public deletes: string[] = [];
+  async delete(path: string): Promise<void> {
+    this.deletes.push(path);
+  }
+
+  // Test hook
+  push(batch: FileChangeEvent[]): void {
+    for (const h of this.handlers) h(batch);
+  }
+}
+
+describe("FileGlobSource", () => {
+  let ch: MockFileChannel;
+
+  beforeEach(() => {
+    ch = new MockFileChannel();
+  });
+
+  test("on create, reads snapshot and fires initial with matching files", async () => {
+    ch.files = [
+      { path: "a.md", content: "# A" },
+      { path: "b.css", content: "body {}" },
+      { path: "c.md", content: "# C" },
+    ];
+    const source = new FileGlobSource({ patterns: ["**/*.md"] }, ch);
+    const events: SourceEvent<ViewerFileContent[]>[] = [];
+    source.subscribe((e) => events.push(e));
+    await Promise.resolve();  // let the initial microtask run
+    expect(events).toHaveLength(1);
+    if (events[0].kind !== "value") throw new Error("expected value");
+    expect(events[0].origin).toBe("initial");
+    expect(events[0].value.map((f) => f.path).sort()).toEqual(["a.md", "c.md"]);
+  });
+
+  test("external file change matching patterns emits external event", async () => {
+    ch.files = [{ path: "a.md", content: "# A" }];
+    const source = new FileGlobSource({ patterns: ["**/*.md"] }, ch);
+    await Promise.resolve();  // drain initial
+    const events: SourceEvent<ViewerFileContent[]>[] = [];
+    source.subscribe((e) => events.push(e));
+    ch.files = [{ path: "a.md", content: "# A edited" }];
+    ch.push([{ path: "a.md", content: "# A edited", origin: "external" }]);
+    expect(events).toHaveLength(1);
+    if (events[0].kind !== "value") throw new Error("expected value");
+    expect(events[0].origin).toBe("external");
+    expect(events[0].value.find((f) => f.path === "a.md")?.content).toBe("# A edited");
+  });
+
+  test("self-origin change emits self event (unchanged origin tag)", async () => {
+    ch.files = [{ path: "a.md", content: "# A" }];
+    const source = new FileGlobSource({ patterns: ["**/*.md"] }, ch);
+    await Promise.resolve();
+    const events: SourceEvent<ViewerFileContent[]>[] = [];
+    source.subscribe((e) => events.push(e));
+    ch.push([{ path: "a.md", content: "# Fresh", origin: "self" }]);
+    expect(events).toHaveLength(1);
+    if (events[0].kind !== "value") throw new Error("expected value");
+    expect(events[0].origin).toBe("self");
+  });
+
+  test("file change not matching patterns does not emit", async () => {
+    ch.files = [{ path: "a.md", content: "# A" }];
+    const source = new FileGlobSource({ patterns: ["**/*.md"] }, ch);
+    await Promise.resolve();
+    const events: SourceEvent<ViewerFileContent[]>[] = [];
+    source.subscribe((e) => events.push(e));
+    ch.push([{ path: "b.css", content: "body {}", origin: "external" }]);
+    expect(events).toHaveLength(0);
+  });
+
+  test("write() throws — file-glob is read-only via Source.write", async () => {
+    const source = new FileGlobSource({ patterns: ["**/*.md"] }, ch);
+    await expect(source.write([])).rejects.toThrow(/read-only/i);
+  });
+
+  test("batch with a mix of matching and non-matching files emits once with the full current set", async () => {
+    ch.files = [
+      { path: "a.md", content: "# A" },
+      { path: "b.md", content: "# B" },
+    ];
+    const source = new FileGlobSource({ patterns: ["**/*.md"] }, ch);
+    await Promise.resolve();
+    const events: SourceEvent<ViewerFileContent[]>[] = [];
+    source.subscribe((e) => events.push(e));
+    ch.files = [
+      { path: "a.md", content: "# A2" },
+      { path: "b.md", content: "# B" },
+    ];
+    ch.push([
+      { path: "a.md", content: "# A2", origin: "external" },
+      { path: "x.css", content: "...", origin: "external" },
+    ]);
+    expect(events).toHaveLength(1);
+    if (events[0].kind !== "value") throw new Error("expected value");
+    const paths = events[0].value.map((f) => f.path).sort();
+    expect(paths).toEqual(["a.md", "b.md"]);
+  });
+
+  test("ignore patterns filter out matching files", async () => {
+    ch.files = [
+      { path: "a.md", content: "# A" },
+      { path: "node_modules/x.md", content: "# X" },
+    ];
+    const source = new FileGlobSource(
+      { patterns: ["**/*.md"], ignore: ["**/node_modules/**"] },
+      ch,
+    );
+    await Promise.resolve();
+    const events: SourceEvent<ViewerFileContent[]>[] = [];
+    source.subscribe((e) => events.push(e));
+    await Promise.resolve();
+    expect(source.current()?.map((f) => f.path)).toEqual(["a.md"]);
+  });
+
+  test("destroy unsubscribes from FileChannel", () => {
+    const source = new FileGlobSource({ patterns: ["**/*.md"] }, ch);
+    expect(ch.handlers.size).toBe(1);
+    source.destroy();
+    expect(ch.handlers.size).toBe(0);
+  });
+});

--- a/core/sources/__tests__/json-file.test.ts
+++ b/core/sources/__tests__/json-file.test.ts
@@ -1,0 +1,210 @@
+import { describe, test, expect, beforeEach } from "bun:test";
+import { JsonFileSource } from "../json-file.js";
+import type {
+  FileChannel,
+  FileChangeEvent,
+  SourceEvent,
+} from "../../types/source.js";
+import type { ViewerFileContent } from "../../types/viewer-contract.js";
+
+interface Project {
+  title: string;
+  count?: number;
+}
+
+class MockFileChannel implements FileChannel {
+  public handlers = new Set<(batch: FileChangeEvent[]) => void>();
+  public files: ViewerFileContent[] = [];
+  public writes: Array<{ path: string; content: string }> = [];
+  public deletes: string[] = [];
+  public writeError: Error | null = null;
+  public writeDelay = 0;
+
+  snapshot(): ReadonlyArray<ViewerFileContent> {
+    return this.files;
+  }
+  subscribe(handler: (batch: FileChangeEvent[]) => void): () => void {
+    this.handlers.add(handler);
+    return () => { this.handlers.delete(handler); };
+  }
+  async write(path: string, content: string): Promise<void> {
+    if (this.writeDelay > 0) await new Promise((r) => setTimeout(r, this.writeDelay));
+    if (this.writeError) throw this.writeError;
+    this.writes.push({ path, content });
+  }
+  async delete(path: string): Promise<void> {
+    this.deletes.push(path);
+  }
+  push(batch: FileChangeEvent[]): void {
+    for (const h of this.handlers) h(batch);
+  }
+}
+
+const parse = (raw: string) => JSON.parse(raw) as Project;
+const serialize = (v: Project) => JSON.stringify(v);
+
+describe("JsonFileSource", () => {
+  let ch: MockFileChannel;
+
+  beforeEach(() => {
+    ch = new MockFileChannel();
+  });
+
+  test("initial snapshot with a parseable file fires initial event", async () => {
+    ch.files = [{ path: "project.json", content: '{"title":"Hello"}' }];
+    const s = new JsonFileSource<Project>(
+      { path: "project.json", parse, serialize },
+      ch,
+    );
+    const events: SourceEvent<Project>[] = [];
+    s.subscribe((e) => events.push(e));
+    await Promise.resolve();
+    expect(events).toHaveLength(1);
+    if (events[0].kind !== "value") throw new Error("expected value");
+    expect(events[0].origin).toBe("initial");
+    expect(events[0].value).toEqual({ title: "Hello" });
+  });
+
+  test("missing file on startup emits no initial event, current() is null", async () => {
+    const s = new JsonFileSource<Project>(
+      { path: "project.json", parse, serialize },
+      ch,
+    );
+    const events: SourceEvent<Project>[] = [];
+    s.subscribe((e) => events.push(e));
+    await Promise.resolve();
+    expect(events).toHaveLength(0);
+    expect(s.current()).toBeNull();
+  });
+
+  test("external update emits external event", async () => {
+    ch.files = [{ path: "project.json", content: '{"title":"A"}' }];
+    const s = new JsonFileSource<Project>(
+      { path: "project.json", parse, serialize },
+      ch,
+    );
+    await Promise.resolve();
+    const events: SourceEvent<Project>[] = [];
+    s.subscribe((e) => events.push(e));
+    ch.files = [{ path: "project.json", content: '{"title":"B"}' }];
+    ch.push([{ path: "project.json", content: '{"title":"B"}', origin: "external" }]);
+    expect(events).toHaveLength(1);
+    if (events[0].kind !== "value") throw new Error("expected value");
+    expect(events[0].origin).toBe("external");
+    expect(events[0].value).toEqual({ title: "B" });
+  });
+
+  test("write persists via channel and emits self event", async () => {
+    ch.files = [{ path: "project.json", content: '{"title":"A"}' }];
+    const s = new JsonFileSource<Project>(
+      { path: "project.json", parse, serialize },
+      ch,
+    );
+    await Promise.resolve();
+    const events: SourceEvent<Project>[] = [];
+    s.subscribe((e) => events.push(e));
+    await s.write({ title: "B" });
+    expect(ch.writes).toHaveLength(1);
+    expect(ch.writes[0]).toEqual({
+      path: "project.json",
+      content: '{"title":"B"}',
+    });
+    expect(events).toHaveLength(1);
+    if (events[0].kind !== "value") throw new Error("expected value");
+    expect(events[0].origin).toBe("self");
+    expect(events[0].value).toEqual({ title: "B" });
+    expect(s.current()).toEqual({ title: "B" });
+  });
+
+  test("write followed by the echo event emits only the self event (not a duplicate external)", async () => {
+    ch.files = [{ path: "project.json", content: '{"title":"A"}' }];
+    const s = new JsonFileSource<Project>(
+      { path: "project.json", parse, serialize },
+      ch,
+    );
+    await Promise.resolve();
+    const events: SourceEvent<Project>[] = [];
+    s.subscribe((e) => events.push(e));
+
+    // 1. viewer writes
+    await s.write({ title: "B" });
+    expect(events).toHaveLength(1);
+    expect((events[0] as { origin?: string }).origin).toBe("self");
+
+    // 2. FileChannel delivers the server-tagged echo. Because the server
+    // tags it origin: "self" via pendingSelfWrites, JsonFileSource should
+    // recognize it as an already-emitted self and drop it rather than
+    // re-emit another self event.
+    ch.files = [{ path: "project.json", content: '{"title":"B"}' }];
+    ch.push([{ path: "project.json", content: '{"title":"B"}', origin: "self" }]);
+    expect(events).toHaveLength(1);  // no duplicate
+  });
+
+  test("parse failure on initial load emits error event, not value", async () => {
+    ch.files = [{ path: "project.json", content: "{not json" }];
+    const s = new JsonFileSource<Project>(
+      { path: "project.json", parse, serialize },
+      ch,
+    );
+    const events: SourceEvent<Project>[] = [];
+    s.subscribe((e) => events.push(e));
+    await Promise.resolve();
+    expect(events).toHaveLength(1);
+    expect(events[0].kind).toBe("error");
+    expect(s.current()).toBeNull();
+  });
+
+  test("parse failure is non-fatal — a later valid external update succeeds", async () => {
+    ch.files = [{ path: "project.json", content: "{not json" }];
+    const s = new JsonFileSource<Project>(
+      { path: "project.json", parse, serialize },
+      ch,
+    );
+    await Promise.resolve();  // drain initial error
+    const events: SourceEvent<Project>[] = [];
+    s.subscribe((e) => events.push(e));
+    ch.files = [{ path: "project.json", content: '{"title":"Recovered"}' }];
+    ch.push([{ path: "project.json", content: '{"title":"Recovered"}', origin: "external" }]);
+    // The source had never successfully observed a value before, so this
+    // one is still the "first" — it fires with origin="initial".
+    expect(events).toHaveLength(1);
+    if (events[0].kind !== "value") throw new Error("expected value");
+    expect(events[0].origin).toBe("initial");
+    expect(events[0].value).toEqual({ title: "Recovered" });
+  });
+
+  test("write failure propagates and does not update current()", async () => {
+    ch.files = [{ path: "project.json", content: '{"title":"A"}' }];
+    const s = new JsonFileSource<Project>(
+      { path: "project.json", parse, serialize },
+      ch,
+    );
+    await Promise.resolve();
+    ch.writeError = new Error("disk full");
+    await expect(s.write({ title: "B" })).rejects.toThrow("disk full");
+    expect(s.current()).toEqual({ title: "A" });
+  });
+
+  test("only events for the declared path are processed", async () => {
+    ch.files = [{ path: "project.json", content: '{"title":"A"}' }];
+    const s = new JsonFileSource<Project>(
+      { path: "project.json", parse, serialize },
+      ch,
+    );
+    await Promise.resolve();
+    const events: SourceEvent<Project>[] = [];
+    s.subscribe((e) => events.push(e));
+    ch.push([{ path: "other.json", content: '{"title":"X"}', origin: "external" }]);
+    expect(events).toHaveLength(0);
+  });
+
+  test("destroy unsubscribes from channel", () => {
+    const s = new JsonFileSource<Project>(
+      { path: "project.json", parse, serialize },
+      ch,
+    );
+    expect(ch.handlers.size).toBe(1);
+    s.destroy();
+    expect(ch.handlers.size).toBe(0);
+  });
+});

--- a/core/sources/__tests__/memory.test.ts
+++ b/core/sources/__tests__/memory.test.ts
@@ -1,0 +1,46 @@
+import { describe, test, expect } from "bun:test";
+import { MemorySource } from "../memory.js";
+import type { SourceEvent } from "../../types/source.js";
+
+describe("MemorySource", () => {
+  test("starts with null current when no initial given", () => {
+    const s = new MemorySource<number>({});
+    expect(s.current()).toBeNull();
+  });
+
+  test("starts with initial value and emits initial event synchronously on create", () => {
+    const s = new MemorySource<number>({ initial: 42 });
+    // MemorySource fires its initial event in the next microtask, so after
+    // one tick current() should be 42. We use a microtask await.
+    return Promise.resolve().then(() => {
+      expect(s.current()).toBe(42);
+    });
+  });
+
+  test("subscribers registered before the first tick receive the initial event", async () => {
+    const s = new MemorySource<number>({ initial: 42 });
+    const events: SourceEvent<number>[] = [];
+    s.subscribe((e) => events.push(e));
+    await Promise.resolve();  // let the microtask run
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({ kind: "value", value: 42, origin: "initial" });
+  });
+
+  test("write() emits a self event and updates current()", async () => {
+    const s = new MemorySource<number>({ initial: 0 });
+    await Promise.resolve();  // drain initial
+    const events: SourceEvent<number>[] = [];
+    s.subscribe((e) => events.push(e));
+    await s.write(7);
+    expect(s.current()).toBe(7);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({ kind: "value", value: 7, origin: "self" });
+  });
+
+  test("destroy stops further writes", async () => {
+    const s = new MemorySource<number>({ initial: 0 });
+    s.destroy();
+    await s.write(1);
+    expect(s.current()).toBeNull();
+  });
+});

--- a/core/sources/aggregate-file.ts
+++ b/core/sources/aggregate-file.ts
@@ -1,0 +1,182 @@
+import { BaseSource } from "./base.js";
+import type {
+  FileChannel,
+  FileChangeEvent,
+} from "../types/source.js";
+import type { ViewerFileContent } from "../types/viewer-contract.js";
+
+export interface AggregateFileConfig<T> {
+  /** All file path globs this aggregate depends on. Used to scope watching. */
+  patterns: string[];
+  /** Optional ignore globs. */
+  ignore?: string[];
+  /**
+   * Build the aggregate from the current file snapshot. Return null if the
+   * aggregate cannot be built (e.g. required files missing) — the source
+   * will stay in "no initial yet" state and a later snapshot change may
+   * succeed. Throw to emit an error event without killing the source.
+   */
+  load: (files: ReadonlyArray<ViewerFileContent>) => T | null;
+  /**
+   * Decompose a new aggregate value back into file-level operations.
+   * Called from write(). Receives the current (pre-write) snapshot so
+   * save can compute diffs (e.g. which slide files to delete when an
+   * id has been removed from a Deck).
+   */
+  save: (
+    value: T,
+    current: ReadonlyArray<ViewerFileContent>,
+  ) => {
+    writes: Array<{ path: string; content: string }>;
+    deletes: string[];
+  };
+}
+
+/**
+ * Multi-file domain aggregate source.
+ *
+ * Used when a mode's domain is a structured aggregate (a Deck, a Site,
+ * a Studio) that happens to be persisted across multiple files. The
+ * viewer consumes `Source<T>` where T is the domain type and never
+ * sees file paths; the provider handles translation to/from files.
+ *
+ * Origin handling: when a file change batch arrives, the provider
+ * re-runs `load()` against the full current snapshot. If the batch
+ * contains any `origin: "self"` entries, the emission is tagged "self"
+ * (our own write round-tripped); otherwise "external". The first
+ * successful load ever emits "initial" regardless of the triggering
+ * origin.
+ *
+ * Parse/load errors are non-fatal: they emit `{ kind: "error" }` and
+ * leave the source alive for future updates.
+ */
+export class AggregateFileSource<T> extends BaseSource<T> {
+  private unsubscribe: (() => void) | null = null;
+  private matcher: (path: string) => boolean;
+  private ignoreMatcher: (path: string) => boolean;
+  private hasEmittedInitial = false;
+
+  constructor(
+    private config: AggregateFileConfig<T>,
+    private channel: FileChannel,
+  ) {
+    super();
+    this.matcher = compileGlobList(config.patterns);
+    this.ignoreMatcher = compileGlobList(config.ignore ?? []);
+    this.unsubscribe = channel.subscribe((batch) => this.onBatch(batch));
+    queueMicrotask(() => this.tryLoad("initial"));
+  }
+
+  private onBatch(batch: FileChangeEvent[]): void {
+    if (this.isDestroyed) return;
+    const relevant = batch.some(
+      (ev) => this.matcher(ev.path) && !this.ignoreMatcher(ev.path),
+    );
+    if (!relevant) return;
+    const hasSelf = batch.some((ev) => ev.origin === "self");
+    const origin: "self" | "external" = hasSelf ? "self" : "external";
+    // If we've never successfully loaded, the first success still fires
+    // as "initial" — we treat initial-after-error as the first real observation.
+    const effectiveOrigin = this.hasEmittedInitial ? origin : "initial";
+    this.tryLoad(effectiveOrigin);
+  }
+
+  private tryLoad(origin: "initial" | "self" | "external"): void {
+    if (this.isDestroyed) return;
+    const files = this.channel.snapshot().filter(
+      (f) => this.matcher(f.path) && !this.ignoreMatcher(f.path),
+    );
+    let value: T | null;
+    try {
+      value = this.config.load(files);
+    } catch (err) {
+      this.emit({
+        kind: "error",
+        code: "E_LOAD",
+        message: (err as Error).message,
+      });
+      return;
+    }
+    if (value === null) {
+      // load returned null — aggregate not yet ready (missing required
+      // files). Silent: don't emit, don't error. A later file change
+      // may produce a valid aggregate.
+      return;
+    }
+    this.hasEmittedInitial = true;
+    this.emit({ kind: "value", value, origin });
+  }
+
+  protected async doWrite(value: T): Promise<void> {
+    const currentFiles = this.channel.snapshot().filter(
+      (f) => this.matcher(f.path) && !this.ignoreMatcher(f.path),
+    );
+    let ops: { writes: Array<{ path: string; content: string }>; deletes: string[] };
+    try {
+      ops = this.config.save(value, currentFiles);
+    } catch (err) {
+      this.emit({
+        kind: "error",
+        code: "E_SAVE",
+        message: (err as Error).message,
+      });
+      throw err;
+    }
+    // Execute the file operations in order: writes first, then deletes.
+    // A single save() producing both writes and deletes means the viewer
+    // has computed a complete new state; ordering only matters for
+    // observable intermediate states which we don't expose.
+    for (const w of ops.writes) {
+      await this.channel.write(w.path, w.content);
+    }
+    for (const d of ops.deletes) {
+      await this.channel.delete(d);
+    }
+    // Emit the self event after all file ops have been ack'd.
+    this.hasEmittedInitial = true;
+    this.emit({ kind: "value", value, origin: "self" });
+  }
+
+  destroy(): void {
+    this.unsubscribe?.();
+    this.unsubscribe = null;
+    super.destroy();
+  }
+}
+
+// Shared with file-glob — kept inline here to avoid cross-module imports
+// in this leaf file. If a third provider needs it, lift to sources/glob.ts.
+function compileGlobList(patterns: string[]): (path: string) => boolean {
+  if (patterns.length === 0) return () => false;
+  const regexes = patterns.map(compileGlob);
+  return (path: string) => regexes.some((r) => r.test(path));
+}
+
+function compileGlob(pattern: string): RegExp {
+  let p = pattern.replace(/^\.\//, "");
+  let rx = "";
+  let i = 0;
+  while (i < p.length) {
+    const ch = p[i];
+    if (ch === "*") {
+      if (p[i + 1] === "*") {
+        rx += ".*";
+        i += 2;
+        if (p[i] === "/") i++;
+      } else {
+        rx += "[^/]*";
+        i++;
+      }
+    } else if (ch === "?") {
+      rx += "[^/]";
+      i++;
+    } else if ("\\^$.|+()[]{}".includes(ch)) {
+      rx += "\\" + ch;
+      i++;
+    } else {
+      rx += ch;
+      i++;
+    }
+  }
+  return new RegExp("^" + rx + "$");
+}

--- a/core/sources/base.ts
+++ b/core/sources/base.ts
@@ -1,0 +1,122 @@
+import type { Source, SourceEvent } from "../types/source.js";
+
+/**
+ * Abstract base class for all built-in and third-party Source implementations.
+ *
+ * Owns the four invariants documented on Source<T> in core/types/source.ts:
+ * single writer, change-read-via-subscription, time-locked write Promises,
+ * origin tagging. Subclasses only fill in:
+ *
+ *   - doWrite(value): perform the actual persistence. Must emit a
+ *     { origin: "self" } event before resolving (see the helper
+ *     emit() method below). Should throw on failure — BaseSource
+ *     re-throws to the write() caller.
+ *
+ *   - Whatever mechanism they use to observe external changes.
+ *     When an external change arrives, the subclass calls
+ *     this.emit({ kind: "value", value, origin: "external" }) to
+ *     propagate it.
+ *
+ *   - An initial-load pathway that ultimately calls
+ *     this.emit({ kind: "value", value, origin: "initial" }) once.
+ *
+ * Subclasses should call super.destroy() from their own destroy() to
+ * guarantee the listener set is cleared.
+ */
+export abstract class BaseSource<T> implements Source<T> {
+  private listeners = new Set<(e: SourceEvent<T>) => void>();
+  private latest: T | null = null;
+  private destroyed = false;
+
+  // Serializes write() calls. Each write awaits the previous. We use
+  // .catch inside the chain so one rejection doesn't poison subsequent
+  // writes — the rejection is still propagated to THAT call's caller via
+  // the separate `next` promise.
+  private writeQueue: Promise<void> = Promise.resolve();
+
+  current(): T | null {
+    return this.latest;
+  }
+
+  subscribe(listener: (event: SourceEvent<T>) => void): () => void {
+    if (this.destroyed) return () => {};
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  /**
+   * Public entry point for writes. Serializes against any in-flight or
+   * queued writes, then calls the subclass's doWrite(). The returned
+   * Promise resolves only after doWrite() has resolved AND the self event
+   * has been delivered to all subscribers (the subclass is responsible
+   * for emitting that event from within doWrite, typically as its very
+   * last step before returning).
+   */
+  write(value: T): Promise<void> {
+    if (this.destroyed) return Promise.resolve();
+    // Chain: wait for previous write (regardless of success), then run
+    // this one. The returned `next` is what we give the caller; the
+    // `.catch` on the stored queue prevents one failure from breaking
+    // the chain for later writes.
+    const prev = this.writeQueue;
+    const next = prev
+      .catch(() => {})
+      .then(() => {
+        if (this.destroyed) return;
+        return this.doWrite(value);
+      });
+    this.writeQueue = next.catch(() => {});
+    return next;
+  }
+
+  destroy(): void {
+    if (this.destroyed) return;
+    this.destroyed = true;
+    this.listeners.clear();
+    this.latest = null;
+  }
+
+  /**
+   * Subclass hook: actually persist the value. Must emit a self event
+   * before resolving. Throw to signal failure — BaseSource propagates
+   * the error to the write() caller.
+   */
+  protected abstract doWrite(value: T): Promise<void>;
+
+  /**
+   * Subclass hook: emit an event to all current subscribers. Updates
+   * the internal `latest` cache if this is a value event. Listeners that
+   * throw are isolated — their error is caught and logged, other
+   * listeners still receive the event.
+   */
+  protected emit(event: SourceEvent<T>): void {
+    if (this.destroyed) return;
+    if (event.kind === "value") {
+      this.latest = event.value;
+    }
+    // Snapshot the listener set so a listener that subscribes / unsubscribes
+    // during delivery doesn't disturb iteration.
+    for (const listener of Array.from(this.listeners)) {
+      try {
+        listener(event);
+      } catch (err) {
+        // Don't throw — one listener's bug shouldn't break others.
+        // Log to console; providers can override this if they need
+        // structured logging (via SourceContext.log, but BaseSource has
+        // no ctx, so console is the floor).
+        // eslint-disable-next-line no-console
+        console.error("[source] listener threw", err);
+      }
+    }
+  }
+
+  /**
+   * Subclass utility: check whether destroy() has been called. Useful
+   * for guarding async code paths that resume after an await boundary.
+   */
+  protected get isDestroyed(): boolean {
+    return this.destroyed;
+  }
+}

--- a/core/sources/file-glob.ts
+++ b/core/sources/file-glob.ts
@@ -1,0 +1,153 @@
+import { BaseSource } from "./base.js";
+import type {
+  FileChannel,
+  FileChangeEvent,
+} from "../types/source.js";
+import type { ViewerFileContent } from "../types/viewer-contract.js";
+
+export interface FileGlobConfig {
+  patterns: string[];
+  ignore?: string[];
+}
+
+/**
+ * Multi-file aggregate source backed by a FileChannel. Subscribes to the
+ * channel, filters incoming changes by its declared patterns, and emits
+ * the full snapshot of matching files as a single SourceEvent on each
+ * change.
+ *
+ * ## Why the whole snapshot, not just the delta?
+ *
+ * Existing viewers (all 6 write-back modes + diagram) consume a full
+ * `files: ViewerFileContent[]` array and do `files.find(...)` / filter.
+ * Emitting the full snapshot lets the P5 migration be a 1-line change
+ * (useSource(sources.files)) without restructuring any viewer's internal
+ * data flow. A future optimization could emit a delta shape, but it
+ * would force every viewer to rebuild its own snapshot cache. YAGNI.
+ *
+ * ## Write semantics
+ *
+ * file-glob is READ-ONLY via `source.write()`. A viewer that wants to
+ * write individual files should declare a separate `json-file` source
+ * per file, or call FileChannel.write() directly if it genuinely needs
+ * to write an arbitrary unstructured path (e.g. a binary asset). Calling
+ * write() on a FileGlobSource throws.
+ */
+export class FileGlobSource extends BaseSource<ViewerFileContent[]> {
+  private unsubscribe: (() => void) | null = null;
+  private matcher: (path: string) => boolean;
+  private ignoreMatcher: (path: string) => boolean;
+
+  constructor(
+    private config: FileGlobConfig,
+    private channel: FileChannel,
+  ) {
+    super();
+    this.matcher = compileGlobList(config.patterns);
+    this.ignoreMatcher = compileGlobList(config.ignore ?? []);
+    this.unsubscribe = channel.subscribe((batch) => this.onBatch(batch));
+    // Fire initial snapshot on the next microtask so synchronous
+    // subscribers see it.
+    queueMicrotask(() => this.fireInitial());
+  }
+
+  private fireInitial(): void {
+    if (this.isDestroyed) return;
+    const matching = this.filterSnapshot(this.channel.snapshot());
+    this.emit({ kind: "value", value: matching, origin: "initial" });
+  }
+
+  private onBatch(batch: FileChangeEvent[]): void {
+    if (this.isDestroyed) return;
+    const anyMatch = batch.some(
+      (ev) => this.matcher(ev.path) && !this.ignoreMatcher(ev.path),
+    );
+    if (!anyMatch) return;
+    // Determine the dominant origin for this emission. If any event in
+    // the batch is tagged "self", we tag the whole emission "self"
+    // (the viewer's own write round-tripped); otherwise "external".
+    // We do NOT combine self+external in one emission — the FileChannel
+    // guarantees that batches are coherent (one chokidar debounce window)
+    // and a mixed-origin batch would indicate a runtime bug we want to
+    // surface rather than paper over.
+    const hasSelf = batch.some((ev) => ev.origin === "self");
+    const origin: "self" | "external" = hasSelf ? "self" : "external";
+    const matching = this.filterSnapshot(this.channel.snapshot());
+    this.emit({ kind: "value", value: matching, origin });
+  }
+
+  private filterSnapshot(
+    files: ReadonlyArray<ViewerFileContent>,
+  ): ViewerFileContent[] {
+    return files.filter(
+      (f) => this.matcher(f.path) && !this.ignoreMatcher(f.path),
+    );
+  }
+
+  protected async doWrite(_value: ViewerFileContent[]): Promise<void> {
+    throw new Error(
+      "FileGlobSource is read-only via Source.write(). To write " +
+        "individual files, declare a json-file source per path or use " +
+        "FileChannel.write() directly.",
+    );
+  }
+
+  destroy(): void {
+    this.unsubscribe?.();
+    this.unsubscribe = null;
+    super.destroy();
+  }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Minimal glob matcher
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Compile a list of glob patterns into a single predicate.
+ *
+ * Supports the subset of glob syntax that Pneuma's existing watchPatterns
+ * use: `*` (any chars except /), `**` (any chars including /), `?`
+ * (single char), literal paths. No brace expansion, no character classes.
+ * If the list is empty, the predicate returns false (use this for the
+ * ignore list; patterns list callers should guarantee non-empty).
+ */
+function compileGlobList(patterns: string[]): (path: string) => boolean {
+  if (patterns.length === 0) return () => false;
+  const regexes = patterns.map(compileGlob);
+  return (path: string) => regexes.some((r) => r.test(path));
+}
+
+function compileGlob(pattern: string): RegExp {
+  // Normalize leading ./ — watchPatterns don't typically use it, but be safe.
+  let p = pattern.replace(/^\.\//, "");
+  // Escape regex specials except for the glob metachars we care about.
+  let rx = "";
+  let i = 0;
+  while (i < p.length) {
+    const ch = p[i];
+    if (ch === "*") {
+      if (p[i + 1] === "*") {
+        // ** — any characters including /
+        rx += ".*";
+        i += 2;
+        // Swallow a following / so `**/foo` matches `foo` too.
+        if (p[i] === "/") i++;
+      } else {
+        // * — any characters except /
+        rx += "[^/]*";
+        i++;
+      }
+    } else if (ch === "?") {
+      rx += "[^/]";
+      i++;
+    } else if ("\\^$.|+()[]{}".includes(ch)) {
+      rx += "\\" + ch;
+      i++;
+    } else {
+      rx += ch;
+      i++;
+    }
+  }
+  return new RegExp("^" + rx + "$");
+}

--- a/core/sources/index.ts
+++ b/core/sources/index.ts
@@ -1,0 +1,66 @@
+import type { SourceProvider, SourceContext, Source } from "../types/source.js";
+import { MemorySource, type MemorySourceConfig } from "./memory.js";
+import { FileGlobSource, type FileGlobConfig } from "./file-glob.js";
+import { JsonFileSource, type JsonFileConfig } from "./json-file.js";
+import { AggregateFileSource, type AggregateFileConfig } from "./aggregate-file.js";
+
+export { BaseSource } from "./base.js";
+export { MemorySource, type MemorySourceConfig } from "./memory.js";
+export { FileGlobSource, type FileGlobConfig } from "./file-glob.js";
+export { JsonFileSource, type JsonFileConfig } from "./json-file.js";
+export { AggregateFileSource, type AggregateFileConfig } from "./aggregate-file.js";
+
+/**
+ * The four built-in providers, ready to register with a SourceRegistry.
+ * Ordering matters only for debug output; providers are keyed by `kind`.
+ */
+export const BUILT_IN_PROVIDERS: SourceProvider[] = [
+  {
+    kind: "memory",
+    create<T>(config: unknown, _ctx: SourceContext): Source<T> {
+      return new MemorySource<T>((config ?? {}) as MemorySourceConfig<T>);
+    },
+  },
+  {
+    kind: "file-glob",
+    create<T>(config: unknown, ctx: SourceContext): Source<T> {
+      if (!ctx.files) {
+        throw new Error(
+          "file-glob source requires SourceContext.files (FileChannel). " +
+            "This usually means the provider is being instantiated outside " +
+            "the browser runtime.",
+        );
+      }
+      const fgc = config as FileGlobConfig;
+      // The generic T is pinned to ViewerFileContent[] at the call site,
+      // but we return Source<T> here because the registry signature is
+      // erased. Callers passing the wrong T get a TS error at the
+      // manifest declaration site, not here.
+      return new FileGlobSource(fgc, ctx.files) as unknown as Source<T>;
+    },
+  },
+  {
+    kind: "json-file",
+    create<T>(config: unknown, ctx: SourceContext): Source<T> {
+      if (!ctx.files) {
+        throw new Error(
+          "json-file source requires SourceContext.files (FileChannel).",
+        );
+      }
+      const jfc = config as JsonFileConfig<T>;
+      return new JsonFileSource<T>(jfc, ctx.files);
+    },
+  },
+  {
+    kind: "aggregate-file",
+    create<T>(config: unknown, ctx: SourceContext): Source<T> {
+      if (!ctx.files) {
+        throw new Error(
+          "aggregate-file source requires SourceContext.files (FileChannel).",
+        );
+      }
+      const afc = config as AggregateFileConfig<T>;
+      return new AggregateFileSource<T>(afc, ctx.files);
+    },
+  },
+];

--- a/core/sources/json-file.ts
+++ b/core/sources/json-file.ts
@@ -1,0 +1,107 @@
+import { BaseSource } from "./base.js";
+import type {
+  FileChannel,
+  FileChangeEvent,
+} from "../types/source.js";
+
+export interface JsonFileConfig<T> {
+  path: string;
+  parse: (raw: string) => T;
+  serialize: (value: T) => string;
+}
+
+/**
+ * Single-file structured source. Reads a file as raw text, calls `parse`
+ * to produce a typed value, and on write() calls `serialize` + persists
+ * via FileChannel.write().
+ *
+ * ## Origin handling
+ *
+ * JsonFileSource relies on the FileChannel / server tagging file change
+ * events with origin: "self" vs "external". When it receives an event
+ * tagged "self", it treats the content as the echo of its own write()
+ * and drops the event (since it has already emitted a self event from
+ * the write() call itself). When it receives an event tagged "external",
+ * it parses and emits as external.
+ *
+ * This means the CORRECTNESS of origin detection is entirely the
+ * responsibility of the server-side pendingSelfWrites machinery
+ * (server/file-watcher.ts + server/index.ts POST /api/files). This
+ * source trusts the tag.
+ *
+ * ## Parse errors
+ *
+ * Non-fatal. A parse failure emits a { kind: "error" } event; the
+ * source stays live and a later successful update still delivers a
+ * value event. If the first-ever value is observed post-error, it
+ * still fires with origin: "initial" (a parse error does not count
+ * as having observed an initial value).
+ */
+export class JsonFileSource<T> extends BaseSource<T> {
+  private unsubscribe: (() => void) | null = null;
+  private hasEmittedInitial = false;
+
+  constructor(
+    private config: JsonFileConfig<T>,
+    private channel: FileChannel,
+  ) {
+    super();
+    this.unsubscribe = channel.subscribe((batch) => this.onBatch(batch));
+    queueMicrotask(() => this.fireInitialFromSnapshot());
+  }
+
+  private fireInitialFromSnapshot(): void {
+    if (this.isDestroyed) return;
+    const file = this.channel.snapshot().find((f) => f.path === this.config.path);
+    if (!file) return;  // missing on startup is not an error — current() stays null
+    this.processContent(file.content, "initial");
+  }
+
+  private onBatch(batch: FileChangeEvent[]): void {
+    if (this.isDestroyed) return;
+    const relevant = batch.find((ev) => ev.path === this.config.path);
+    if (!relevant) return;
+    if (relevant.origin === "self") {
+      // Our own write has already emitted a self event from write().
+      // Drop the echo.
+      return;
+    }
+    // External change (or initial for a previously-missing file).
+    const origin = this.hasEmittedInitial ? "external" : "initial";
+    this.processContent(relevant.content, origin);
+  }
+
+  private processContent(raw: string, origin: "initial" | "external"): void {
+    let parsed: T;
+    try {
+      parsed = this.config.parse(raw);
+    } catch (err) {
+      this.emit({
+        kind: "error",
+        code: "E_PARSE",
+        message: (err as Error).message,
+        raw,
+      });
+      return;
+    }
+    this.hasEmittedInitial = true;
+    this.emit({ kind: "value", value: parsed, origin });
+  }
+
+  protected async doWrite(value: T): Promise<void> {
+    const content = this.config.serialize(value);
+    await this.channel.write(this.config.path, content);
+    // The write succeeded. Emit the self event now so the caller's
+    // await resolves with state already consistent. hasEmittedInitial
+    // is guaranteed true after a write because we are now observing
+    // a value.
+    this.hasEmittedInitial = true;
+    this.emit({ kind: "value", value, origin: "self" });
+  }
+
+  destroy(): void {
+    this.unsubscribe?.();
+    this.unsubscribe = null;
+    super.destroy();
+  }
+}

--- a/core/sources/memory.ts
+++ b/core/sources/memory.ts
@@ -1,0 +1,35 @@
+import { BaseSource } from "./base.js";
+
+/**
+ * Ephemeral in-process source. Keeps state in memory, no persistence.
+ * Used for session-scoped data (presence, cursor, UI mode flags, etc.)
+ * where a refresh is expected to start fresh.
+ *
+ * Config:
+ *   { initial?: T }  -- optional starting value
+ *
+ * The initial event fires in a microtask after construction so that
+ * subscribers registered synchronously right after `new MemorySource()`
+ * still catch it.
+ */
+export interface MemorySourceConfig<T> {
+  initial?: T;
+}
+
+export class MemorySource<T> extends BaseSource<T> {
+  constructor(config: MemorySourceConfig<T>) {
+    super();
+    if (config.initial !== undefined) {
+      // Defer to a microtask so listeners subscribed right after
+      // construction still catch the initial event.
+      queueMicrotask(() => {
+        if (this.isDestroyed) return;
+        this.emit({ kind: "value", value: config.initial as T, origin: "initial" });
+      });
+    }
+  }
+
+  protected async doWrite(value: T): Promise<void> {
+    this.emit({ kind: "value", value, origin: "self" });
+  }
+}

--- a/core/types/index.ts
+++ b/core/types/index.ts
@@ -66,3 +66,13 @@ export type {
   MemorySearchResult,
   MemorySource,
 } from "./plugin.js";
+
+export type {
+  Source,
+  SourceEvent,
+  SourceProvider,
+  SourceContext,
+  FileChannel,
+  FileChangeEvent,
+  SourceDescriptor,
+} from "./source.js";

--- a/core/types/mode-manifest.ts
+++ b/core/types/mode-manifest.ts
@@ -17,6 +17,8 @@
  * ```
  */
 
+import type { SourceDescriptor } from "./source.js";
+
 /** MCP server declaration — automatically registered to the workspace's .mcp.json during skill installation */
 export interface McpServerConfig {
   /** Server name (key under mcpServers in .mcp.json) */
@@ -295,4 +297,29 @@ export interface ModeManifest {
   editing?: { supported: true };
   /** Reverse proxy routes — forwards /proxy/<name>/* to external APIs, avoiding CORS */
   proxy?: Record<string, ProxyRoute>;
+
+  /**
+   * Declarative data-channel configuration. Each entry instantiates a
+   * Source<T> via the SourceRegistry at mode startup and exposes it to
+   * the viewer as props.sources[id].
+   *
+   * If omitted, the runtime synthesizes a default entry:
+   *
+   *   sources: {
+   *     files: {
+   *       kind: "file-glob",
+   *       config: {
+   *         patterns: this.viewer.watchPatterns,
+   *         ignore: this.viewer.ignorePatterns,
+   *       },
+   *     },
+   *   }
+   *
+   * so every pre-existing mode continues to receive a `files` source with
+   * zero manifest changes. New or migrated modes declare sources explicitly.
+   *
+   * See core/types/source.ts for the SourceDescriptor shape and the
+   * built-in provider kinds (file-glob, json-file, aggregate-file, memory).
+   */
+  sources?: Record<string, SourceDescriptor>;
 }

--- a/core/types/plugin.ts
+++ b/core/types/plugin.ts
@@ -5,6 +5,8 @@
  * Read by PluginRegistry to drive discovery, loading, and activation.
  */
 
+import type { SourceProvider } from "./source.js";
+
 // ── Hook Names ──────────────────────────────────────────────────────────────
 
 export type HookName =
@@ -102,6 +104,20 @@ export interface PluginManifest {
    */
   memorySource?: boolean;
 
+  /**
+   * Source providers contributed by this plugin. Registered on the
+   * session's SourceRegistry during plugin activation, making them
+   * available to every mode (builtin + external) that declares
+   * `sources: { ..., [id]: { kind: "<your-kind>" } }` in its manifest.
+   *
+   * Naming: use a plugin-scoped kind to avoid collisions with built-ins.
+   * For example, a Redis provider from a plugin named "@acme/pneuma-redis"
+   * should register as kind "acme-redis" rather than just "redis".
+   * Collision with an existing kind causes registration to throw
+   * (SourceRegistry.register does not silently overwrite).
+   */
+  sources?: SourceProvider[];
+
   /** Lifecycle: relative path to activate(context) function */
   activate?: string;
   /** Lifecycle: relative path to deactivate() function */
@@ -153,6 +169,8 @@ export interface LoadedPlugin {
   hooks: Partial<Record<HookName, HookHandler>>;
   slots: Partial<Record<SlotName, SlotDeclaration>>;
   routes: ((ctx: PluginRouteContext) => unknown) | null;
+  /** Source providers from this plugin. Empty if the plugin doesn't ship any. */
+  sources: SourceProvider[];
 }
 
 // ── Settings Storage ────────────────────────────────────────────────────────

--- a/core/types/source.ts
+++ b/core/types/source.ts
@@ -1,0 +1,280 @@
+/**
+ * Source<T> — the typed data channel between the runtime and a mode viewer.
+ *
+ * Reads flow through subscribe() events tagged with origin. Writes flow
+ * through write(), which providers serialize internally. The provider base
+ * class (core/sources/base.ts) enforces the invariants documented on the
+ * interfaces below; individual providers only fill in how to load and how
+ * to persist.
+ *
+ * This file is pure types — no runtime code, no imports except type-only.
+ */
+
+import type { ViewerFileContent } from "./viewer-contract.js";
+
+// ────────────────────────────────────────────────────────────────────────────
+// Events
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * A single event emitted by a Source.
+ *
+ * Subscribers handle events via the discriminant `kind`. All non-error events
+ * carry an `origin` tag that identifies what caused the event:
+ *
+ *   - "initial"  — the first value this source instance observes from its
+ *                  underlying medium. Fires exactly once per source instance,
+ *                  only after the provider has finished its initial load.
+ *                  Late subscribers miss this event; they should read
+ *                  `current()` for the starting value.
+ *
+ *   - "self"     — the value was committed by a call to `write()` on this
+ *                  same source instance. The write()'s returned Promise
+ *                  resolves only after this event has been delivered to all
+ *                  current subscribers and `current()` reflects the new
+ *                  value. A viewer that `await`s its own write() is
+ *                  guaranteed to see its own committed state on the next
+ *                  render without holding optimistic local state.
+ *
+ *   - "external" — the value was committed by someone other than this source
+ *                  instance. For file-backed sources this means the agent's
+ *                  Edit tool, another viewer tab, or any non-self writer.
+ *                  Viewers that want conflict handling inspect this origin.
+ *
+ * Errors (parse failure, write failure, network drop, etc.) emit a separate
+ * `error` event. Errors are non-fatal: the source remains live and subsequent
+ * events still flow.
+ */
+export type SourceEvent<T> =
+  | { kind: "value"; value: T; origin: "initial" | "self" | "external" }
+  | { kind: "error"; code: string; message: string; raw?: unknown };
+
+// ────────────────────────────────────────────────────────────────────────────
+// Source
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * A typed data channel. Instances are created by a SourceProvider and handed
+ * to a viewer via ViewerPreviewProps.sources.
+ *
+ * ## Invariants (enforced by core/sources/base.ts)
+ *
+ * 1. **Single writer.** `write()` is the only way to mutate the source's
+ *    committed state. Concurrent calls to write() are serialized internally
+ *    via a Promise queue — they run in call order, never in parallel.
+ *
+ * 2. **Change-read-via-subscription.** All state changes — including those
+ *    caused by this source's own write() — reach consumers as subscribe()
+ *    events. Viewers do not maintain optimistic local state; they render
+ *    from the latest delivered value event. `current()` is a synchronous
+ *    accessor that always returns the most recently delivered value.
+ *
+ * 3. **Time-locked write Promises.** `await source.write(v)` resolves only
+ *    after the corresponding `{ kind: "value", value: v, origin: "self" }`
+ *    event has been delivered to all current subscribers and `current()`
+ *    reflects v. After the await, the viewer's state is guaranteed
+ *    consistent with the committed value.
+ *
+ * 4. **Origin-tagged events.** Every value event carries origin. Self-writes
+ *    are NOT silently absorbed; they emit a `value` event with origin="self".
+ *    This lets viewers distinguish "my commit landed" from "someone else
+ *    changed the world" without maintaining shadow refs.
+ *
+ * 5. **Non-fatal errors.** Parse failures, write failures, and transport
+ *    errors emit `{ kind: "error" }` events. The source stays live; a later
+ *    successful read or write still delivers a value event.
+ *
+ * 6. **Idempotent destroy.** `destroy()` is safe to call multiple times.
+ *    After destroy, write() resolves without effect, subscribe() returns a
+ *    no-op unsubscribe, current() returns null.
+ */
+export interface Source<T> {
+  /**
+   * The most recently delivered value, or null if the source has not yet
+   * emitted its initial event. Synchronous — safe to call during render.
+   */
+  current(): T | null;
+
+  /**
+   * Register a listener for future events. Does NOT fire a synthetic initial
+   * event on subscribe — use current() for first-render state, then rely on
+   * subscribe() for subsequent updates. Returns an unsubscribe function.
+   */
+  subscribe(listener: (event: SourceEvent<T>) => void): () => void;
+
+  /**
+   * Commit a new value. Writes are serialized: a later write() call waits
+   * for all earlier writes to settle before running. Resolves after the
+   * provider has persisted the value AND delivered the corresponding
+   * { origin: "self" } event to all current subscribers. Rejects if the
+   * provider cannot persist.
+   */
+  write(value: T): Promise<void>;
+
+  /**
+   * Release resources held by this source. Idempotent. After destroy,
+   * write() is a silent no-op that resolves immediately, subscribe()
+   * returns a no-op unsubscribe, current() returns null.
+   */
+  destroy(): void;
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Providers
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * A SourceProvider is a factory that creates Source instances of a specific
+ * kind. Built-in providers live in core/sources/ and are registered with the
+ * runtime's SourceRegistry at startup. Third-party providers are exported
+ * from plugins via PluginManifest.sources.
+ *
+ * The provider owns the schema of its `config` — the runtime passes config
+ * through unchanged. Providers are free to define config as a TypeScript
+ * object with function fields (e.g., parse/serialize callbacks) because
+ * manifest.ts is loaded as a real TS module, not parsed as JSON.
+ */
+export interface SourceProvider {
+  /** The discriminant that manifest.sources entries use to select this provider. */
+  kind: string;
+
+  /**
+   * Instantiate a new source. The runtime calls this once per declared
+   * manifest.sources entry when activating a mode. The returned Source
+   * should be ready to receive subscribe() calls immediately, even if its
+   * initial value has not yet loaded (in which case current() returns null
+   * until the initial event fires).
+   */
+  create<T>(config: unknown, ctx: SourceContext): Source<T>;
+}
+
+/**
+ * Per-mode runtime services exposed to providers during create(). Providers
+ * use these instead of reaching for globals, so that multiple modes can
+ * coexist in the launcher without cross-contamination.
+ */
+export interface SourceContext {
+  /** Absolute path to the workspace this mode is operating on. */
+  workspace: string;
+
+  /** Logger. Providers should log via this instead of console.* so output
+   *  can be captured and routed per-mode. */
+  log(message: string, level?: "debug" | "info" | "warn" | "error"): void;
+
+  /** Aborted when the mode is destroyed. Providers should listen on this
+   *  signal to clean up long-running work. */
+  signal: AbortSignal;
+
+  /**
+   * Optional file channel for file-backed providers. Only present in the
+   * browser runtime; the server-side runtime does not need it. memory/redis/
+   * yjs providers ignore this.
+   */
+  files?: FileChannel;
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// FileChannel
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Bridge between file-backed providers and the server's chokidar → WS
+ * pipeline. The runtime instantiates exactly one FileChannel per mode
+ * session and hands it to every file-backed provider via SourceContext.
+ *
+ * ## Origin tagging
+ *
+ * When a provider calls `write(path, content)`, the runtime (specifically the
+ * server-side /api/files handler) records a `pendingSelfWrite` entry for that
+ * path + content hash. When chokidar subsequently fires for that path, the
+ * server consults the entry and tags the outgoing FileUpdate with
+ * origin: "self"; otherwise origin: "external". Providers observe the tag via
+ * the `origin` field on FileChangeEvent and propagate it to their own
+ * SourceEvent output.
+ *
+ * This is the ONLY place in the system where self/external origin is
+ * determined for file-backed data. Providers do not reverse-engineer it.
+ */
+export interface FileChannel {
+  /**
+   * Synchronous snapshot of all currently-known files in the workspace.
+   * Used by providers for their initial load (providers then filter this
+   * snapshot by their declared patterns).
+   */
+  snapshot(): ReadonlyArray<ViewerFileContent>;
+
+  /**
+   * Subscribe to file change events. The handler is called for each batch
+   * of file changes arriving from the server. The batch may include files
+   * outside any given provider's declared patterns — providers filter.
+   * Returns an unsubscribe function.
+   */
+  subscribe(handler: (batch: FileChangeEvent[]) => void): () => void;
+
+  /**
+   * Persist file content to the workspace. Wraps the existing
+   * `POST /api/files` endpoint. Returns when the server has acknowledged
+   * the write (which also means the pendingSelfWrite entry has been recorded
+   * on the server side, so the resulting chokidar echo will be tagged
+   * origin: "self" when it arrives).
+   *
+   * Providers call this from their doWrite() implementation. The runtime
+   * guarantees write ordering within a single source via the BaseSource
+   * queue; cross-source ordering is not guaranteed.
+   */
+  write(path: string, content: string): Promise<void>;
+
+  /**
+   * Delete a file from the workspace. Wraps `DELETE /api/files?path=...`.
+   * Like write(), the server records a pendingSelfDelete entry so the
+   * resulting chokidar `unlink` event is tagged origin: "self" and the
+   * provider can absorb its own echo.
+   *
+   * Used primarily by `aggregate-file` providers whose `save()` produces
+   * a { writes, deletes } diff — e.g. when a slide is removed from a
+   * Deck, the provider deletes the corresponding `slides/slide-N.html`
+   * via this method.
+   */
+  delete(path: string): Promise<void>;
+}
+
+/**
+ * One file change observed by the runtime's FileChannel. Emitted to all
+ * subscribed providers, which then filter to their declared patterns.
+ */
+export interface FileChangeEvent {
+  path: string;
+  content: string;
+  /**
+   * "self" if this change is the echo of a write() call made through any
+   * FileChannel on this session. "external" otherwise (agent's Edit tool,
+   * manual file-system edit, concurrent writer, etc.). "initial" for
+   * entries delivered via the very first snapshot() payload.
+   */
+  origin: "initial" | "self" | "external";
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Manifest descriptor
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * A single source declaration in ModeManifest.sources. The runtime reads
+ * kind, looks up the matching SourceProvider in the SourceRegistry, and
+ * calls provider.create(config, ctx) to instantiate.
+ *
+ * config is typed as `unknown` here because its shape is provider-specific.
+ * Providers document their own config schema. The built-in providers use:
+ *
+ *   - file-glob: { patterns: string[]; ignore?: string[] }
+ *   - json-file: { path: string; parse: (raw: string) => T;
+ *                  serialize: (v: T) => string }
+ *   - memory:    { initial?: T }
+ *   - aggregate-file: { patterns: string[]; ignore?: string[];
+ *                       load: (files) => T | null;
+ *                       save: (value, current) => { writes; deletes } }
+ */
+export interface SourceDescriptor {
+  kind: string;
+  config?: unknown;
+}

--- a/core/types/viewer-contract.ts
+++ b/core/types/viewer-contract.ts
@@ -10,6 +10,7 @@
  */
 
 import type { ComponentType } from "react";
+import type { Source, FileChannel } from "./source.js";
 
 /** File content (kept in sync with FileContent in src/types.ts) */
 export interface ViewerFileContent {
@@ -188,8 +189,24 @@ export interface ViewerLocator {
 
 /** Props for the preview component */
 export interface ViewerPreviewProps {
-  /** Workspace file list */
-  files: ViewerFileContent[];
+  /**
+   * Source map. Keys come from `manifest.sources` (or the synthesized
+   * default `{ files: file-glob }` for unmigrated modes). Viewers
+   * consume sources via the `useSource` hook from src/hooks/useSource.ts.
+   * Each Source<T> delivers typed, origin-tagged events and, for
+   * write-capable providers, exposes a write() method.
+   */
+  sources: Record<string, Source<unknown>>;
+
+  /**
+   * Direct file I/O channel for viewers with dynamic write targets
+   * (e.g., a text editor where the active file is user-selected).
+   * Writes through this channel are origin-tagged server-side
+   * identically to Source.write() — viewers do not need to maintain
+   * echo-detection state. Viewers with a static, declared write target
+   * should use a `json-file` source in their manifest instead.
+   */
+  fileChannel: FileChannel;
   /** Currently selected element */
   selection: ViewerSelectionContext | null;
   /** Selection callback */

--- a/docs/adr/adr-007-file-watching-live-preview.md
+++ b/docs/adr/adr-007-file-watching-live-preview.md
@@ -1,9 +1,11 @@
 # ADR-007: 文件监听与实时预览
 
-> **状态**: Accepted
+> **状态**: Accepted，Viewer-facing 契约部分被 `feat/source-abstraction` superseded（2026-04-13）
 > **日期**: 2026-02-26
 > **决策者**: Pandazki
 > **关联**: ADR-002, ADR-004
+>
+> **Supersession note (2026-04-13)**：本 ADR 做出的基础设施决策**全部仍然有效**——chokidar 仍是文件监听实现，~500ms 端到端延迟目标仍然成立，HTTP `/content/*` + WebSocket `content_update` 的传输结构没有变。**变的是 viewer 一侧的契约**：viewer 不再直接消费 `files: ViewerFileContent[]` prop 或自己维护 `lastSavedContentRef` 这类 echo-skip 机制，而是通过 `Source<T>` 抽象订阅 typed、origin-aware 的事件流。服务端新增 `pendingSelfWrites` origin 标记表作为 chokidar 发射路径上的一个小扩展，让 `origin: "self" | "external"` 在源头就能确定。详见 `docs/superpowers/plans/2026-04-13-source-abstraction.md` 和 `docs/reference/viewer-agent-protocol.md` 的 "Sources" 小节。
 
 ---
 

--- a/docs/design/pneuma-3.0-design.md
+++ b/docs/design/pneuma-3.0-design.md
@@ -169,6 +169,8 @@ Viewer 占据整个窗口，Agent 完全隐藏。
 
 关键点：**app 布局的 viewer 不依赖 agent 写文件来驱动 UI 更新。** 它通过 `onNotifyAgent` 发送任务，通过 `actionRequest` 接收结果，直接在内存中渲染。文件系统只用于持久化交付物。
 
+> **实现基础设施（2026-04 新增）**：要让 app 布局的 viewer 真正「用 domain 语言驱动 UI」而不是「看到一堆原始文件」，viewer 需要一个 typed + origin-aware 的订阅协议。这就是 `feat/source-abstraction` 引入的 `Source<T>` 层——`T` 是 mode 的 domain 模型（`Deck` / `Board` / `TranslationJob` / ...），provider（`file-glob` / `json-file` / `aggregate-file` / 自定义）负责 domain ↔ 文件/远端介质的翻译。详见实施计划 `docs/superpowers/plans/2026-04-13-source-abstraction.md` 和协议文档 `docs/reference/viewer-agent-protocol.md` 的 "Sources — Viewer 的数据通道" 小节。3.0 的 "viewer 是整个 app 的 UI" 愿景需要这层基础设施才算真正落地——没有它，viewer 作者要么被迫手写 file echo detection（现状），要么在 `files.find(...)` 里把 storage 形状泄漏进 UI 代码。
+
 ---
 
 ## 4. Manifest 扩展

--- a/docs/migration/2.29-source-abstraction.md
+++ b/docs/migration/2.29-source-abstraction.md
@@ -1,0 +1,470 @@
+# Migrating an external mode to pneuma-skills 2.29.0 (Source abstraction)
+
+> **Audience:** authors of modes installed via `pneuma mode add github:...` / `pneuma mode add <url>` / local mode directories, whose manifest was written against the pre-2.29 contract.
+>
+> **TL;DR:** add a `sources` field to your manifest (4 lines for most modes) + destructure `sources` instead of `files` in your viewer + call `useSource(sources.files)` to get the file list. Done in 5 minutes for typical read-only modes. For write-back modes, also swap your `POST /api/files` calls for `props.fileChannel.write()`. For modes whose domain is a structured multi-file aggregate (like a slide deck or a site), see the `aggregate-file` pattern in the "Advanced" section.
+>
+> **If you can't migrate now:** pin to `pneuma-skills@2.28` and you're fine until you're ready.
+
+## Why
+
+Before 2.29, every viewer received a `files: ViewerFileContent[]` prop — a raw dump of workspace file contents. Viewers had to grep through it with `files.find(f => f.path === ...)`, parse manifest.json inline, and reverse-engineer write origins with string-compared refs to know "is this the file watcher echoing my own save, or an agent edit?"
+
+Since 2.29, every viewer consumes typed, origin-aware, subscription-based data channels via `props.sources`. The echo-detection machinery moved to the server side (where it was always the right place), the viewer-to-runtime contract became explicitly typed, and modes whose domain is structured (a Deck, a Site, a Studio) can now expose `Source<Deck>` to their viewer — the viewer sees the domain object, never a file path.
+
+Files on disk remain the canonical persistence layer — they're the coding agent's native habitat. Nothing about agent behavior changes. Only the **viewer's contract with the runtime** changes.
+
+Full design rationale: `docs/reference/viewer-agent-protocol.md` (Sources section) and `docs/superpowers/plans/2026-04-13-source-abstraction.md`.
+
+## Decision tree
+
+Start here:
+
+1. **Does your mode have a viewer?**
+   - **No** (agent-only mode like `evolve`): [Headless opt-out](#headless-opt-out). One-line fix.
+   - **Yes**: continue.
+
+2. **Does your viewer write files back to disk from the UI?**
+   - **No** (pure viewer — agent generates, user just watches): [Pattern A — read-only](#pattern-a--read-only). ~10 lines total.
+   - **Yes**: continue.
+
+3. **Is your write target a single known path** (like `project.json`, `board.json`, `config.yaml` — the mode always writes to the same file)?
+   - **Yes**: you want [Pattern C — typed single-file aggregate with `json-file`](#pattern-c--typed-single-file-aggregate). ClipCraft's example.
+   - **No** (the write target is user-chosen at runtime, like "the currently active .md file" or "the slide the user clicked"): continue.
+
+4. **Is your mode's domain a structured multi-file aggregate** (e.g., a slide deck distributed across `manifest.json` + `slides/*.html` + `theme.css`, or a website with pages + assets)?
+   - **Yes**: [Pattern C — multi-file aggregate](#pattern-c--typed-multi-file-aggregate) with `aggregate-file`. This is the most work (~30–60 min) but also the biggest architectural win.
+   - **No** (the domain really is just "a collection of files" and the user picks which one to edit): [Pattern D — dynamic write target](#pattern-d--dynamic-write-target). ~15 lines.
+
+## Pattern A — Read-only
+
+Your mode reads files from disk and renders them. The user never triggers a save from the UI (the agent does all writing via its Edit tool).
+
+Examples from pneuma-skills: `doc` (actually writes back — see Pattern D), `diagram`, `mode-maker`, `remotion`.
+
+### Step 1: Add `sources` to `manifest.ts`
+
+```ts
+// modes/your-mode/manifest.ts
+const manifest: ModeManifest = {
+  // ...existing fields...
+
+  viewer: {
+    watchPatterns: ["**/*.md"],          // ← existing
+    ignorePatterns: [],
+  },
+
+  // ── ADD THIS ──
+  sources: {
+    files: {
+      kind: "file-glob",
+      config: {
+        patterns: ["**/*.md"],            // copy from viewer.watchPatterns
+        // ignore: ["node_modules/**"],   // optional
+      },
+    },
+  },
+};
+```
+
+Yes, the patterns are duplicated with `viewer.watchPatterns` — `viewer.watchPatterns` still drives server-side chokidar; `sources.files.config.patterns` drives the viewer's subscription filter. They are the same today; a future plan may collapse them.
+
+### Step 2: Update your viewer component
+
+```tsx
+import type { Source } from "../../../core/types/source.js";
+import type { ViewerFileContent, ViewerPreviewProps } from "../../../core/types/viewer-contract.js";
+import { useSource } from "../../../src/hooks/useSource.js";
+
+// BEFORE:
+// export default function MyPreview({ files, ...rest }: ViewerPreviewProps) {
+//   const doc = files.find((f) => f.path === "README.md");
+//   ...
+// }
+
+// AFTER:
+export default function MyPreview({ sources, ...rest }: ViewerPreviewProps) {
+  const filesSource = sources.files as Source<ViewerFileContent[]>;
+  const { value: filesValue } = useSource(filesSource);
+  const files: ViewerFileContent[] = filesValue ?? [];
+
+  // ← Everything below stays identical. The local `const files` has the
+  //   same `ViewerFileContent[]` shape the old prop did.
+  const doc = files.find((f) => f.path === "README.md");
+  // ...
+}
+```
+
+That's it. Your viewer now reads files through `useSource`, which uses React's `useSyncExternalStore` under the hood — StrictMode-safe, concurrent-render-safe, properly unsubscribes on unmount.
+
+## Pattern D — Dynamic write target
+
+Your viewer lets the user edit a file (the user picks which one at runtime — an active markdown file, an active drawing, the current page in a multi-page site). Your current code probably has an inline `fetch('/api/files', { method: 'POST', ... })` somewhere in an edit handler, plus a hand-rolled ref like `lastSavedContentRef` or `lastExternalRef` to avoid re-applying your own save as if it were an external change.
+
+### Step 1: Add `sources` (same as Pattern A)
+
+```ts
+sources: {
+  files: {
+    kind: "file-glob",
+    config: { patterns: ["**/*.md"] },
+  },
+},
+```
+
+### Step 2: Destructure `fileChannel` alongside `sources`
+
+```tsx
+export default function MyPreview({
+  sources,
+  fileChannel,        // ← NEW
+  ...rest
+}: ViewerPreviewProps) {
+  const filesSource = sources.files as Source<ViewerFileContent[]>;
+  const { value: filesValue, status } = useSource(filesSource);
+  const files: ViewerFileContent[] = filesValue ?? [];
+  // ...
+}
+```
+
+`fileChannel` is a typed channel for writes to dynamic paths. It does `POST /api/files` internally but the runtime tags the resulting chokidar echo as `origin: "self"` server-side, so your subscription sees it as your own save — no echo loop.
+
+### Step 3: Replace your inline `fetch` with `fileChannel.write`
+
+```tsx
+// BEFORE:
+async function handleSave(path: string, content: string) {
+  await fetch(`/api/files`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ path, content }),
+  });
+  lastSavedContentRef.current = content; // ← load-bearing echo ref
+}
+
+// AFTER:
+async function handleSave(path: string, content: string) {
+  try {
+    await fileChannel.write(path, content);
+  } catch (err) {
+    console.error("[my-mode] save failed", err);
+  }
+}
+```
+
+### Step 4: Delete your echo-detection refs
+
+Search your viewer for `lastSavedContentRef`, `lastExternalRef`, `isUpdatingFromFileRef`, `hydratedDiskRef`, or similar — any ref whose purpose was "did I just write this so I should skip re-applying it?". Delete them.
+
+If you had an effect that compared incoming `file.content` to a ref to decide whether to update a textarea / canvas, rewrite it using `status.lastOrigin`:
+
+```tsx
+// BEFORE:
+useEffect(() => {
+  if (file.content !== lastExternalRef.current) {
+    textareaRef.current.value = file.content;
+    lastExternalRef.current = file.content;
+  }
+}, [file.content]);
+
+// AFTER:
+useEffect(() => {
+  // Skip self-origin echoes — textarea already has the user's latest edit
+  if (status.lastOrigin === "self") return;
+  if (textareaRef.current.value !== file.content) {
+    textareaRef.current.value = file.content;
+  }
+}, [file.content, status.lastOrigin]);
+```
+
+The `status.lastOrigin` value is one of `"initial" | "self" | "external" | null`. The server-side `pendingSelfWrites` machinery is the single source of truth for which events are echoes — you don't reverse-engineer it from content comparison anymore.
+
+### Example migration: `doc` mode
+
+See `modes/doc/viewer/DocPreview.tsx` in the source-abstraction PR for a full working example. It had `lastExternalRef` + a module-scoped `saveFile` helper; both are gone and the code is shorter.
+
+## Pattern C — Typed single-file aggregate
+
+Your mode has a single known file that's the canonical source of truth for a structured domain object (ClipCraft's `project.json` → `ProjectFile`; a board builder's `board.json` → `Board`). You want the viewer to consume `Source<ProjectFile>` directly — not a raw file content string.
+
+### Step 1: Declare a `json-file` source
+
+```ts
+// modes/your-mode/manifest.ts
+import type { ProjectFile } from "./types.js";
+import { parseProjectFile, formatProjectJson } from "./serialization.js";
+
+sources: {
+  project: {
+    kind: "json-file",
+    config: {
+      path: "project.json",
+      parse: (raw: string): ProjectFile => {
+        const result = parseProjectFile(raw);
+        if (!result.ok) throw new Error(result.error);
+        return result.value;
+      },
+      serialize: (value: ProjectFile): string => formatProjectJson(value),
+    },
+  },
+},
+```
+
+`parse` throws on malformed content; the provider catches it and emits a non-fatal `{ kind: "error" }` event (the source stays live for future updates). `serialize` must be **byte-deterministic** — the same input must always produce the same output bytes, or the server's self-write echo detection will miss and you'll see phantom "external" events for your own writes. If you use `JSON.stringify`, ensure object key order is stable.
+
+### Step 2: Consume the source in your viewer
+
+```tsx
+import { useSource } from "../../../src/hooks/useSource.js";
+import type { Source } from "../../../core/types/source.js";
+import type { ProjectFile } from "../types.js";
+
+export default function MyPreview({ sources }: ViewerPreviewProps) {
+  const projectSource = sources.project as Source<ProjectFile>;
+  const { value: project, write: writeProject, status } = useSource(projectSource);
+
+  if (!project) return <EmptyState />;
+
+  // Save: domain value in, provider handles serialize + POST
+  const handleEdit = (changes: Partial<ProjectFile>) => {
+    writeProject({ ...project, ...changes });
+  };
+
+  // Render directly from the typed value — no JSON.parse, no files.find
+  return <Canvas title={project.title} data={project.data} />;
+}
+```
+
+`await writeProject(v)` resolves only after:
+1. The serialized content is on disk
+2. The server has tagged the echo as `origin: "self"`
+3. `useSource`'s value has been updated to `v`
+
+So after `await writeProject(v)`, the next render sees the new value without any optimistic state bookkeeping on your side.
+
+### Example migration: ClipCraft
+
+See `docs/superpowers/plans/clipcraft-source-migration.md` for a full working example with ClipCraft's `ProjectFile` + three-ref dance removal.
+
+## Pattern C — Typed multi-file aggregate
+
+Your mode's domain is a structured aggregate persisted across multiple files. Examples: slide decks (`manifest.json` + `slides/*.html` + `theme.css`), websites (`manifest.json` + pages/*.html + assets), image studios (`manifest.json` + images). This is the biggest architectural win — the viewer consumes `Source<Deck>` / `Source<Site>` / `Source<Studio>` and never sees file paths at all.
+
+### Step 1: Create `modes/your-mode/domain.ts` with typed load/save
+
+```ts
+// modes/your-mode/domain.ts
+import type { ViewerFileContent } from "../../core/types/viewer-contract.js";
+
+export interface Slide {
+  id: string;
+  file: string;    // relative path, e.g. "slides/slide-01.html"
+  html: string;
+  title?: string;
+}
+
+export interface DeckManifest {
+  title: string;
+  slides: Slide[];
+}
+
+/**
+ * Support content sets by bucketing per prefix.
+ * "" = root-level manifest.
+ * "en/" = content set "en".
+ */
+export interface Deck {
+  byContentSet: Record<string, DeckManifest>;
+}
+
+export function loadDeck(
+  files: ReadonlyArray<ViewerFileContent>,
+): Deck | null {
+  const byContentSet: Record<string, DeckManifest> = {};
+  for (const file of files) {
+    if (!file.path.endsWith("manifest.json")) continue;
+    const prefix = file.path === "manifest.json"
+      ? ""
+      : file.path.slice(0, -"manifest.json".length);
+    const parsed = JSON.parse(file.content);  // throws on bad JSON → error event
+    const slides: Slide[] = (parsed.slides ?? [])
+      .map((entry: { file: string; id?: string; title?: string }) => {
+        const fullPath = `${prefix}${entry.file}`;
+        const htmlFile = files.find((f) => f.path === fullPath);
+        if (!htmlFile) return null;
+        return {
+          id: entry.id ?? entry.file,
+          file: entry.file,
+          html: htmlFile.content,
+          title: entry.title,
+        };
+      })
+      .filter((s: Slide | null): s is Slide => s !== null);
+    byContentSet[prefix] = { title: parsed.title ?? "Untitled", slides };
+  }
+  if (Object.keys(byContentSet).length === 0) return null;
+  return { byContentSet };
+}
+
+export function saveDeck(
+  next: Deck,
+  current: ReadonlyArray<ViewerFileContent>,
+): { writes: Array<{ path: string; content: string }>; deletes: string[] } {
+  const writes: Array<{ path: string; content: string }> = [];
+  const deletes: string[] = [];
+
+  for (const [prefix, manifest] of Object.entries(next.byContentSet)) {
+    // manifest.json — write if serialized bytes differ
+    const manifestJson = JSON.stringify(
+      {
+        title: manifest.title,
+        slides: manifest.slides.map((s) => ({
+          file: s.file,
+          id: s.id,
+          title: s.title,
+        })),
+      },
+      null,
+      2,
+    ) + "\n";
+    const existingManifest = current.find((f) => f.path === `${prefix}manifest.json`);
+    if (existingManifest?.content !== manifestJson) {
+      writes.push({ path: `${prefix}manifest.json`, content: manifestJson });
+    }
+
+    // Each slide file — write if html differs
+    for (const slide of manifest.slides) {
+      const fullPath = `${prefix}${slide.file}`;
+      const existing = current.find((f) => f.path === fullPath);
+      if (existing?.content !== slide.html) {
+        writes.push({ path: fullPath, content: slide.html });
+      }
+    }
+
+    // Delete slide files that existed but are no longer referenced
+    const keep = new Set(manifest.slides.map((s) => `${prefix}${s.file}`));
+    for (const f of current) {
+      if (
+        f.path.startsWith(`${prefix}slides/`) &&
+        f.path.endsWith(".html") &&
+        !keep.has(f.path)
+      ) {
+        deletes.push(f.path);
+      }
+    }
+  }
+
+  return { writes, deletes };
+}
+```
+
+### Step 2: Declare `aggregate-file` in the manifest
+
+```ts
+import { loadDeck, saveDeck } from "./domain.js";
+
+sources: {
+  deck: {
+    kind: "aggregate-file",
+    config: {
+      patterns: ["**/manifest.json", "**/slides/*.html", "**/theme.css"],
+      load: loadDeck,
+      save: saveDeck,
+    },
+  },
+},
+```
+
+### Step 3: Consume `Source<Deck>` in the viewer
+
+```tsx
+import type { Deck } from "../domain.js";
+
+export default function MyPreview({ sources }: ViewerPreviewProps) {
+  const deckSource = sources.deck as Source<Deck>;
+  const { value: deck, write: writeDeck, status } = useSource(deckSource);
+
+  if (!deck) return <EmptyState />;
+
+  // Reorder — one call replaces the old three write paths
+  const handleReorder = (prefix: string, from: number, to: number) => {
+    const manifest = deck.byContentSet[prefix];
+    const slides = [...manifest.slides];
+    const [moved] = slides.splice(from, 1);
+    slides.splice(to, 0, moved);
+    writeDeck({
+      ...deck,
+      byContentSet: { ...deck.byContentSet, [prefix]: { ...manifest, slides } },
+    });
+  };
+}
+```
+
+The provider figures out from the diff which files to write and which slide files to delete. The viewer never touches a file path.
+
+### Worked examples in the pneuma-skills source tree
+
+- `modes/slide/domain.ts` + `modes/slide/viewer/SlidePreview.tsx` — `Deck` aggregate, full reorder/delete/text-edit collapsed
+- `modes/webcraft/domain.ts` + `modes/webcraft/viewer/WebPreview.tsx` — `Site` aggregate with manifest fallback to html-glob
+- `modes/illustrate/domain.ts` + `modes/illustrate/viewer/IllustratePreview.tsx` — `Studio` aggregate, read-only pattern
+
+## Headless opt-out
+
+If your mode is agent-only (no viewer at all — something like `evolve`), declare an empty sources block:
+
+```ts
+sources: {},
+```
+
+That's it. The runtime sees you've explicitly opted out of data channels.
+
+## Common errors and fixes
+
+### `Mode "X" is not compatible with pneuma-skills 2.29.0+`
+
+That's the error that sent you to this doc. Pick the pattern above that matches your mode and apply it.
+
+### tsc: `Property 'files' does not exist on type 'ViewerPreviewProps'`
+
+Your viewer is still destructuring `files` from props. Change it to `sources` and derive a local `files` via `useSource` (Pattern A Step 2).
+
+### I save a file and the viewer immediately shows a phantom "external" event
+
+Your `serialize` function is not byte-deterministic. Two calls with the same input produce different output, so the server's content-hash match for self-writes misses. Common culprits:
+- `JSON.stringify` over an object whose key insertion order depends on mutation history — use a sort
+- Floating-point formatting differences
+- Trailing newline added by one code path but not another
+
+Test: run `serialize(v)` twice in a row and assert the outputs are identical.
+
+### My viewer's iframe flashes on every save
+
+You're probably re-keying the iframe on every `files` change. Gate it on `status.lastOrigin`:
+
+```tsx
+if (iframeRef.current && status.lastOrigin !== "self") {
+  iframeRef.current.srcdoc = newSrcdoc;
+}
+```
+
+See `modes/webcraft/viewer/WebPreview.tsx` for a reference implementation.
+
+## If you can't migrate now
+
+Pin the Pneuma runtime to the last 2.28.x release:
+
+```bash
+npm install -g pneuma-skills@2.28
+# or, if you use the desktop app, download the 2.28.x installer
+```
+
+2.28.x is the last minor with the pre-Source contract. Your mode will continue to work there until you're ready to migrate. The Source abstraction is a one-time migration — 2.29.x won't break again.
+
+## Questions / problems
+
+- Full design rationale: `docs/reference/viewer-agent-protocol.md` (Sources section)
+- Implementation plan (for the curious): `docs/superpowers/plans/2026-04-13-source-abstraction.md`
+- Per-mode worked examples: `modes/doc/`, `modes/draw/`, `modes/gridboard/` (Pattern D), `modes/slide/`, `modes/webcraft/`, `modes/illustrate/` (Pattern C)
+- ClipCraft-specific guide (for that mode's author): `docs/superpowers/plans/clipcraft-source-migration.md`
+
+If a corner case isn't covered by any of the four patterns, open an issue on the pneuma-skills repo with a minimal reproduction and we'll figure out whether it's a pattern gap or a bug.

--- a/docs/reference/viewer-agent-protocol.md
+++ b/docs/reference/viewer-agent-protocol.md
@@ -2,6 +2,20 @@
 
 > Pneuma 的核心通信模型。三个参与方之间有 6 个通信方向，每个方向有明确的职责和契约。
 
+## 基本立场
+
+Pneuma 的协议建立在一条基本立场上：**coding agent（Claude Code / Codex）直接在 workspace 的文件上干活，这是它的母语，不被中介也不被替代。** `pneuma-3.0-design.md` 把这条立场推到终点：Viewer 不是一个文件预览器，而是一个 **针对特定任务的 player + 可选参与面板**——人通过它实时观察 agent 的工作、在需要时直接介入（拖、删、重排）或通过结构化命令提建议。
+
+这带来三层正交的关注点：
+
+| 层 | 归谁 | 服务谁 | 动词 |
+|---|---|---|---|
+| **Layer 1 — 文件系统** | Agent 的母语 | Claude Code / Codex 通过 Read/Edit/Write 工具跟世界对话 | read / edit / write file by path |
+| **Layer 2 — 传输** | Runtime 基础设施 | 把 Layer 1 的变化变成可订阅的事件流 | chokidar → pendingSelfWrites → WS → event bus |
+| **Layer 3 — Source** | Viewer 的输入/输出协议 | mode 作者写 viewer 时只看这一层，用 domain 类型订阅 | `Source<T>.subscribe` / `write`，T 是 domain 而非 file shape |
+
+本文档描述的是 **Viewer / User / Agent 三方之间** 的 6 个通信方向（下面的 ① ~ ⑥）。Layer 3 的 **Source 协议** 是 viewer 和 runtime 之间的契约，跟 6 方向正交——Viewer 通过 Source 消费 agent 在 workspace 上的工作成果，再通过 6 方向里的其他通道跟 User / Agent 交互。Source 协议本身有专门一节在本文档末尾描述。
+
 ## 协议总览
 
 ![Protocol Overview — 三方角色与 6 个通信方向](images/protocol-overview.png)
@@ -10,9 +24,9 @@
 
 | 角色 | 实体 | 职责 |
 |------|------|------|
-| **User** | 浏览器中的人类 | 观察预览、选择元素、输入消息、审批权限 |
-| **Viewer** | Mode 级 React 组件 | 渲染工作区内容、捕获用户交互、执行 Agent 请求的操作、主动上报观测 |
-| **Agent** | Claude Code / Codex 进程 | 理解意图、编辑文件、调用工具、请求 Viewer 操作 |
+| **User** | 浏览器中的人类 | 观察 viewer 播放、选择元素、输入消息、审批权限、按需参与 |
+| **Viewer** | Mode 级 React 组件 | 把 agent 的工作成果以 domain 语言渲染成实时 player；捕获用户交互；执行 Agent 请求的操作；主动上报观测 |
+| **Agent** | Claude Code / Codex 进程 | 理解意图、**直接编辑 workspace 文件**、调用工具、请求 Viewer 操作 |
 
 ---
 
@@ -34,18 +48,21 @@
 
 ---
 
-### ② Viewer → User: Rendering（视觉呈现）
+### ② Viewer → User: Rendering（视觉呈现 / Player）
 
-Viewer 把工作区内容渲染为用户可见的实时预览。
+Viewer 把 agent 在 workspace 上的工作成果渲染为用户可见的实时 player。这是这个系统的主流数据流——**agent 持续在背后编辑文件，每一次编辑都通过 Layer 2 变成一个带 origin 的 Source 事件到达 viewer，viewer 据此刷新画面、滚动到新元素、高亮变化。** viewer 的首要人格是「player / 观察器」，不是「编辑器」。
 
 **系统支撑:**
-- Viewer 组件根据 `files` prop 变更触发重渲染，以 Mode 特定的方式呈现内容
+- Viewer 通过 `props.sources` 订阅运行时实例化的 `Source<T>` 句柄；`T` 是 mode 定义的 domain 类型（`Deck`、`Board`、`Project`……），不是原始文件数组
+- 每个 Source 事件带 `origin` 标记：`"initial"`（首次快照）、`"external"`（agent 或其他 writer）、`"self"`（本 viewer 自己的 write 回声）——viewer 据此决定要不要重挂载 domain store、要不要高亮「刚被 agent 改过」、要不要忽略自己的 echo
 - Content set 切换、文件导航、视口管理等 UI 状态由 Viewer 自主管理
 
 **数据契约:**
-- `files: ViewerFileContent[]` — 工作区文件列表（runtime 注入）
+- `sources: Record<string, Source<T>>` — runtime 根据 `manifest.sources` 声明实例化的 typed 数据通道 map；viewer 通过 `useSource` hook 订阅（参见末尾 Sources 小节）
 - `contentVersion` / `imageVersion` — 变更信号，用于缓存失效
 - `workspaceItems: WorkspaceItem[]` — 结构化的工作区项（由 workspace model 计算）
+
+> **历史注记**：在 Source 抽象引入之前，viewer 接收一个原子的 `files: ViewerFileContent[]` prop，每个 viewer 自己去 `files.find(...)` 定位自己关心的文件、自己维护 echo-skip 的 ref。Source 协议把这些 storage 细节关进 provider，让 viewer 直接消费 domain 类型。见文档末尾 "Sources — Viewer 的数据通道"。
 
 ---
 
@@ -134,13 +151,15 @@ Runtime 在 Agent 空闲时 flush notification，作为系统消息注入。
 | `viewerApi.workspace` | ② Viewer → User | 工作区文件组织模型 |
 | `viewerApi.scaffold` | ① User → Viewer | 工作区初始化/重置能力 |
 | `viewerApi.locatorDescription` | ⑤ Agent → Viewer | 定位卡片格式说明（注入 CLAUDE.md） |
+| `sources` | ② Viewer → User | 声明 viewer 的 typed 数据通道（kind + config），runtime 按 kind 调用对应 SourceProvider 实例化后注入 `props.sources`。参见末尾 Sources 小节。 |
 | `proxy` | ② Viewer → User | 反向代理路由，解决 Viewer fetch 外部 API 的 CORS 问题 |
 | `skill` | ③④⑤⑥ | Agent 的领域知识和行为指导 |
 
 **Runtime** 是中枢 — 读取 manifest、分发数据、桥接所有通道：
 
 - **skill-installer**: manifest → CLAUDE.md（注入 skill prompt + action descriptions + viewer API + proxy docs）
-- **store + props**: manifest → Viewer props（注入 commands、actions、files、workspace items）
+- **source-registry**: manifest.sources → runtime 按 kind 实例化 Source；built-in provider + plugin-registered provider 都在同一个 registry 里（参见末尾 Sources 小节）
+- **store + props**: manifest → Viewer props（注入 commands、actions、sources、workspace items）
 - **proxy middleware**: manifest.proxy + workspace proxy.json → `/proxy/<name>/*` 反向代理（Viewer 用相对路径访问外部 API，Runtime 服务端转发）
 - **WS bridge**: browser JSON ↔ backend transport（Claude NDJSON / Codex stdio JSON-RPC）
 - **context injection**: `extractContext()` → `<viewer-context>` 注入到 user message
@@ -193,3 +212,70 @@ editing: false   消费阶段 — Agent 不主动编辑，Viewer 锁定编辑功
 4. **Agent 自描述** — Agent 通过 CLAUDE.md 了解可调用的 Viewer 操作，但不知道 UI 布局
 5. **Runtime 是中枢** — 所有跨角色通信都经过 Runtime Shell 中转
 6. **Action ≠ Command** — Action 是 Agent → Viewer（⑤ 操作指令），Command 是 User 经 Viewer 发给 Agent（① → ⑥ 命令触发），方向相反，契约分离
+7. **Files 归 agent，Domain 归 viewer** — Layer 1（文件系统）是 agent 的母语，不抽象；Layer 3（Source）把 agent 的工作成果以 domain 类型、origin-aware、可订阅的方式交给 viewer，让 viewer 成为 agent 工作的 player。两者是两个独立的写入路径，共享同一份磁盘状态，通过 origin 标记相互识别（见下方 Sources 小节）。
+
+---
+
+## Sources — Viewer 的数据通道
+
+Source 协议是 **Runtime ↔ Viewer 中枢-末端边界** 上的数据契约，不属于 User / Viewer / Agent 三角中的任一方向。它在协议上是第二类（和 6 个跨角色方向正交），但对 mode 作者的心智路径至关重要。
+
+### 首要职责：把 agent 的工作成果变成 player 可渲染的 typed 流
+
+Source 不是一个编辑器抽象，是一个 **player 抽象**——首要用途是让 viewer 能够订阅、渲染、高亮 agent 正在对 workspace 做的事情。数据流的主方向是：
+
+```
+Agent (Edit / Write)              ← Layer 1: Agent 的母语
+      ↓ 写文件
+chokidar → pendingSelfWrites      ← Layer 2: Runtime 传输
+      ↓ origin-tagged event
+WS → fileEventBus
+      ↓ subscribe
+Source<T> (file-glob / json-file / aggregate-file / custom provider)
+      ↓ typed + origin-aware event
+useSource in Viewer React tree    ← Layer 3: Viewer 的 player 渲染
+```
+
+作为补充能力，viewer 也可以通过 `Source.write()` 或 `FileChannel.write()` 发起 **人的可选参与**：直接决策（拖拽、删除、reorder）在 UI 里落地，结构化建议则通过 ⑥ 通道的 command notification 反馈给 agent。Source 的 single-writer / Promise 时序 / origin 标记这些约束存在，是为了让这种可选参与不会跟 agent 的持续工作互相打架。
+
+### 四条不变量（provider 层强制，不靠 viewer 自律）
+
+1. **Single writer** — `write()` 是改变 source 状态的唯一入口；BaseSource 用 Promise 队列串行化所有 write 调用。
+2. **变更读订阅** — 所有状态变化（包括 viewer 自己 write 的结果）都以 `subscribe()` 事件回流；viewer 不持有乐观 local state，render 永远 = 最近一次 value 事件。
+3. **Promise 时序锁** — `await source.write(v)` 只在对应 value 事件已派发到所有 subscriber、`current() === v` 之后才 resolve。
+4. **Origin 标签** — 每个 value 事件带 `origin: "initial" | "self" | "external"`；自写不被静默吸收，external 来自 agent 或 peer writer，由服务端 `pendingSelfWrites` 机制识别。
+
+### Agent 和 Source 的关系
+
+**Source 层不替代文件系统。** Agent backend（Claude Code / Codex）继续通过它原生的 Edit / Write / Read 工具直接操作 workspace 里的文件——这是 Pneuma 跟 coding agent 协作的基本契约，不会也不应该被中介。服务端的 `pendingSelfWrites` origin 标记机制对 agent 写入完全透明：agent 直接调 Edit，产生的 chokidar 事件被标为 `origin: "external"`，viewer 的 source 订阅者因此知道「这是 agent 干的，不是我自己刚 write 的」，并可以选择合适的 reconcile 策略（重挂载 domain store、动画高亮、prompt 用户合并等）。**Source 层和 agent 的 file tools 是两个独立的写入路径，共享同一份磁盘状态，通过 origin 标记相互识别。**
+
+### Built-in providers
+
+| kind | 用途 | config | 读写语义 |
+|---|---|---|---|
+| `file-glob` | 多文件按 glob 聚合订阅 | `{ patterns: string[]; ignore?: string[] }` | 读：`ViewerFileContent[]`；写：不支持（多文件写语义在单 source 上不清晰）。domain 真的是「一组文件」的 mode 用这个（doc / mode-maker / remotion）。|
+| `json-file` | 单文件结构化 JSON（或任意可序列化格式） | `{ path: string; parse; serialize }` | 读：parse 后的 typed `T`；写：serialize 后 POST。full round-trip 时序锁。domain 是单一聚合（ClipCraft 的 Project）用这个。|
+| `aggregate-file` | 多文件聚合但 viewer 看 domain 类型 | `{ patterns; load: (files) → T; save: (T, current) → { writes; deletes } }` | 读：domain 类型 `T`；写：provider 把 T 拆回若干 file write + delete。**slide / webcraft / illustrate 这类「domain 是 aggregate 但散落多文件」的 mode 用这个**——viewer 彻底不看文件，消费 `Source<Deck>`, `Source<Site>`, `Source<Studio>`。|
+| `memory` | 纯进程内状态，无持久层 | `{ initial?: T }` | 读/写都在内存，跨刷新即丢失。用于 ephemeral session state（presence、cursor、临时选择等）。|
+
+### 自定义 provider
+
+任何实现 `SourceProvider` 接口的对象都可以通过 `PluginManifest.sources` 数组注册到 runtime 的 SourceRegistry。plugin 的 provider 对所有 mode 可见；如果要 mode 私有，在 mode 的 `manifest.ts` 里直接声明也可以。典型自定义 provider：Redis / Yjs / S3 / Figma 素材 / 内部 BFF——这些是「素材从哪来，成品到哪去」的打通点。provider 作者继承 `BaseSource`，只填 `doWrite()` 和初始加载逻辑，四条不变量自动获得。
+
+### Mode 作者的心智路径
+
+1. 问「我的 domain 是什么？」——定义 domain model（DDD）
+2. 问「它存在哪？」——单文件 / 多文件聚合 / 内存 / 远端服务
+3. 选 source kind：
+   - domain 本来就是「一组文件」（doc / mode-maker / remotion）→ `file-glob`
+   - domain 是单一结构化聚合（ClipCraft）→ `json-file`
+   - domain 是多文件拼成的聚合（slide / webcraft / illustrate）→ `aggregate-file` + 写 `load` / `save` 纯函数
+   - ephemeral session 状态 → `memory`
+   - 接外部介质（Redis / Yjs / 云）→ 写自定义 `SourceProvider`，plugin 注册
+4. 声明 `manifest.sources`
+5. viewer 里 `const { value, write } = useSource(props.sources.xxx)`——**viewer 只看 domain 类型，不看文件路径**
+6. 需要写回就 `await write(v)`，await 返回后 `value` 一定是新值，不需要乐观 state 或 echo-skip ref
+
+### 设计 rationale
+
+完整的设计讨论 + 为什么 `fileChannel` 作为「domain 就是文件」型 mode 的逃生口 + 三层正交的讲解，见实施计划 `docs/superpowers/plans/2026-04-13-source-abstraction.md`。原始的 ClipCraft-only transport 提案 `docs/superpowers/plans/2026-04-13-mode-sync-transport.md` 是这套设计的起点，已被上面那份 superseded。Source 抽象是 `docs/design/pneuma-3.0-design.md` 描述的「viewer 是整个 app 的 UI」这一愿景的 **viewer-contract 层基础设施**——3.0 要求 viewer 用 domain 语言驱动 UI，这正是 `Source<T>` 里那个 `T` 的含义。

--- a/docs/superpowers/plans/2026-04-13-mode-sync-transport.md
+++ b/docs/superpowers/plans/2026-04-13-mode-sync-transport.md
@@ -1,0 +1,654 @@
+# Mode Sync Transport Abstraction
+
+> **⚠️ SUPERSEDED (2026-04-13).** This ClipCraft-only proposal has been generalized into a full-stack Source abstraction that covers all modes. See `docs/superpowers/plans/2026-04-13-source-abstraction.md`. The original proposal is preserved here as historical context for the ClipCraft echo-loop problem that motivated the work — its analysis of the three-ref dance is still the clearest description of the failure mode, and the new plan's P7 (ClipCraft migration guide) refers back to this document for the original rationale.
+
+> **Context:** motivated by ClipCraft (Plan 3d of the clipcraft × pneuma-craft series), but the abstraction itself is cross-mode infrastructure and lives in `modes/_shared/`. Any future mode with a structured domain model and bidirectional disk sync can consume the same transport.
+>
+> **Split:** this plan has two phases. **Phase 1** builds the transport library with unit tests — no consumers, no refactors, no cross-repo work. **Phase 2** integrates it into ClipCraft, replacing the current three-ref loop-protection dance. Phase 1 lands on `main`. Phase 2 lands on `feat/clipcraft-by-pneuma-craft` after rebasing onto the new main, and is my job (not covered in detail here — just an API-validation sketch).
+
+**Goal (Phase 1):** Define a `SyncTransport<T>` abstraction for bidirectional disk-or-storage sync with first-class **origin tagging** (`initial` / `external` / `parse-error`, with `local-echo` absorbed internally). Ship one concrete implementation, `createJsonFileTransport`, that wraps Pneuma's existing `files` prop + `POST /api/files` pipe into a typed, origin-aware transport. Land it with strong unit test coverage. No runtime or manifest changes.
+
+**Architecture:** Pure TypeScript, no React dependency. The transport is a plain factory function that returns an object with `feed()`, `subscribe()`, `write()`, `destroy()`. Callers push raw snapshots in via `feed(rawContent)`, get typed events back, and call `write(value)` to serialize + persist. The transport internally tracks "what did I just write" to tag its own echoes and drop them before they reach listeners.
+
+The cross-mode sync problem is: when a mode's viewer can both **read from** and **write to** a watched file, the file watcher echoes the viewer's own writes back as change events. Every mode that writes has to invent its own "is this my echo?" logic. ClipCraft's Plan 3b+3c did this with three refs + a state counter + a load-bearing null-reset in `onExternalEdit`, and Plan 3b Task 6 proved that getting it right is subtle (a silent React effect-ordering race shipped before an E2E test caught it). This abstraction consolidates the loop-protection logic into one testable module so future modes don't reinvent it.
+
+**Tech Stack:**
+- TypeScript, `bun:test`, no React (the library is framework-agnostic)
+- Lives in `modes/_shared/sync/` — sibling to the existing `modes/_shared/skills/` directory
+- No cross-repo work, no `@pneuma-craft/*` changes
+
+**Out of scope for Plan 3d (explicit):**
+- Diff-and-dispatch. This abstraction is about **origin identification**, not about how to reconcile two states when they disagree. The current "remount the provider on external edit" strategy stays in ClipCraft's Phase 2; diff-and-dispatch is a separate future plan.
+- Multiple transport implementations beyond `createJsonFileTransport`. No in-memory, no BroadcastChannel, no IndexedDB. YAGNI until a second consumer needs them.
+- Manifest-level declarative persistence (e.g. `manifest.persistence: { path: "project.json", schema: "v1" }`). That's a runtime-level upgrade for when a second mode adopts the transport.
+- Removing the `providerKey` remount strategy from ClipCraft. The transport gives cleaner origin tagging but the craft store still needs a hard reset on external edit. Diff-and-dispatch will address this later.
+- React integration helpers. Phase 2 (ClipCraft integration) will write a tiny `useJsonFileTransport` hook inside `modes/clipcraft/viewer/hooks/` — **not** in `modes/_shared/sync/`, because the React wiring is mode-specific until there's a second consumer.
+
+---
+
+## The problem in one paragraph
+
+ClipCraft's `useProjectSync` (Plan 3b + 3c) maintains four pieces of state to avoid the write → chokidar-echo → rehydrate-and-duplicate loop:
+
+| Ref / State | Lives in | Survives | Solves |
+|---|---|---|---|
+| `lastAppliedRef: string \| null` | parent component (`ClipCraftPreview`) | provider remount | echo-skip ("did I just write this?") |
+| `hydratedDiskRef: string \| null` | hook instance (`useProjectSync`) | — (dies on remount) | React 19 StrictMode effect double-invoke |
+| `providerKey: number` | parent state | provider remount | forces Zustand store rebuild on real external edit |
+| `currentTitleRef: string` | hook instance | — | title side-channel (craft has no title concept) |
+
+Plus a load-bearing coupling: `ClipCraftPreview.onExternalEdit` must reset `lastAppliedRef.current = null` BEFORE calling `setProviderKey`, or the fresh hook instance sees a stale ref and treats the new disk content as "yet another external edit" → infinite remount. Plan 3b's initial implementation violated this ordering and shipped a silent regression that only an E2E test caught. The pattern is fragile.
+
+The root of the fragility is that the `files` prop delivered by Pneuma's runtime is **origin-less**: the viewer receives a content string and has no idea whether the change was caused by itself (its own `POST /api/files` echoing through chokidar) or by an external actor (the agent's Edit tool). Every piece of the loop-protection dance is hand-rolled "reverse-engineer the origin by comparing strings" logic.
+
+**The fix:** move origin identification into a pure-data-logic module. Content comparison happens in one place. Event origins are first-class (`initial` / `external` / `parse-error`, with `local-echo` absorbed internally). Consumers stop asking "is this my echo?" and start asking "what kind of event is this?".
+
+---
+
+## The abstraction
+
+### `SyncEvent<T>` — discriminated union
+
+```ts
+// modes/_shared/sync/types.ts
+
+/**
+ * A single event emitted by a SyncTransport.
+ *
+ * Consumers handle events via the discriminant `kind`.
+ *
+ * Note: there is no `local-echo` variant. When the transport writes value V
+ * and the storage fires a change for V back at it, the transport DROPS the
+ * event internally and never emits it. Consumers only see changes that are
+ * NOT their own.
+ */
+export type SyncEvent<T> =
+  /**
+   * The first non-null content observed by this transport instance. Fires
+   * exactly once per transport instance, on the first feed() that yields a
+   * parseable value. Use this to drive initial hydration.
+   */
+  | { kind: "initial"; value: T }
+  /**
+   * A change caused by someone other than this transport. Use this to
+   * reconcile against the current in-memory state — for ClipCraft, this
+   * means remounting the provider and rehydrating on a fresh store.
+   */
+  | { kind: "external"; value: T }
+  /**
+   * The raw content couldn't be parsed. `raw` is the offending string,
+   * `error` is the parser's message. The transport continues running;
+   * future feeds with valid content will still emit initial/external.
+   */
+  | { kind: "parse-error"; error: string; raw: string };
+```
+
+### `SyncTransport<T>` — interface
+
+```ts
+// modes/_shared/sync/types.ts (continued)
+
+export interface SyncTransport<T> {
+  /**
+   * Push a raw snapshot in. The transport classifies the content
+   * against its internal state (last-fed, last-written) and either:
+   *   - drops it (duplicate of last-fed, or equal to last-written = echo)
+   *   - classifies it as initial (first non-null content)
+   *   - classifies it as external (differs from last-fed and last-written)
+   *   - classifies it as parse-error (parse fails)
+   *
+   * The returned value is the event that was emitted to listeners, or
+   * null if the feed was deduplicated or echo-skipped. Consumers can
+   * either subscribe to events or inspect the return value synchronously.
+   */
+  feed(rawContent: string | null): SyncEvent<T> | null;
+
+  /**
+   * Subscribe to events. The listener is called on every non-dropped
+   * feed(). Returns an unsubscribe function.
+   *
+   * Does NOT fire a synthetic initial event on subscribe — subscribe
+   * before the first feed() and you'll see the initial event when it
+   * arrives; subscribe after and you'll miss it. Consumers that want
+   * sync access to the current value should rely on feed()'s return.
+   */
+  subscribe(listener: (event: SyncEvent<T>) => void): () => void;
+
+  /**
+   * Serialize and persist the value. Resolves on storage acknowledgement,
+   * rejects on failure. On success, the transport updates its "last
+   * written" marker so the subsequent echo from the storage layer is
+   * recognized and dropped.
+   *
+   * Implementations are free to debounce internally or delegate debouncing
+   * to the caller — the default json-file-transport writes through and
+   * lets the caller debounce.
+   */
+  write(value: T): Promise<void>;
+
+  /**
+   * Release any resources held by this transport. After destroy(),
+   * feed() and write() become no-ops and existing subscribers are
+   * removed.
+   */
+  destroy(): void;
+}
+```
+
+### `createJsonFileTransport<T>` — concrete implementation
+
+```ts
+// modes/_shared/sync/json-file-transport.ts
+
+export interface JsonFileTransportOptions<T> {
+  /** Parse raw text to a typed value. ok=true on success. */
+  parse: (raw: string) => { ok: true; value: T } | { ok: false; error: string };
+  /** Serialize a typed value to raw text. Must be deterministic — same
+   *  input produces byte-identical output. */
+  serialize: (value: T) => string;
+  /** Write serialized content to the underlying storage. Must resolve on
+   *  success and reject on failure. For the json-file-transport, this is
+   *  typically a thin wrapper around `POST /api/files`. */
+  writer: (content: string) => Promise<void>;
+}
+
+export function createJsonFileTransport<T>(
+  options: JsonFileTransportOptions<T>,
+): SyncTransport<T> {
+  // ... (see Phase 1 Task 2 for the full implementation)
+}
+```
+
+Three injected behaviors:
+1. **How to parse** — mode supplies the schema validator. For ClipCraft: `parseProjectFile`.
+2. **How to serialize** — mode supplies the formatter. For ClipCraft: `(f) => formatProjectJson(f)` wrapping `serializeProject`.
+3. **How to write** — mode supplies the IO. For ClipCraft: `writeProjectFile` (which POSTs to `/api/files`).
+
+The transport owns everything else: last-fed dedup, last-written echo detection, listener management, lifecycle.
+
+---
+
+## File Structure (Phase 1)
+
+**Created:**
+- `modes/_shared/sync/types.ts` — `SyncEvent<T>`, `SyncTransport<T>`, `JsonFileTransportOptions<T>`
+- `modes/_shared/sync/json-file-transport.ts` — `createJsonFileTransport<T>` implementation
+- `modes/_shared/sync/index.ts` — barrel re-export (`export * from "./types.js"; export * from "./json-file-transport.js";`)
+- `modes/_shared/sync/__tests__/json-file-transport.test.ts` — unit tests
+
+**Not touched in Phase 1:**
+- Any file under `modes/clipcraft/` (lives on feat branch, Phase 2)
+- Any file under `core/` (no runtime changes)
+- Any file under `server/` (the transport uses the existing `POST /api/files` endpoint)
+- `package.json`, tsconfig, build scripts
+
+---
+
+## Phase 1 Tasks (main branch)
+
+### Task 1: Define types
+
+**Files:**
+- Create: `modes/_shared/sync/types.ts`
+
+Write the `SyncEvent<T>` discriminated union and the `SyncTransport<T>` interface exactly as shown in "The abstraction" section above. Include the JSDoc comments verbatim — they document the subtle semantics (echoes absorbed internally, initial fires exactly once, parse-error is non-fatal).
+
+Also include `JsonFileTransportOptions<T>`.
+
+No logic, no tests for this file — it's a pure type declaration module.
+
+Commit: `feat(sync): SyncTransport + JsonFileTransportOptions type definitions`
+
+---
+
+### Task 2: Implement `createJsonFileTransport` (TDD)
+
+**Files:**
+- Create: `modes/_shared/sync/__tests__/json-file-transport.test.ts`
+- Create: `modes/_shared/sync/json-file-transport.ts`
+
+Test cases (all should be in the failing-test file BEFORE any implementation exists):
+
+```ts
+import { describe, it, expect, beforeEach } from "bun:test";
+import { createJsonFileTransport } from "../json-file-transport.js";
+import type { SyncEvent } from "../types.js";
+
+// Test parser: accepts any JSON object with a `title` string; rejects the rest
+interface Payload { title: string; count?: number }
+const parse = (raw: string) => {
+  try {
+    const parsed = JSON.parse(raw);
+    if (typeof parsed !== "object" || parsed === null) return { ok: false as const, error: "not an object" };
+    if (typeof parsed.title !== "string") return { ok: false as const, error: "title not a string" };
+    return { ok: true as const, value: parsed as Payload };
+  } catch (e) {
+    return { ok: false as const, error: `parse: ${(e as Error).message}` };
+  }
+};
+const serialize = (v: Payload) => JSON.stringify(v);
+
+describe("createJsonFileTransport", () => {
+  let writes: string[];
+  let writeResolve: (() => void) | null;
+  let writeReject: ((err: Error) => void) | null;
+  let writer: (content: string) => Promise<void>;
+
+  beforeEach(() => {
+    writes = [];
+    writeResolve = null;
+    writeReject = null;
+    writer = (content: string) => {
+      writes.push(content);
+      return new Promise<void>((res, rej) => {
+        writeResolve = res;
+        writeReject = rej;
+      });
+    };
+  });
+
+  function makeTransport() {
+    return createJsonFileTransport<Payload>({ parse, serialize, writer });
+  }
+
+  it("feed with null content emits nothing and returns null", () => {
+    const t = makeTransport();
+    const events: SyncEvent<Payload>[] = [];
+    t.subscribe((e) => events.push(e));
+    const r = t.feed(null);
+    expect(r).toBeNull();
+    expect(events).toHaveLength(0);
+  });
+
+  it("first valid feed emits kind='initial'", () => {
+    const t = makeTransport();
+    const events: SyncEvent<Payload>[] = [];
+    t.subscribe((e) => events.push(e));
+    const r = t.feed('{"title":"Hello"}');
+    expect(r?.kind).toBe("initial");
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({ kind: "initial", value: { title: "Hello" } });
+  });
+
+  it("second valid feed with different content emits kind='external'", () => {
+    const t = makeTransport();
+    t.feed('{"title":"Hello"}');  // initial
+    const events: SyncEvent<Payload>[] = [];
+    t.subscribe((e) => events.push(e));
+    const r = t.feed('{"title":"World"}');
+    expect(r?.kind).toBe("external");
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({ kind: "external", value: { title: "World" } });
+  });
+
+  it("duplicate feed with identical content emits nothing (dedup)", () => {
+    const t = makeTransport();
+    t.feed('{"title":"Hello"}');  // initial
+    const events: SyncEvent<Payload>[] = [];
+    t.subscribe((e) => events.push(e));
+    const r = t.feed('{"title":"Hello"}');
+    expect(r).toBeNull();
+    expect(events).toHaveLength(0);
+  });
+
+  it("parse error emits kind='parse-error' with the offending raw text", () => {
+    const t = makeTransport();
+    const events: SyncEvent<Payload>[] = [];
+    t.subscribe((e) => events.push(e));
+    const r = t.feed("{not json");
+    expect(r?.kind).toBe("parse-error");
+    expect(events).toHaveLength(1);
+    if (events[0].kind === "parse-error") {
+      expect(events[0].raw).toBe("{not json");
+      expect(events[0].error).toMatch(/parse/i);
+    }
+  });
+
+  it("parse error does not advance to initial — a later valid feed still fires initial", () => {
+    const t = makeTransport();
+    const events: SyncEvent<Payload>[] = [];
+    t.subscribe((e) => events.push(e));
+    t.feed("{not json");  // parse-error
+    t.feed('{"title":"Hello"}');  // initial (still first valid)
+    expect(events).toHaveLength(2);
+    expect(events[0].kind).toBe("parse-error");
+    expect(events[1].kind).toBe("initial");
+  });
+
+  it("write calls the writer with serialized content", async () => {
+    const t = makeTransport();
+    t.feed('{"title":"Hello"}');
+    const writePromise = t.write({ title: "World" });
+    expect(writes).toHaveLength(1);
+    expect(writes[0]).toBe('{"title":"World"}');
+    writeResolve!();
+    await writePromise;
+  });
+
+  it("subsequent feed with the just-written content is absorbed as echo", async () => {
+    const t = makeTransport();
+    t.feed('{"title":"Hello"}');  // initial
+    const events: SyncEvent<Payload>[] = [];
+    t.subscribe((e) => events.push(e));
+
+    const writePromise = t.write({ title: "World" });
+    writeResolve!();
+    await writePromise;
+
+    const r = t.feed('{"title":"World"}');  // echo
+    expect(r).toBeNull();
+    expect(events).toHaveLength(0);
+  });
+
+  it("external change AFTER a local write emits kind='external'", async () => {
+    const t = makeTransport();
+    t.feed('{"title":"Hello"}');  // initial
+    const writePromise = t.write({ title: "World" });
+    writeResolve!();
+    await writePromise;
+    t.feed('{"title":"World"}');  // echo (absorbed)
+
+    const events: SyncEvent<Payload>[] = [];
+    t.subscribe((e) => events.push(e));
+    const r = t.feed('{"title":"Modified by agent"}');
+    expect(r?.kind).toBe("external");
+    expect(events).toHaveLength(1);
+  });
+
+  it("failed write does not update the echo marker — the next feed of the attempted content is treated as external", async () => {
+    const t = makeTransport();
+    t.feed('{"title":"Hello"}');
+    const writePromise = t.write({ title: "World" });
+    writeReject!(new Error("disk full"));
+    await expect(writePromise).rejects.toThrow("disk full");
+
+    const events: SyncEvent<Payload>[] = [];
+    t.subscribe((e) => events.push(e));
+    const r = t.feed('{"title":"World"}');
+    expect(r?.kind).toBe("external");
+    expect(events).toHaveLength(1);
+  });
+
+  it("destroy stops emitting events", () => {
+    const t = makeTransport();
+    const events: SyncEvent<Payload>[] = [];
+    t.subscribe((e) => events.push(e));
+    t.destroy();
+    t.feed('{"title":"Hello"}');
+    expect(events).toHaveLength(0);
+  });
+
+  it("multiple subscribers all receive events", () => {
+    const t = makeTransport();
+    const a: SyncEvent<Payload>[] = [];
+    const b: SyncEvent<Payload>[] = [];
+    t.subscribe((e) => a.push(e));
+    t.subscribe((e) => b.push(e));
+    t.feed('{"title":"Hello"}');
+    expect(a).toHaveLength(1);
+    expect(b).toHaveLength(1);
+  });
+
+  it("unsubscribe stops that listener without affecting others", () => {
+    const t = makeTransport();
+    const a: SyncEvent<Payload>[] = [];
+    const b: SyncEvent<Payload>[] = [];
+    const unsubA = t.subscribe((e) => a.push(e));
+    t.subscribe((e) => b.push(e));
+    unsubA();
+    t.feed('{"title":"Hello"}');
+    expect(a).toHaveLength(0);
+    expect(b).toHaveLength(1);
+  });
+});
+```
+
+Run the tests to confirm they all fail (module not found).
+
+Then implement `modes/_shared/sync/json-file-transport.ts`:
+
+```ts
+import type { SyncEvent, SyncTransport, JsonFileTransportOptions } from "./types.js";
+
+export function createJsonFileTransport<T>(
+  options: JsonFileTransportOptions<T>,
+): SyncTransport<T> {
+  const { parse, serialize, writer } = options;
+
+  let lastFedContent: string | null = null;    // dedup + parse-error state
+  let lastWrittenContent: string | null = null; // echo detection
+  let hasEmittedInitial = false;                // initial-vs-external discriminator
+  let destroyed = false;
+  const listeners = new Set<(e: SyncEvent<T>) => void>();
+
+  function emit(event: SyncEvent<T>): void {
+    for (const listener of listeners) {
+      listener(event);
+    }
+  }
+
+  return {
+    feed(rawContent: string | null): SyncEvent<T> | null {
+      if (destroyed) return null;
+      if (rawContent === null) return null;
+
+      // Dedup — same raw text as last feed, drop.
+      if (rawContent === lastFedContent) return null;
+      lastFedContent = rawContent;
+
+      // Echo skip — this is the content we just wrote ourselves.
+      if (rawContent === lastWrittenContent) return null;
+
+      // Parse and classify.
+      const result = parse(rawContent);
+      if (!result.ok) {
+        const event: SyncEvent<T> = {
+          kind: "parse-error",
+          error: result.error,
+          raw: rawContent,
+        };
+        emit(event);
+        return event;
+      }
+
+      const kind = hasEmittedInitial ? "external" : "initial";
+      hasEmittedInitial = true;
+      const event: SyncEvent<T> = { kind, value: result.value };
+      emit(event);
+      return event;
+    },
+
+    subscribe(listener: (event: SyncEvent<T>) => void): () => void {
+      if (destroyed) return () => {};
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+
+    async write(value: T): Promise<void> {
+      if (destroyed) return;
+      const content = serialize(value);
+      await writer(content);
+      // Only update the echo marker AFTER the writer resolves — on
+      // failure, the caller's next retry should be treated as a fresh
+      // external intent, not as an echo of a write that never happened.
+      lastWrittenContent = content;
+      // Also update lastFedContent so a dedup-check picks up the echo
+      // that arrives via the file watcher after this write succeeds.
+      // (The lastWrittenContent check above would also catch it, but
+      // updating both is belt-and-suspenders.)
+      lastFedContent = content;
+    },
+
+    destroy(): void {
+      destroyed = true;
+      listeners.clear();
+    },
+  };
+}
+```
+
+Run the tests and confirm they all pass (13 tests in the test file).
+
+**One subtle thing to verify with an extra test or comment:** the dedup check happens BEFORE the echo check. Under React StrictMode, feed(X) can be called twice in rapid succession with the same X; the dedup drops the second call cheaply. If we reversed the order (echo check first), we'd still need the dedup after a successful external classification to avoid double-emitting to subscribers. Either order works for correctness, but "dedup first" minimizes work.
+
+Commit: `feat(sync): createJsonFileTransport with origin-aware feed/write`
+
+---
+
+### Task 3: Barrel re-export
+
+**Files:**
+- Create: `modes/_shared/sync/index.ts`
+
+```ts
+export * from "./types.js";
+export * from "./json-file-transport.js";
+```
+
+Run the test suite one more time to make sure nothing regressed from the barrel-file addition.
+
+Commit: `feat(sync): barrel export for modes/_shared/sync`
+
+---
+
+### Task 4: Typecheck + final verification
+
+**Files:** none modified.
+
+- `bun run tsc --noEmit 2>&1 | grep "modes/_shared/sync"` — expected empty
+- `bun test modes/_shared/sync/__tests__/` — expected: all green
+- `bun test 2>&1 | tail -5` — expected: full suite unchanged except for the new test file
+
+No commit for Task 4.
+
+---
+
+## Phase 1 self-review checklist
+
+- [ ] All types documented with JSDoc including the subtle semantics (echoes absorbed internally, initial fires exactly once, parse-error is non-fatal)
+- [ ] All 13 test cases in `json-file-transport.test.ts` are present and pass
+- [ ] The implementation is <100 lines (the whole transport is a state machine with three pieces of state)
+- [ ] No React imports in any file under `modes/_shared/sync/`
+- [ ] No imports from `modes/clipcraft/` in any file under `modes/_shared/sync/` (the transport must NOT know about its consumers)
+- [ ] No network code, no filesystem code — the `writer` is injected, not implemented here
+- [ ] `destroy()` is idempotent and leaves all methods as no-ops
+- [ ] `feed()` and `write()` are both safe to call on a destroyed transport (no crashes)
+- [ ] Commit history on main: three Phase 1 commits (types → impl → barrel)
+
+---
+
+## Phase 2 sketch (feat branch, my job after rebase)
+
+**Not covered in detail here** — I'll write a fresh plan or fold it into Plan 4 setup after I rebase my feat branch onto the new main. This section exists only so you can validate the API design while implementing Phase 1.
+
+### How ClipCraft will use the transport
+
+```tsx
+// modes/clipcraft/viewer/hooks/useProjectSync.ts (Phase 2 shape)
+
+import { createJsonFileTransport } from "../../../_shared/sync/index.js";
+
+export function useProjectSync(files, options) {
+  const { onExternalEdit } = options;
+  const dispatchEnvelope = usePneumaCraftStore((s) => s.dispatchEnvelope);
+  const coreState = usePneumaCraftStore((s) => s.coreState);
+  const composition = usePneumaCraftStore((s) => s.composition);
+  const eventCount = useEventLog().length;
+
+  const currentTitleRef = useRef<string>("Untitled");
+
+  // Transport is stable across renders, bound to the current writer/parser
+  const transport = useMemo(() => createJsonFileTransport<ProjectFile>({
+    parse: parseProjectFile,
+    serialize: (f) => formatProjectJson(f),
+    writer: writeProjectFile,
+  }), []);
+
+  // Cleanup on unmount
+  useEffect(() => () => transport.destroy(), [transport]);
+
+  // Find project.json content from props and feed the transport
+  const projectFile = files.find((f) => f.path === "project.json" || f.path.endsWith("/project.json"));
+  const diskContent = projectFile?.content ?? null;
+
+  useEffect(() => {
+    const event = transport.feed(diskContent);
+    if (!event) return;
+    switch (event.kind) {
+      case "initial":
+        currentTitleRef.current = event.value.title;
+        for (const env of projectFileToCommands(event.value)) {
+          try { dispatchEnvelope(env); } catch (e) { console.warn(...); }
+        }
+        return;
+      case "external":
+        // Store is live with stale content. Defer to parent for remount.
+        // Transport already tagged this so we KNOW it's external.
+        onExternalEdit();
+        return;
+      case "parse-error":
+        // Future: expose via return value
+        return;
+    }
+  }, [diskContent, transport, dispatchEnvelope, onExternalEdit]);
+
+  // Persistence: debounced serialize + transport.write
+  useEffect(() => {
+    const timer = setTimeout(async () => {
+      const file = serializeProject(coreState, composition, currentTitleRef.current);
+      try {
+        await transport.write(file);
+      } catch (e) {
+        console.error("[clipcraft] autosave failed", e);
+      }
+    }, 500);
+    return () => clearTimeout(timer);
+  }, [eventCount, coreState, composition, transport]);
+
+  // Return error state for StateDump rendering
+  if (diskContent === null) return { error: "project.json not found in workspace" };
+  // parseProjectFile is called again here for sync return — or the hook
+  // could expose the last event via state. TBD in Phase 2.
+  return { error: null };
+}
+```
+
+### What disappears from ClipCraft in Phase 2
+
+| Removed | Replaced by |
+|---|---|
+| `lastAppliedRef` in `ClipCraftPreview` | Transport's internal `lastWrittenContent` |
+| `hydratedDiskRef` in `useProjectSync` | Transport's internal `lastFedContent` (dedup) |
+| String comparison + manual echo detection | Transport's `feed()` classifier |
+| `isExternalEdit` pure helper | Transport emits `kind: "external"` directly |
+| `lastAppliedRef.current = null` in `onExternalEdit` (the load-bearing coupling) | Gone — transport is self-contained, parent just handles the `external` event by remounting |
+| `modes/clipcraft/viewer/externalEdit.ts` (the file itself) | Deleted — no longer needed |
+
+### What stays in ClipCraft after Phase 2
+
+| Kept | Reason |
+|---|---|
+| `providerKey` counter in parent state | Craft store still needs hard reset on external edit. Diff-and-dispatch is a separate future plan; this plan only fixes origin identification. |
+| `onExternalEdit` callback + `providerKey` bump | Same reason — remount-on-external-edit is ClipCraft's strategy for state-machine rebuild, not something the transport can replace. |
+| `currentTitleRef` | Still needed until craft gets a project-level title concept. |
+| `useProjectSync` hook | Still the viewer's sync entry point, just thinner. |
+
+### ClipCraft's architecture doc update
+
+`modes/clipcraft/ARCHITECTURE.md`'s "Loop protection: three refs, three different races" section collapses down to one ref (`providerKey` counter) + a reference to the transport library:
+
+> **Loop protection** is delegated to `modes/_shared/sync`, which owns the `lastWritten` / `lastFed` state machine and tags every change event with an `origin: "initial" | "external" | "parse-error"` discriminant. ClipCraft only handles the semantic decision: `"external"` events trigger a provider remount via `providerKey` bump, because the craft store is live and can't safely receive duplicate commands.
+
+The "Unofficial seventh direction" framing also gets an upgrade: it's no longer "ClipCraft's innovation", it's "the first adopter of `modes/_shared/sync`, which any mode can pick up when it needs bidirectional sync with origin tagging". The extension point is in-tree and reusable.
+
+---
+
+## Known non-goals (worth restating)
+
+- **No diff-and-dispatch.** The craft store still gets rebuilt from scratch on external edit. Preserving in-memory state (undo history, PlaybackEngine position) across agent edits is a separate future plan, probably driven by Plan 4's playback needs.
+- **No manifest-level persistence declaration.** Each mode still creates its transport imperatively. When a second mode needs the same thing, we'll consider a `core/sync/` promotion with a `manifest.persistence` field.
+- **No React integration helper in `modes/_shared/sync/`.** If/when a second consumer arrives, the appropriate shared hook would land in `modes/_shared/sync/react.ts`. Until then, ClipCraft's `useProjectSync` is the only React consumer and it lives in the mode, not the shared library.
+- **No debounce in the transport.** Callers debounce `write()` themselves. ClipCraft's 500ms autosave debounce is a mode-level decision; a text editor mode might want a different value. Keeping debounce out of the transport keeps the library concerns clean.
+- **No provider-layer API (React Context).** The transport is a plain object that doesn't integrate with React's Context API. This is deliberate — the transport should work in any reactive framework, and the React integration is a thin wrapper owned by each consumer.

--- a/docs/superpowers/plans/2026-04-13-source-abstraction.md
+++ b/docs/superpowers/plans/2026-04-13-source-abstraction.md
@@ -1,0 +1,5768 @@
+# Source Abstraction Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give viewers a typed, origin-aware, subscription-shaped view onto the work a coding agent is doing on the workspace — so that mode viewers can function as **real-time players of agent output** rather than raw file-content renderers. This is the viewer-contract-layer infrastructure that realizes the "viewer is the whole app UI" vision from `docs/design/pneuma-3.0-design.md`. The same abstraction lets humans participate optionally (direct edits, structured suggestions) without racing the agent's ongoing work. Implementation: replace the origin-less `files: ViewerFileContent[]` prop with a `Source<T>` data-channel abstraction, ship four built-in providers (`file-glob`, `json-file`, `aggregate-file`, `memory`), expose a plugin extension point for custom providers, and migrate all 9 existing viewer modes onto the new contract.
+
+**Architecture:** Three orthogonal layers, established in `docs/reference/viewer-agent-protocol.md` and `CLAUDE.md`:
+
+- **Layer 1 — Files on disk.** The coding agent's native habitat. Claude Code / Codex continue to edit files directly via their Read/Edit/Write tools. **Not abstracted, not mediated.** Files remain the canonical persistence layer and the shared source of truth between agent and viewer.
+- **Layer 2 — Runtime transport.** chokidar → `pendingSelfWrites` origin tagging → WebSocket `content_update` → browser `fileEventBus`. Infrastructure that turns file changes into an origin-tagged event stream. Not viewer-facing.
+- **Layer 3 — `Source<T>`.** The viewer's contract. `T` is a **domain type** (`Deck`, `Board`, `Project`), not a file shape. Reads come through `subscribe()` events tagged with `origin: "initial" | "self" | "external"`; writes go through `write()`, which providers serialize via a Promise queue with time-locked resolution. Four built-in providers cover the domain-to-storage spectrum: `file-glob` (domain IS files: doc, mode-maker, remotion), `json-file` (domain is a single structured aggregate: ClipCraft, gridboard), `aggregate-file` (domain is a multi-file aggregate: slide, webcraft, illustrate), `memory` (ephemeral session state). The runtime instantiates sources per mode via a `SourceRegistry` and exposes them as `props.sources`. Plugin-registered providers (Redis/Yjs/S3/Figma/...) slot into the same registry.
+
+**Key architectural commitment:** agent's writes and viewer's writes are **two independent paths sharing one disk**, reconciled via the server-side `pendingSelfWrites` table that tags each chokidar event as `self` (viewer echo) or `external` (agent or peer). The viewer NEVER reverse-engineers origin from content comparison; BaseSource providers NEVER try to prevent agent writes; the agent NEVER sees the Source abstraction. The same framing is authoritative in `docs/reference/viewer-agent-protocol.md` (end-of-file "Sources" section, design principle 7) and `docs/design/pneuma-3.0-design.md` (Section 3.4).
+
+**Tech Stack:** TypeScript strict mode, `bun:test`, no new dependencies. Lives in `core/types/source.ts`, `core/sources/`, `core/source-registry.ts`. Touches `core/types/mode-manifest.ts`, `core/types/viewer-contract.ts`, `core/types/plugin.ts`, `server/file-watcher.ts`, `server/index.ts`, `bin/pneuma.ts`, `src/ws.ts`, `src/store/workspace-slice.ts`, `src/App.tsx`, all 9 mode `manifest.ts` + viewer entry files (some with a new `domain.ts`).
+
+**Prep status (already landed on this branch before P1 executes):** framing pass across `README.md`, `CLAUDE.md`, `docs/reference/viewer-agent-protocol.md` (added Sources section + layer-3 framing + design principle 7), `docs/design/pneuma-3.0-design.md` (forward pointer to source abstraction as 3.0 infrastructure), and `docs/adr/adr-007-file-watching-live-preview.md` (supersession note explaining viewer-facing contract change). These edits establish the authoritative vocabulary the plan uses; P1's doc task is now "verify + fine-tune", not "author from scratch".
+
+---
+
+## Background and locked-in design decisions
+
+### What's wrong with the current shape
+
+1. **Origin-less `files` prop, leaking into every write-back viewer.** Six existing modes (doc, draw, slide, webcraft, gridboard, plus diagram for streaming reads) write back to disk via inline `POST /api/files` calls. Each one then receives its own write echoing back through chokidar → WS → `props.files`, and has to reverse-engineer "is this my echo?" with refs and string comparison. The current state of echo handling across the codebase:
+   - **doc** (`DocPreview.tsx:744–755, 213–225`): `lastExternalRef` string-compare guard. Overwrites the user's unsaved textarea on every incoming external content — known latent bug.
+   - **draw** (`DrawPreview.tsx:259–263, 335–351, 358–371`): `lastSavedContentRef` + `isUpdatingFromFileRef` 500ms busy flag + remount key. **Load-bearing ordering** — line 370 sets `lastSavedContentRef.current = content` BEFORE the `fetch()` call, exactly the same fragility class as the ClipCraft `lastAppliedRef.current = null` ordering bug that originally motivated this work.
+   - **slide** (`SlidePreview.tsx:639–646, 674–681, 700–707`): three POST sites (manifest reorder, manifest delete, debounced text edit). **Zero echo guard.** Currently survives because writes are user-driven and low-frequency; a faster cadence would race silently.
+   - **webcraft** (`WebPreview.tsx:978–1008`): debounced 800ms iframe-message-driven POST. **Zero echo guard.** Iframe `srcdoc` reassignment on every files prop change masks the flash, but a pending save in the debounce window can still overwrite an incoming external edit.
+   - **gridboard** (`GridBoardPreview.tsx:165–171, 530, 672, 886, 947`): immediate awaited POST on every drag/resize. **Zero echo guard.** Survives only because saves are synchronous — any future async pathway breaks it.
+   - **diagram** (`DiagramPreview.tsx:139, 382`): `lastFileContentRef` + `currentFilePathRef` skip-on-no-change guard. Read-only, so the guard exists purely to skip expensive re-parse on prop churn, not to dodge an echo loop.
+
+   Of the six viewers that touch the file watcher, **three have hand-rolled echo refs (doc, draw, diagram), three have no protection at all (slide, webcraft, gridboard), and zero of them share a single line of code.** Every author has invented a different solution. None of them is correct in the general case.
+
+2. **`viewer.watchPatterns` is a silent contract.** Multi-file modes (webcraft declares 14 patterns, slide declares 4, gridboard declares 5) declare globs server-side, then viewers do ad-hoc `files.find(...)` / `files.filter(...)` on their own. If a viewer expects a file type the manifest doesn't watch, the failure is silent. There's no schema or assertion linking declaration to consumption.
+
+3. **No extensibility.** Modes can only consume disk files. Future modes wanting Redis / Yjs / S3 / in-memory state have no protocol to plug in — they'd have to fork the runtime.
+
+### What this plan introduces
+
+A `Source<T>` data-channel abstraction with these invariants (enforced by the provider base class, not by viewer self-discipline):
+
+1. **Single writer.** `write()` is the only way to mutate a source. The base class serializes all `write()` calls per source instance via an internal Promise queue. Concurrent writes are sequenced, never raced.
+2. **Change-read-via-subscription.** All state changes (including the source's own commits) reach consumers as `subscribe()` events. Viewers do not hold optimistic local state; they always render from the latest event. `current()` exists only as a synchronous accessor for first-render and is identical to the latest emitted value.
+3. **`write()` Promise time-locked.** `await source.write(v)` resolves only after the corresponding `{ origin: "self", value: v }` event has been delivered to all current subscribers and `current()` reflects `v`. After await, viewer state is guaranteed consistent.
+4. **Origin tagging at the source.** Events carry `origin: "initial" | "self" | "external"`. Self-writes are NOT silently absorbed; they emit a `value` event with `origin: "self"`. External changes (agent edits, peer writes) emit `origin: "external"`. The first observed value emits `origin: "initial"`.
+5. **Errors are non-fatal.** Parse failures, network errors, etc. emit `{ kind: "error", code, message }`. The source remains live; subsequent events still flow.
+
+### What the user-facing migration looks like
+
+Each existing mode declares a single source named `files` of kind `file-glob`, with patterns lifted from its current `viewer.watchPatterns`:
+
+```ts
+// before
+viewer: { watchPatterns: ["**/*.md"], ignorePatterns: [] }
+
+// after
+viewer: { watchPatterns: ["**/*.md"], ignorePatterns: [] },  // kept until P5 last commit
+sources: {
+  files: { kind: "file-glob", config: { patterns: ["**/*.md"] } },
+}
+```
+
+And each viewer replaces:
+
+```ts
+// before
+export default function DocPreview({ files, ... }: ViewerPreviewProps) {
+  // files: ViewerFileContent[]
+}
+
+// after
+import { useSource } from "../../../src/hooks/useSource.js";
+export default function DocPreview({ sources, ... }: ViewerPreviewProps) {
+  const files = useSource(sources.files as Source<ViewerFileContent[]>) ?? [];
+}
+```
+
+`useSource` is a thin `useSyncExternalStore` wrapper provided by the runtime. The viewer keeps its existing `files.find(...)` / `files.filter(...)` patterns unchanged — only the input plumbing differs.
+
+### What is explicitly out of scope for this plan
+
+- **Splitting modes into multiple typed sources.** webcraft could conceptually have `manifest`, `pages`, `assets` as three sources. This plan migrates every mode as a single-`files`-source unit to keep the migration mechanical. Domain refactoring is a follow-up.
+- **Removing `viewer.watchPatterns` from the manifest.** Kept for the duration of this plan because it's still consumed by `startFileWatcher` to drive chokidar. The `sources` declaration is additive. A follow-up plan can collapse them once every file-glob source is the source of truth.
+- **Diff-and-dispatch / state reconciliation.** `Source<T>` only provides origin-tagged events. What a viewer DOES on `origin: "external"` (rebuild a Zustand store, merge state, prompt the user) is left to each consumer.
+- **ClipCraft refactor.** That mode lives on a separate feat branch. P7 produces a written migration guide for its author; the actual code refactor is theirs.
+- **React integration helpers beyond `useSource`.** No source-providers, no context API, no Suspense integration. `useSource` is a 15-line hook.
+
+---
+
+## File structure
+
+### Created files (new)
+
+| Path | Responsibility |
+|---|---|
+| `core/types/source.ts` | `Source<T>`, `SourceEvent<T>`, `SourceProvider`, `SourceContext`, `FileChannel`, `SourceDescriptor` types. Pure type module, no logic. |
+| `core/sources/base.ts` | `BaseSource<T>` abstract class. Implements listener management, write serialization, current() accessor, destroy. Subclasses fill `doWrite()` and call `this.emit()`. |
+| `core/sources/memory.ts` | `MemorySource<T>` — ephemeral in-process source. Trivial reference implementation that exercises the BaseSource contract. |
+| `core/sources/file-glob.ts` | `FileGlobSource` — multi-file aggregate. Subscribes to `FileChannel`, filters by patterns, emits `FileContent[]`. `doWrite()` throws (file-glob is read-only via Source.write; agents write files directly). |
+| `core/sources/json-file.ts` | `JsonFileSource<T>` — single structured file. Parses on read, serializes + writes via `FileChannel.write()` on `doWrite()`. |
+| `core/sources/index.ts` | Barrel re-export + built-in `SourceProvider[]` registry. |
+| `core/source-registry.ts` | `SourceRegistry` class: holds providers (built-in + plugin-registered), instantiates sources from `manifest.sources` declarations against a `SourceContext`. |
+| `core/sources/__tests__/base.test.ts` | bun:test for BaseSource invariants (write serialization, Promise time-lock, listener fan-out, destroy). |
+| `core/sources/__tests__/memory.test.ts` | bun:test for MemorySource. |
+| `core/sources/__tests__/file-glob.test.ts` | bun:test for FileGlobSource (with mock FileChannel). |
+| `core/sources/__tests__/json-file.test.ts` | bun:test for JsonFileSource (with mock FileChannel). |
+| `core/__tests__/source-registry.test.ts` | bun:test for SourceRegistry — register, instantiate, destroy. |
+| `src/hooks/useSource.ts` | React hook wrapping `useSyncExternalStore` over a `Source<T>`. |
+| `src/runtime/file-channel.ts` | Browser-side `FileChannel` impl: bridges store + ws + POST /api/files into the `FileChannel` interface that providers consume. |
+| `src/runtime/file-event-bus.ts` | Browser-side singleton pub/sub. `workspace-slice.updateFiles()` publishes; `BrowserFileChannel` subscribes and re-emits to provider instances. |
+| `src/runtime/scoped-source.ts` | (P5.11) `wrapWithContentSetScope` — decorates a `file-glob` source with content-set path stripping, preserving the pre-P5 `useViewerProps` content-set behavior. |
+| `docs/superpowers/plans/clipcraft-source-migration.md` | (P7) Written guide for ClipCraft's author. |
+
+### Modified files
+
+| Path | Change |
+|---|---|
+| `core/types/mode-manifest.ts` | Add `SourceDescriptor` import + optional `sources?: Record<string, SourceDescriptor>` field on `ModeManifest`. |
+| `core/types/viewer-contract.ts` | Add `sources: Record<string, Source<unknown>>` to `ViewerPreviewProps`. Mark `files` as `@deprecated` in P3, delete in P5 final commit. |
+| `core/types/plugin.ts` | Add optional `sources?: SourceProvider[]` to `PluginManifest` for plugin-registered providers. |
+| `core/types/index.ts` | Re-export source types. |
+| `core/plugin-registry.ts` | When loading a plugin, collect its `sources` array and hand it to the SourceRegistry. |
+| `server/file-watcher.ts` | Add `pendingSelfWrites: Map<string, { hash, ts }>` API + integration so the watcher tags echoes. Extend `FileUpdate` with optional `origin?: "self" \| "external"`. |
+| `server/index.ts` | `/api/files` POST registers a self-write entry before writing to disk. The watcher reads this on the next event. |
+| `bin/pneuma.ts` | The `content_update` broadcast forwards the `origin` tag added by the watcher. |
+| `src/ws.ts` | The `content_update` handler forwards `origin` into the store. |
+| `src/store/workspace-slice.ts` | `updateFiles()` accepts and forwards `origin`. Adds an event-bus shape (`fileEventBus`) so `FileChannel` browser impl can subscribe to incoming changes. |
+| `src/App.tsx` | `useViewerProps()` builds a `SourceRegistry` per active mode, instantiates sources from manifest, exposes them as `props.sources`. Keeps `files` populated through P3–P5. Removes `files` in P5 final commit. |
+| `modes/doc/manifest.ts` | Add `sources: { files: { kind: "file-glob", config: { patterns: [...] } } }`. |
+| `modes/doc/viewer/DocPreview.tsx` | Replace `files` destructure with `sources` + `useSource`. |
+| `modes/diagram/manifest.ts` | Same. |
+| `modes/diagram/viewer/DiagramPreview.tsx` | Same. |
+| `modes/draw/manifest.ts` | Same. |
+| `modes/draw/viewer/DrawPreview.tsx` | Same. |
+| `modes/illustrate/manifest.ts` | Same. |
+| `modes/illustrate/viewer/IllustratePreview.tsx` | Same. |
+| `modes/remotion/manifest.ts` | Same. |
+| `modes/remotion/viewer/*` | Same. |
+| `modes/mode-maker/manifest.ts` | Same. |
+| `modes/mode-maker/viewer/ModeMakerPreview.tsx` | Same. |
+| `modes/gridboard/manifest.ts` | Same. |
+| `modes/gridboard/viewer/GridBoardPreview.tsx` | Same. |
+| `modes/slide/manifest.ts` | Same. |
+| `modes/slide/viewer/SlidePreview.tsx` | Same. |
+| `modes/webcraft/manifest.ts` | Same. |
+| `modes/webcraft/viewer/WebPreview.tsx` | Same. |
+| `docs/reference/viewer-agent-protocol.md` | Update direction ②, manifest table, new "Sources" section, design principles. |
+| `docs/superpowers/plans/2026-04-13-mode-sync-transport.md` | Add superseded-by header pointing at this plan. |
+
+---
+
+
+## Phase 1: Contract + protocol documentation
+
+Phase 1 lands only types and documentation. No runtime code changes. This phase is a single commit that you can hand to the user for review before any implementation begins.
+
+### Task 1.1: Create `core/types/source.ts`
+
+**Files:**
+- Create: `core/types/source.ts`
+
+- [ ] **Step 1: Write the file in full**
+
+```ts
+/**
+ * Source<T> — the typed data channel between the runtime and a mode viewer.
+ *
+ * Reads flow through subscribe() events tagged with origin. Writes flow
+ * through write(), which providers serialize internally. The provider base
+ * class (core/sources/base.ts) enforces the invariants documented on the
+ * interfaces below; individual providers only fill in how to load and how
+ * to persist.
+ *
+ * This file is pure types — no runtime code, no imports except type-only.
+ */
+
+import type { ViewerFileContent } from "./viewer-contract.js";
+
+// ────────────────────────────────────────────────────────────────────────────
+// Events
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * A single event emitted by a Source.
+ *
+ * Subscribers handle events via the discriminant `kind`. All non-error events
+ * carry an `origin` tag that identifies what caused the event:
+ *
+ *   - "initial"  — the first value this source instance observes from its
+ *                  underlying medium. Fires exactly once per source instance,
+ *                  only after the provider has finished its initial load.
+ *                  Late subscribers miss this event; they should read
+ *                  `current()` for the starting value.
+ *
+ *   - "self"     — the value was committed by a call to `write()` on this
+ *                  same source instance. The write()'s returned Promise
+ *                  resolves only after this event has been delivered to all
+ *                  current subscribers and `current()` reflects the new
+ *                  value. A viewer that `await`s its own write() is
+ *                  guaranteed to see its own committed state on the next
+ *                  render without holding optimistic local state.
+ *
+ *   - "external" — the value was committed by someone other than this source
+ *                  instance. For file-backed sources this means the agent's
+ *                  Edit tool, another viewer tab, or any non-self writer.
+ *                  Viewers that want conflict handling inspect this origin.
+ *
+ * Errors (parse failure, write failure, network drop, etc.) emit a separate
+ * `error` event. Errors are non-fatal: the source remains live and subsequent
+ * events still flow.
+ */
+export type SourceEvent<T> =
+  | { kind: "value"; value: T; origin: "initial" | "self" | "external" }
+  | { kind: "error"; code: string; message: string; raw?: unknown };
+
+// ────────────────────────────────────────────────────────────────────────────
+// Source
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * A typed data channel. Instances are created by a SourceProvider and handed
+ * to a viewer via ViewerPreviewProps.sources.
+ *
+ * ## Invariants (enforced by core/sources/base.ts)
+ *
+ * 1. **Single writer.** `write()` is the only way to mutate the source's
+ *    committed state. Concurrent calls to write() are serialized internally
+ *    via a Promise queue — they run in call order, never in parallel.
+ *
+ * 2. **Change-read-via-subscription.** All state changes — including those
+ *    caused by this source's own write() — reach consumers as subscribe()
+ *    events. Viewers do not maintain optimistic local state; they render
+ *    from the latest delivered value event. `current()` is a synchronous
+ *    accessor that always returns the most recently delivered value.
+ *
+ * 3. **Time-locked write Promises.** `await source.write(v)` resolves only
+ *    after the corresponding `{ kind: "value", value: v, origin: "self" }`
+ *    event has been delivered to all current subscribers and `current()`
+ *    reflects v. After the await, the viewer's state is guaranteed
+ *    consistent with the committed value.
+ *
+ * 4. **Origin-tagged events.** Every value event carries origin. Self-writes
+ *    are NOT silently absorbed; they emit a `value` event with origin="self".
+ *    This lets viewers distinguish "my commit landed" from "someone else
+ *    changed the world" without maintaining shadow refs.
+ *
+ * 5. **Non-fatal errors.** Parse failures, write failures, and transport
+ *    errors emit `{ kind: "error" }` events. The source stays live; a later
+ *    successful read or write still delivers a value event.
+ *
+ * 6. **Idempotent destroy.** `destroy()` is safe to call multiple times.
+ *    After destroy, write() resolves without effect, subscribe() returns a
+ *    no-op unsubscribe, feed()/current() return null.
+ */
+export interface Source<T> {
+  /**
+   * The most recently delivered value, or null if the source has not yet
+   * emitted its initial event. Synchronous — safe to call during render.
+   */
+  current(): T | null;
+
+  /**
+   * Register a listener for future events. Does NOT fire a synthetic initial
+   * event on subscribe — use current() for first-render state, then rely on
+   * subscribe() for subsequent updates. Returns an unsubscribe function.
+   */
+  subscribe(listener: (event: SourceEvent<T>) => void): () => void;
+
+  /**
+   * Commit a new value. Writes are serialized: a later write() call waits
+   * for all earlier writes to settle before running. Resolves after the
+   * provider has persisted the value AND delivered the corresponding
+   * { origin: "self" } event to all current subscribers. Rejects if the
+   * provider cannot persist.
+   */
+  write(value: T): Promise<void>;
+
+  /**
+   * Release resources held by this source. Idempotent. After destroy,
+   * write() is a silent no-op that resolves immediately, subscribe()
+   * returns a no-op unsubscribe, current() returns null.
+   */
+  destroy(): void;
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Providers
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * A SourceProvider is a factory that creates Source instances of a specific
+ * kind. Built-in providers live in core/sources/ and are registered with the
+ * runtime's SourceRegistry at startup. Third-party providers are exported
+ * from plugins via PluginManifest.sources.
+ *
+ * The provider owns the schema of its `config` — the runtime passes config
+ * through unchanged. Providers are free to define config as a TypeScript
+ * object with function fields (e.g., parse/serialize callbacks) because
+ * manifest.ts is loaded as a real TS module, not parsed as JSON.
+ */
+export interface SourceProvider {
+  /** The discriminant that manifest.sources entries use to select this provider. */
+  kind: string;
+
+  /**
+   * Instantiate a new source. The runtime calls this once per declared
+   * manifest.sources entry when activating a mode. The returned Source
+   * should be ready to receive subscribe() calls immediately, even if its
+   * initial value has not yet loaded (in which case current() returns null
+   * until the initial event fires).
+   */
+  create<T>(config: unknown, ctx: SourceContext): Source<T>;
+}
+
+/**
+ * Per-mode runtime services exposed to providers during create(). Providers
+ * use these instead of reaching for globals, so that multiple modes can
+ * coexist in the launcher without cross-contamination.
+ */
+export interface SourceContext {
+  /** Absolute path to the workspace this mode is operating on. */
+  workspace: string;
+
+  /** Logger. Providers should log via this instead of console.* so output
+   *  can be captured and routed per-mode. */
+  log(message: string, level?: "debug" | "info" | "warn" | "error"): void;
+
+  /** Aborted when the mode is destroyed. Providers should listen on this
+   *  signal to clean up long-running work. */
+  signal: AbortSignal;
+
+  /**
+   * Optional file channel for file-backed providers. Only present in the
+   * browser runtime; the server-side runtime does not need it. memory/redis/
+   * yjs providers ignore this.
+   */
+  files?: FileChannel;
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// FileChannel
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Bridge between file-backed providers and the server's chokidar → WS
+ * pipeline. The runtime instantiates exactly one FileChannel per mode
+ * session and hands it to every file-backed provider via SourceContext.
+ *
+ * ## Origin tagging
+ *
+ * When a provider calls `write(path, content)`, the runtime (specifically the
+ * server-side /api/files handler) records a `pendingSelfWrite` entry for that
+ * path + content hash. When chokidar subsequently fires for that path, the
+ * server consults the entry and tags the outgoing FileUpdate with
+ * origin: "self"; otherwise origin: "external". Providers observe the tag via
+ * the `origin` field on FileChangeEvent and propagate it to their own
+ * SourceEvent output.
+ *
+ * This is the ONLY place in the system where self/external origin is
+ * determined for file-backed data. Providers do not reverse-engineer it.
+ */
+export interface FileChannel {
+  /**
+   * Synchronous snapshot of all currently-known files in the workspace.
+   * Used by providers for their initial load (providers then filter this
+   * snapshot by their declared patterns).
+   */
+  snapshot(): ReadonlyArray<ViewerFileContent>;
+
+  /**
+   * Subscribe to file change events. The handler is called for each batch
+   * of file changes arriving from the server. The batch may include files
+   * outside any given provider's declared patterns — providers filter.
+   * Returns an unsubscribe function.
+   */
+  subscribe(handler: (batch: FileChangeEvent[]) => void): () => void;
+
+  /**
+   * Persist file content to the workspace. Wraps the existing
+   * `POST /api/files` endpoint. Returns when the server has acknowledged
+   * the write (which also means the pendingSelfWrite entry has been recorded
+   * on the server side, so the resulting chokidar echo will be tagged
+   * origin: "self" when it arrives).
+   *
+   * Providers call this from their doWrite() implementation. The runtime
+   * guarantees write ordering within a single source via the BaseSource
+   * queue; cross-source ordering is not guaranteed.
+   */
+  write(path: string, content: string): Promise<void>;
+
+  /**
+   * Delete a file from the workspace. Wraps `DELETE /api/files?path=...`.
+   * Like write(), the server records a pendingSelfDelete entry so the
+   * resulting chokidar `unlink` event is tagged origin: "self" and the
+   * provider can absorb its own echo.
+   *
+   * Used primarily by `aggregate-file` providers whose `save()` produces
+   * a { writes, deletes } diff — e.g. when a slide is removed from a
+   * Deck, the provider deletes the corresponding `slides/slide-N.html`
+   * via this method.
+   */
+  delete(path: string): Promise<void>;
+}
+
+/**
+ * One file change observed by the runtime's FileChannel. Emitted to all
+ * subscribed providers, which then filter to their declared patterns.
+ */
+export interface FileChangeEvent {
+  path: string;
+  content: string;
+  /**
+   * "self" if this change is the echo of a write() call made through any
+   * FileChannel on this session. "external" otherwise (agent's Edit tool,
+   * manual file-system edit, concurrent writer, etc.). "initial" for
+   * entries delivered via the very first snapshot() payload.
+   */
+  origin: "initial" | "self" | "external";
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Manifest descriptor
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * A single source declaration in ModeManifest.sources. The runtime reads
+ * kind, looks up the matching SourceProvider in the SourceRegistry, and
+ * calls provider.create(config, ctx) to instantiate.
+ *
+ * config is typed as `unknown` here because its shape is provider-specific.
+ * Providers document their own config schema. The built-in providers use:
+ *
+ *   - file-glob: { patterns: string[]; ignore?: string[] }
+ *   - json-file: { path: string; parse: (raw: string) => T;
+ *                  serialize: (v: T) => string }
+ *   - memory:    { initial?: T }
+ */
+export interface SourceDescriptor {
+  kind: string;
+  config?: unknown;
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `bun run tsc --noEmit`
+Expected: no errors. If you see errors about `ViewerFileContent` missing, check the import path — it's `./viewer-contract.js` (note the `.js` extension even though the file is `.ts` — required by bundler module resolution).
+
+- [ ] **Step 3: Do NOT commit yet.** Task 1.2 modifies an adjacent file and both land in the same P1 commit.
+
+---
+
+### Task 1.2: Add `sources` field to `ModeManifest`
+
+**Files:**
+- Modify: `core/types/mode-manifest.ts`
+
+- [ ] **Step 1: Add the import**
+
+At the top of the file, near the other type imports, add:
+
+```ts
+import type { SourceDescriptor } from "./source.js";
+```
+
+- [ ] **Step 2: Add the field to `ModeManifest`**
+
+In the `ModeManifest` interface (currently ~lines 252–298), add the optional `sources` field at the end of the interface body, just before the closing brace:
+
+```ts
+  /**
+   * Declarative data-channel configuration. Each entry instantiates a
+   * Source<T> via the SourceRegistry at mode startup and exposes it to
+   * the viewer as props.sources[id].
+   *
+   * If omitted, the runtime synthesizes a default entry:
+   *
+   *   sources: {
+   *     files: {
+   *       kind: "file-glob",
+   *       config: {
+   *         patterns: this.viewer.watchPatterns,
+   *         ignore: this.viewer.ignorePatterns,
+   *       },
+   *     },
+   *   }
+   *
+   * so every pre-existing mode continues to receive a `files` source with
+   * zero manifest changes. New or migrated modes declare sources explicitly.
+   *
+   * See core/types/source.ts for the SourceDescriptor shape and the
+   * built-in provider kinds (file-glob, json-file, memory).
+   */
+  sources?: Record<string, SourceDescriptor>;
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run: `bun run tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 4: Do NOT commit yet.** Wait for Task 1.3.
+
+---
+
+### Task 1.3: Re-export source types from the barrel
+
+**Files:**
+- Modify: `core/types/index.ts`
+
+- [ ] **Step 1: Add the re-export**
+
+Append to the file (after the existing `export * from "./plugin.js";` or wherever the last export lives):
+
+```ts
+export type {
+  Source,
+  SourceEvent,
+  SourceProvider,
+  SourceContext,
+  FileChannel,
+  FileChangeEvent,
+  SourceDescriptor,
+} from "./source.js";
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `bun run tsc --noEmit`
+Expected: no errors.
+
+---
+
+### Task 1.4: Compile-time contract test
+
+**Files:**
+- Create: `core/__tests__/source-types.test.ts`
+
+This task is a type-assertion test — it has no runtime assertions but will fail `tsc` if the contract drifts. It exists so the next person to touch source.ts gets a loud signal if they break a load-bearing type.
+
+- [ ] **Step 1: Write the test file**
+
+```ts
+import { describe, test, expect } from "bun:test";
+import type {
+  Source,
+  SourceEvent,
+  SourceProvider,
+  SourceContext,
+  SourceDescriptor,
+  FileChannel,
+  FileChangeEvent,
+} from "../types/source.js";
+import type { ModeManifest } from "../types/mode-manifest.js";
+
+describe("Source contract shape", () => {
+  test("SourceEvent discriminates on kind", () => {
+    // Compile-time exhaustiveness check: if a new kind is added without
+    // updating this function, tsc will complain about the unreachable case.
+    function assertNever(x: never): never {
+      throw new Error(`Unexpected: ${String(x)}`);
+    }
+    function reduce<T>(e: SourceEvent<T>): string {
+      switch (e.kind) {
+        case "value":
+          return e.origin;
+        case "error":
+          return e.code;
+        default:
+          return assertNever(e);
+      }
+    }
+    expect(
+      reduce<number>({ kind: "value", value: 1, origin: "initial" }),
+    ).toBe("initial");
+    expect(
+      reduce<number>({ kind: "error", code: "E_PARSE", message: "bad" }),
+    ).toBe("E_PARSE");
+  });
+
+  test("Source<T> has the four required methods", () => {
+    const stub: Source<number> = {
+      current: () => null,
+      subscribe: () => () => {},
+      write: async () => {},
+      destroy: () => {},
+    };
+    expect(typeof stub.current).toBe("function");
+    expect(typeof stub.subscribe).toBe("function");
+    expect(typeof stub.write).toBe("function");
+    expect(typeof stub.destroy).toBe("function");
+  });
+
+  test("SourceProvider.create takes config and context, returns Source", () => {
+    const provider: SourceProvider = {
+      kind: "test",
+      create<T>(_config: unknown, _ctx: SourceContext): Source<T> {
+        return {
+          current: () => null,
+          subscribe: () => () => {},
+          write: async () => {},
+          destroy: () => {},
+        };
+      },
+    };
+    expect(provider.kind).toBe("test");
+  });
+
+  test("SourceContext exposes workspace, log, signal, optional files", () => {
+    const ctx: SourceContext = {
+      workspace: "/tmp/ws",
+      log: () => {},
+      signal: new AbortController().signal,
+    };
+    expect(ctx.workspace).toBe("/tmp/ws");
+    expect(ctx.files).toBeUndefined();
+  });
+
+  test("FileChannel has snapshot, subscribe, write, delete", () => {
+    const channel: FileChannel = {
+      snapshot: () => [],
+      subscribe: () => () => {},
+      write: async () => {},
+      delete: async () => {},
+    };
+    expect(channel.snapshot()).toEqual([]);
+  });
+
+  test("FileChangeEvent origin is one of initial|self|external", () => {
+    const events: FileChangeEvent[] = [
+      { path: "a.md", content: "x", origin: "initial" },
+      { path: "a.md", content: "y", origin: "self" },
+      { path: "a.md", content: "z", origin: "external" },
+    ];
+    expect(events).toHaveLength(3);
+  });
+
+  test("SourceDescriptor is assignable from manifest.sources entry", () => {
+    const d: SourceDescriptor = {
+      kind: "file-glob",
+      config: { patterns: ["**/*.md"] },
+    };
+    expect(d.kind).toBe("file-glob");
+  });
+
+  test("ModeManifest.sources is optional and takes SourceDescriptors", () => {
+    // Compile-time: this must typecheck without errors.
+    const partial: Pick<ModeManifest, "sources"> = {
+      sources: {
+        files: { kind: "file-glob", config: { patterns: ["**/*.md"] } },
+      },
+    };
+    expect(partial.sources?.files.kind).toBe("file-glob");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `bun test core/__tests__/source-types.test.ts`
+Expected: 7 pass, 0 fail.
+
+---
+
+### Task 1.5: Verify `docs/reference/viewer-agent-protocol.md` framing (already landed)
+
+**Files:**
+- Read-only: `docs/reference/viewer-agent-protocol.md`
+
+This task previously authored the Sources section + direction ② rewrite + manifest table row from scratch. Those edits **already landed as a prep commit on this branch** before P1 execution began — see the "Prep status" note in the plan preamble. This task is now a verification pass to catch drift between the authoritative doc and what P1 Task 1.1 (`core/types/source.ts`) implements. **Do not rewrite the doc; only fix drift.**
+
+- [ ] **Step 1: Open the protocol doc and confirm these sections exist**
+
+Open `docs/reference/viewer-agent-protocol.md`. Confirm that each of the following is present and says what it should:
+
+1. A `## 基本立场` section near the top that names the three layers (Layer 1 = files as agent native habitat; Layer 2 = runtime transport via chokidar + pendingSelfWrites + WS + fileEventBus; Layer 3 = `Source<T>` as viewer's domain-typed contract)
+2. Direction `② Viewer → User: Rendering（视觉呈现 / Player）` whose **数据契约** lists `sources: Record<string, Source<T>>` as the primary field, with a history note acknowledging the legacy `files` prop
+3. A row for `sources` in the Manifest / Runtime role table pointing at direction ② and the Sources小节
+4. A top-level `## Sources — Viewer 的数据通道` section near the end that covers:
+   - "First job is observation, write is optional participation" framing
+   - Four invariants (single writer, change-read-via-subscription, time-locked write Promise, origin tagging)
+   - "Agent 和 Source 的关系" paragraph explaining the two independent write paths sharing one disk reconciled by origin tags
+   - Built-in providers table with FOUR entries: `file-glob`, `json-file`, `aggregate-file`, `memory` (note: `aggregate-file` is listed because P2 Tasks 2.11–2.12 add it)
+   - Plugin extension path
+   - Mode author 6-step mental path
+5. Design principle 7 "Files 归 agent，Domain 归 viewer"
+
+- [ ] **Step 2: Cross-check contract vocabulary**
+
+Grep the doc for every method name and event shape. They must match `core/types/source.ts` from Task 1.1 exactly:
+
+```bash
+grep -n "Source<T>\|SourceEvent\|SourceProvider\|FileChannel\|origin:" \
+  docs/reference/viewer-agent-protocol.md
+```
+
+Confirm:
+- `Source<T>` exposes `current() / subscribe() / write() / destroy()` (no other method names)
+- `SourceEvent<T>` has `kind: "value" | "error"` and value events have `origin: "initial" | "self" | "external"`
+- `SourceProvider.create(config, ctx)` is the factory signature
+- `FileChannel` exposes `snapshot() / subscribe() / write() / delete()` (delete is added by Task 2.12; if the protocol doc lists `delete` before P2 lands it, that's fine — it's forward compatible)
+- `SourceDescriptor { kind, config }` is the manifest entry shape
+
+If any name or signature in the doc disagrees with `core/types/source.ts`, **fix whichever is wrong** — the types file is the source of truth for wire shape; the doc is the source of truth for framing. Record the fix in the P1 commit. Do NOT re-author the doc's prose.
+
+- [ ] **Step 3: Do NOT commit yet.** Wait for Task 1.6.
+
+---
+
+
+---
+
+### Task 1.6: Verify `mode-sync-transport.md` has the superseded-by header (already landed)
+
+**Files:**
+- Read-only: `docs/superpowers/plans/2026-04-13-mode-sync-transport.md`
+
+The superseded-by header **already landed** as part of the doc framing prep commit on this branch (see the "Prep status" note in the plan preamble). This task is a one-line verification.
+
+- [ ] **Step 1: Confirm the header is present**
+
+```bash
+head -5 docs/superpowers/plans/2026-04-13-mode-sync-transport.md | grep -q "SUPERSEDED" && echo OK || echo MISSING
+```
+
+Expected: `OK`. If `MISSING`, add the superseded header (see the prep commit for the exact wording) before proceeding.
+
+- [ ] **Step 2: Do NOT commit yet.** Wait for the P1 verification task.
+
+---
+
+### Task 1.7: P1 verification
+
+**Files:** none modified.
+
+- [ ] **Step 1: Typecheck the whole repo**
+
+Run: `bun run tsc --noEmit 2>&1 | tee /tmp/tsc.log`
+Expected: no errors. If there are errors outside `core/types/source.ts`, `core/types/mode-manifest.ts`, `core/types/index.ts`, or the new test file, investigate — P1 should not have touched anything else.
+
+- [ ] **Step 2: Run the full test suite**
+
+Run: `bun test 2>&1 | tail -30`
+Expected: the suite passes. Count of new passing tests should include the 7 from `core/__tests__/source-types.test.ts`.
+
+- [ ] **Step 3: Confirm diff shape**
+
+Run: `git diff --stat main`
+Expected: 6 files changed — 3 new (`core/types/source.ts`, `core/__tests__/source-types.test.ts`, untouched plan doc), 3 modified (`core/types/mode-manifest.ts`, `core/types/index.ts`, `docs/reference/viewer-agent-protocol.md`, `docs/superpowers/plans/2026-04-13-mode-sync-transport.md`).
+
+(The plan doc itself — `docs/superpowers/plans/2026-04-13-source-abstraction.md` — was created as part of plan authoring, not P1 implementation. It should already be in the diff but is not a deliverable of this task.)
+
+---
+
+### Task 1.8: Commit P1
+
+- [ ] **Step 1: Stage only the P1 files**
+
+```bash
+git add \
+  core/types/source.ts \
+  core/types/mode-manifest.ts \
+  core/types/index.ts \
+  core/__tests__/source-types.test.ts \
+  docs/reference/viewer-agent-protocol.md \
+  docs/superpowers/plans/2026-04-13-mode-sync-transport.md \
+  docs/superpowers/plans/2026-04-13-source-abstraction.md
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git commit -m "$(cat <<'EOF'
+feat(source): contract + protocol doc for source abstraction (P1)
+
+Introduces the Source<T> data-channel contract that will replace the
+origin-less files prop across all viewer modes. This commit is types +
+documentation only — no runtime code, no mode changes, nothing exercises
+the contract at runtime yet.
+
+- core/types/source.ts: Source<T>, SourceEvent<T>, SourceProvider,
+  SourceContext, FileChannel, FileChangeEvent, SourceDescriptor
+- core/types/mode-manifest.ts: optional sources field on ModeManifest
+- core/types/index.ts: re-export
+- core/__tests__/source-types.test.ts: compile-time contract assertions
+- docs/reference/viewer-agent-protocol.md: direction ② rewrite,
+  manifest table row, new Sources section, design principle 7
+- docs/superpowers/plans/2026-04-13-mode-sync-transport.md: superseded-by
+  header; original proposal preserved as historical context
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 3: Stop here for review.**
+
+P1 is the contract-and-docs commit that deserves an explicit user sign-off before any implementation lands on top of it. Present the commit hash and ask the user to review the protocol doc wording and the Source contract semantics before starting P2.
+
+---
+
+
+## Phase 2: Provider base class + three built-in providers
+
+Phase 2 implements the runtime side of the Source contract. Everything in this phase is pure TypeScript under `core/sources/`, framework-agnostic, and fully unit-testable without any browser, server, or file system. The phase ends with `bun test core/sources` fully green.
+
+Every provider task is written as **failing test first, then minimal implementation, then confirm green**. Do not skip the failing-test step — it's how you verify the test actually exercises the code and doesn't silently pass against a typo.
+
+### Task 2.1: Write failing tests for `BaseSource`
+
+**Files:**
+- Create: `core/sources/__tests__/base.test.ts`
+
+- [ ] **Step 1: Write the test file in full**
+
+```ts
+import { describe, test, expect } from "bun:test";
+import { BaseSource } from "../base.js";
+import type { SourceEvent } from "../../types/source.js";
+
+// A minimal concrete subclass for testing BaseSource directly.
+// doWrite() just echoes the value back as a "self" event and resolves.
+class TestSource<T> extends BaseSource<T> {
+  public doWriteCalls: T[] = [];
+  public doWriteDelay = 0;
+  public doWriteError: Error | null = null;
+
+  protected async doWrite(value: T): Promise<void> {
+    this.doWriteCalls.push(value);
+    if (this.doWriteDelay > 0) {
+      await new Promise((r) => setTimeout(r, this.doWriteDelay));
+    }
+    if (this.doWriteError) throw this.doWriteError;
+    this.emit({ kind: "value", value, origin: "self" });
+  }
+
+  // Test hooks for driving events from outside
+  public testEmitInitial(value: T): void {
+    this.emit({ kind: "value", value, origin: "initial" });
+  }
+  public testEmitExternal(value: T): void {
+    this.emit({ kind: "value", value, origin: "external" });
+  }
+  public testEmitError(code: string, message: string): void {
+    this.emit({ kind: "error", code, message });
+  }
+}
+
+describe("BaseSource", () => {
+  test("current() returns null before any event", () => {
+    const s = new TestSource<number>();
+    expect(s.current()).toBeNull();
+  });
+
+  test("emit updates current() synchronously", () => {
+    const s = new TestSource<number>();
+    s.testEmitInitial(42);
+    expect(s.current()).toBe(42);
+  });
+
+  test("subscribe receives future events, not a synthetic initial", () => {
+    const s = new TestSource<number>();
+    s.testEmitInitial(1);
+    const events: SourceEvent<number>[] = [];
+    s.subscribe((e) => events.push(e));
+    expect(events).toHaveLength(0);  // no synthetic on subscribe
+    s.testEmitExternal(2);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({ kind: "value", value: 2, origin: "external" });
+  });
+
+  test("multiple subscribers all receive the same event", () => {
+    const s = new TestSource<number>();
+    const a: SourceEvent<number>[] = [];
+    const b: SourceEvent<number>[] = [];
+    s.subscribe((e) => a.push(e));
+    s.subscribe((e) => b.push(e));
+    s.testEmitExternal(7);
+    expect(a).toHaveLength(1);
+    expect(b).toHaveLength(1);
+  });
+
+  test("unsubscribe stops that listener only", () => {
+    const s = new TestSource<number>();
+    const a: SourceEvent<number>[] = [];
+    const b: SourceEvent<number>[] = [];
+    const offA = s.subscribe((e) => a.push(e));
+    s.subscribe((e) => b.push(e));
+    offA();
+    s.testEmitExternal(7);
+    expect(a).toHaveLength(0);
+    expect(b).toHaveLength(1);
+  });
+
+  test("write calls doWrite and emits self event", async () => {
+    const s = new TestSource<string>();
+    const events: SourceEvent<string>[] = [];
+    s.subscribe((e) => events.push(e));
+    await s.write("hello");
+    expect(s.doWriteCalls).toEqual(["hello"]);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({ kind: "value", value: "hello", origin: "self" });
+    expect(s.current()).toBe("hello");
+  });
+
+  test("write Promise resolves AFTER the self event is delivered", async () => {
+    const s = new TestSource<string>();
+    s.doWriteDelay = 20;
+    let eventSeenAt = 0;
+    let writeResolvedAt = 0;
+    s.subscribe((e) => {
+      if (e.kind === "value" && e.origin === "self") {
+        eventSeenAt = performance.now();
+      }
+    });
+    const before = performance.now();
+    await s.write("x");
+    writeResolvedAt = performance.now();
+    // Event must be delivered before or at the same instant write resolves
+    expect(eventSeenAt).toBeGreaterThan(0);
+    expect(eventSeenAt).toBeLessThanOrEqual(writeResolvedAt);
+    // And the write took roughly the doWriteDelay
+    expect(writeResolvedAt - before).toBeGreaterThanOrEqual(15);
+  });
+
+  test("concurrent write calls are serialized in call order", async () => {
+    const s = new TestSource<number>();
+    s.doWriteDelay = 10;
+    const writes = [s.write(1), s.write(2), s.write(3)];
+    await Promise.all(writes);
+    expect(s.doWriteCalls).toEqual([1, 2, 3]);
+    expect(s.current()).toBe(3);
+  });
+
+  test("a failed write propagates its error to the caller", async () => {
+    const s = new TestSource<number>();
+    s.doWriteError = new Error("disk full");
+    await expect(s.write(1)).rejects.toThrow("disk full");
+  });
+
+  test("a failed write does not block subsequent writes", async () => {
+    const s = new TestSource<number>();
+    s.doWriteError = new Error("first fails");
+    await expect(s.write(1)).rejects.toThrow("first fails");
+    s.doWriteError = null;
+    await s.write(2);
+    expect(s.current()).toBe(2);
+  });
+
+  test("destroy() is idempotent and makes write a no-op", async () => {
+    const s = new TestSource<number>();
+    s.destroy();
+    s.destroy();  // second call is safe
+    await s.write(1);  // resolves without calling doWrite
+    expect(s.doWriteCalls).toEqual([]);
+    expect(s.current()).toBeNull();
+  });
+
+  test("destroy() removes all subscribers", () => {
+    const s = new TestSource<number>();
+    const events: SourceEvent<number>[] = [];
+    s.subscribe((e) => events.push(e));
+    s.destroy();
+    s.testEmitExternal(1);  // after destroy, emit is a no-op
+    expect(events).toHaveLength(0);
+  });
+
+  test("subscribe after destroy returns a no-op unsubscribe", () => {
+    const s = new TestSource<number>();
+    s.destroy();
+    const off = s.subscribe(() => {});
+    expect(typeof off).toBe("function");
+    off();  // must not throw
+  });
+
+  test("error events do not update current()", () => {
+    const s = new TestSource<number>();
+    s.testEmitInitial(10);
+    s.testEmitError("E_X", "bad");
+    expect(s.current()).toBe(10);
+  });
+
+  test("error event is delivered to all subscribers", () => {
+    const s = new TestSource<number>();
+    const events: SourceEvent<number>[] = [];
+    s.subscribe((e) => events.push(e));
+    s.testEmitError("E_X", "bad");
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({ kind: "error", code: "E_X", message: "bad" });
+  });
+
+  test("a listener that throws does not prevent other listeners from running", () => {
+    const s = new TestSource<number>();
+    s.subscribe(() => { throw new Error("boom"); });
+    const events: SourceEvent<number>[] = [];
+    s.subscribe((e) => events.push(e));
+    s.testEmitExternal(1);
+    expect(events).toHaveLength(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run to confirm all fail with "BaseSource not found"**
+
+Run: `bun test core/sources/__tests__/base.test.ts 2>&1 | tail -20`
+Expected: module resolution error on `../base.js` because the file doesn't exist yet. This is the intended failing state.
+
+---
+
+### Task 2.2: Implement `BaseSource`
+
+**Files:**
+- Create: `core/sources/base.ts`
+
+- [ ] **Step 1: Write the file**
+
+```ts
+import type { Source, SourceEvent } from "../types/source.js";
+
+/**
+ * Abstract base class for all built-in and third-party Source implementations.
+ *
+ * Owns the four invariants documented on Source<T> in core/types/source.ts:
+ * single writer, change-read-via-subscription, time-locked write Promises,
+ * origin tagging. Subclasses only fill in:
+ *
+ *   - doWrite(value): perform the actual persistence. Must emit a
+ *     { origin: "self" } event before resolving (see the helper
+ *     emit() method below). Should throw on failure — BaseSource
+ *     re-throws to the write() caller.
+ *
+ *   - Whatever mechanism they use to observe external changes.
+ *     When an external change arrives, the subclass calls
+ *     this.emit({ kind: "value", value, origin: "external" }) to
+ *     propagate it.
+ *
+ *   - An initial-load pathway that ultimately calls
+ *     this.emit({ kind: "value", value, origin: "initial" }) once.
+ *
+ * Subclasses should call super.destroy() from their own destroy() to
+ * guarantee the listener set is cleared.
+ */
+export abstract class BaseSource<T> implements Source<T> {
+  private listeners = new Set<(e: SourceEvent<T>) => void>();
+  private latest: T | null = null;
+  private destroyed = false;
+
+  // Serializes write() calls. Each write awaits the previous. We use
+  // .catch inside the chain so one rejection doesn't poison subsequent
+  // writes — the rejection is still propagated to THAT call's caller via
+  // the separate `next` promise.
+  private writeQueue: Promise<void> = Promise.resolve();
+
+  current(): T | null {
+    return this.latest;
+  }
+
+  subscribe(listener: (event: SourceEvent<T>) => void): () => void {
+    if (this.destroyed) return () => {};
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  /**
+   * Public entry point for writes. Serializes against any in-flight or
+   * queued writes, then calls the subclass's doWrite(). The returned
+   * Promise resolves only after doWrite() has resolved AND the self event
+   * has been delivered to all subscribers (the subclass is responsible
+   * for emitting that event from within doWrite, typically as its very
+   * last step before returning).
+   */
+  write(value: T): Promise<void> {
+    if (this.destroyed) return Promise.resolve();
+    // Chain: wait for previous write (regardless of success), then run
+    // this one. The returned `next` is what we give the caller; the
+    // `.catch` on the stored queue prevents one failure from breaking
+    // the chain for later writes.
+    const prev = this.writeQueue;
+    const next = prev
+      .catch(() => {})
+      .then(() => this.doWrite(value));
+    this.writeQueue = next.catch(() => {});
+    return next;
+  }
+
+  destroy(): void {
+    if (this.destroyed) return;
+    this.destroyed = true;
+    this.listeners.clear();
+  }
+
+  /**
+   * Subclass hook: actually persist the value. Must emit a self event
+   * before resolving. Throw to signal failure — BaseSource propagates
+   * the error to the write() caller.
+   */
+  protected abstract doWrite(value: T): Promise<void>;
+
+  /**
+   * Subclass hook: emit an event to all current subscribers. Updates
+   * the internal `latest` cache if this is a value event. Listeners that
+   * throw are isolated — their error is caught and logged, other
+   * listeners still receive the event.
+   */
+  protected emit(event: SourceEvent<T>): void {
+    if (this.destroyed) return;
+    if (event.kind === "value") {
+      this.latest = event.value;
+    }
+    // Snapshot the listener set so a listener that subscribes / unsubscribes
+    // during delivery doesn't disturb iteration.
+    for (const listener of Array.from(this.listeners)) {
+      try {
+        listener(event);
+      } catch (err) {
+        // Don't throw — one listener's bug shouldn't break others.
+        // Log to console; providers can override this if they need
+        // structured logging (via SourceContext.log, but BaseSource has
+        // no ctx, so console is the floor).
+        // eslint-disable-next-line no-console
+        console.error("[source] listener threw", err);
+      }
+    }
+  }
+
+  /**
+   * Subclass utility: check whether destroy() has been called. Useful
+   * for guarding async code paths that resume after an await boundary.
+   */
+  protected get isDestroyed(): boolean {
+    return this.destroyed;
+  }
+}
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `bun test core/sources/__tests__/base.test.ts 2>&1 | tail -20`
+Expected: 16 pass, 0 fail.
+
+- [ ] **Step 3: Do NOT commit yet.** P2 commits once all three providers are green.
+
+---
+
+### Task 2.3: Write failing tests for `MemorySource`
+
+**Files:**
+- Create: `core/sources/__tests__/memory.test.ts`
+
+- [ ] **Step 1: Write the test file**
+
+```ts
+import { describe, test, expect } from "bun:test";
+import { MemorySource } from "../memory.js";
+import type { SourceEvent } from "../../types/source.js";
+
+describe("MemorySource", () => {
+  test("starts with null current when no initial given", () => {
+    const s = new MemorySource<number>({});
+    expect(s.current()).toBeNull();
+  });
+
+  test("starts with initial value and emits initial event synchronously on create", () => {
+    const s = new MemorySource<number>({ initial: 42 });
+    // MemorySource fires its initial event in the next microtask, so after
+    // one tick current() should be 42. We use a microtask await.
+    return Promise.resolve().then(() => {
+      expect(s.current()).toBe(42);
+    });
+  });
+
+  test("subscribers registered before the first tick receive the initial event", async () => {
+    const s = new MemorySource<number>({ initial: 42 });
+    const events: SourceEvent<number>[] = [];
+    s.subscribe((e) => events.push(e));
+    await Promise.resolve();  // let the microtask run
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({ kind: "value", value: 42, origin: "initial" });
+  });
+
+  test("write() emits a self event and updates current()", async () => {
+    const s = new MemorySource<number>({ initial: 0 });
+    await Promise.resolve();  // drain initial
+    const events: SourceEvent<number>[] = [];
+    s.subscribe((e) => events.push(e));
+    await s.write(7);
+    expect(s.current()).toBe(7);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({ kind: "value", value: 7, origin: "self" });
+  });
+
+  test("destroy stops further writes", async () => {
+    const s = new MemorySource<number>({ initial: 0 });
+    s.destroy();
+    await s.write(1);
+    expect(s.current()).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run to confirm all fail with module not found**
+
+Run: `bun test core/sources/__tests__/memory.test.ts 2>&1 | tail -10`
+Expected: module resolution error.
+
+---
+
+### Task 2.4: Implement `MemorySource`
+
+**Files:**
+- Create: `core/sources/memory.ts`
+
+- [ ] **Step 1: Write the file**
+
+```ts
+import { BaseSource } from "./base.js";
+
+/**
+ * Ephemeral in-process source. Keeps state in memory, no persistence.
+ * Used for session-scoped data (presence, cursor, UI mode flags, etc.)
+ * where a refresh is expected to start fresh.
+ *
+ * Config:
+ *   { initial?: T }  -- optional starting value
+ *
+ * The initial event fires in a microtask after construction so that
+ * subscribers registered synchronously right after `new MemorySource()`
+ * still catch it.
+ */
+export interface MemorySourceConfig<T> {
+  initial?: T;
+}
+
+export class MemorySource<T> extends BaseSource<T> {
+  constructor(config: MemorySourceConfig<T>) {
+    super();
+    if (config.initial !== undefined) {
+      // Defer to a microtask so listeners subscribed right after
+      // construction still catch the initial event.
+      queueMicrotask(() => {
+        if (this.isDestroyed) return;
+        this.emit({ kind: "value", value: config.initial as T, origin: "initial" });
+      });
+    }
+  }
+
+  protected async doWrite(value: T): Promise<void> {
+    this.emit({ kind: "value", value, origin: "self" });
+  }
+}
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `bun test core/sources/__tests__/memory.test.ts 2>&1 | tail -15`
+Expected: 5 pass, 0 fail.
+
+---
+
+### Task 2.5: Write failing tests for `FileGlobSource`
+
+**Files:**
+- Create: `core/sources/__tests__/file-glob.test.ts`
+
+- [ ] **Step 1: Write the test file**
+
+```ts
+import { describe, test, expect, beforeEach } from "bun:test";
+import { FileGlobSource } from "../file-glob.js";
+import type {
+  FileChannel,
+  FileChangeEvent,
+  SourceEvent,
+} from "../../types/source.js";
+import type { ViewerFileContent } from "../../types/viewer-contract.js";
+
+// In-memory FileChannel for testing — lets the test drive file events
+// directly without a real server.
+class MockFileChannel implements FileChannel {
+  public handlers = new Set<(batch: FileChangeEvent[]) => void>();
+  public files: ViewerFileContent[] = [];
+  public writes: Array<{ path: string; content: string }> = [];
+  public writeError: Error | null = null;
+
+  snapshot(): ReadonlyArray<ViewerFileContent> {
+    return this.files;
+  }
+
+  subscribe(handler: (batch: FileChangeEvent[]) => void): () => void {
+    this.handlers.add(handler);
+    return () => { this.handlers.delete(handler); };
+  }
+
+  async write(path: string, content: string): Promise<void> {
+    if (this.writeError) throw this.writeError;
+    this.writes.push({ path, content });
+  }
+
+  public deletes: string[] = [];
+  async delete(path: string): Promise<void> {
+    this.deletes.push(path);
+  }
+
+  // Test hook
+  push(batch: FileChangeEvent[]): void {
+    for (const h of this.handlers) h(batch);
+  }
+}
+
+describe("FileGlobSource", () => {
+  let ch: MockFileChannel;
+
+  beforeEach(() => {
+    ch = new MockFileChannel();
+  });
+
+  test("on create, reads snapshot and fires initial with matching files", async () => {
+    ch.files = [
+      { path: "a.md", content: "# A" },
+      { path: "b.css", content: "body {}" },
+      { path: "c.md", content: "# C" },
+    ];
+    const source = new FileGlobSource({ patterns: ["**/*.md"] }, ch);
+    const events: SourceEvent<ViewerFileContent[]>[] = [];
+    source.subscribe((e) => events.push(e));
+    await Promise.resolve();  // let the initial microtask run
+    expect(events).toHaveLength(1);
+    if (events[0].kind !== "value") throw new Error("expected value");
+    expect(events[0].origin).toBe("initial");
+    expect(events[0].value.map((f) => f.path).sort()).toEqual(["a.md", "c.md"]);
+  });
+
+  test("external file change matching patterns emits external event", async () => {
+    ch.files = [{ path: "a.md", content: "# A" }];
+    const source = new FileGlobSource({ patterns: ["**/*.md"] }, ch);
+    await Promise.resolve();  // drain initial
+    const events: SourceEvent<ViewerFileContent[]>[] = [];
+    source.subscribe((e) => events.push(e));
+    ch.push([{ path: "a.md", content: "# A edited", origin: "external" }]);
+    expect(events).toHaveLength(1);
+    if (events[0].kind !== "value") throw new Error("expected value");
+    expect(events[0].origin).toBe("external");
+    expect(events[0].value.find((f) => f.path === "a.md")?.content).toBe("# A edited");
+  });
+
+  test("self-origin change emits self event (unchanged origin tag)", async () => {
+    ch.files = [{ path: "a.md", content: "# A" }];
+    const source = new FileGlobSource({ patterns: ["**/*.md"] }, ch);
+    await Promise.resolve();
+    const events: SourceEvent<ViewerFileContent[]>[] = [];
+    source.subscribe((e) => events.push(e));
+    ch.push([{ path: "a.md", content: "# Fresh", origin: "self" }]);
+    expect(events).toHaveLength(1);
+    if (events[0].kind !== "value") throw new Error("expected value");
+    expect(events[0].origin).toBe("self");
+  });
+
+  test("file change not matching patterns does not emit", async () => {
+    ch.files = [{ path: "a.md", content: "# A" }];
+    const source = new FileGlobSource({ patterns: ["**/*.md"] }, ch);
+    await Promise.resolve();
+    const events: SourceEvent<ViewerFileContent[]>[] = [];
+    source.subscribe((e) => events.push(e));
+    ch.push([{ path: "b.css", content: "body {}", origin: "external" }]);
+    expect(events).toHaveLength(0);
+  });
+
+  test("write() throws — file-glob is read-only via Source.write", async () => {
+    const source = new FileGlobSource({ patterns: ["**/*.md"] }, ch);
+    await expect(source.write([])).rejects.toThrow(/read-only/i);
+  });
+
+  test("batch with a mix of matching and non-matching files emits once with the full current set", async () => {
+    ch.files = [
+      { path: "a.md", content: "# A" },
+      { path: "b.md", content: "# B" },
+    ];
+    const source = new FileGlobSource({ patterns: ["**/*.md"] }, ch);
+    await Promise.resolve();
+    const events: SourceEvent<ViewerFileContent[]>[] = [];
+    source.subscribe((e) => events.push(e));
+    ch.push([
+      { path: "a.md", content: "# A2", origin: "external" },
+      { path: "x.css", content: "...", origin: "external" },
+    ]);
+    expect(events).toHaveLength(1);
+    if (events[0].kind !== "value") throw new Error("expected value");
+    const paths = events[0].value.map((f) => f.path).sort();
+    expect(paths).toEqual(["a.md", "b.md"]);
+  });
+
+  test("ignore patterns filter out matching files", async () => {
+    ch.files = [
+      { path: "a.md", content: "# A" },
+      { path: "node_modules/x.md", content: "# X" },
+    ];
+    const source = new FileGlobSource(
+      { patterns: ["**/*.md"], ignore: ["**/node_modules/**"] },
+      ch,
+    );
+    await Promise.resolve();
+    const events: SourceEvent<ViewerFileContent[]>[] = [];
+    source.subscribe((e) => events.push(e));
+    await Promise.resolve();
+    expect(source.current()?.map((f) => f.path)).toEqual(["a.md"]);
+  });
+
+  test("destroy unsubscribes from FileChannel", () => {
+    const source = new FileGlobSource({ patterns: ["**/*.md"] }, ch);
+    expect(ch.handlers.size).toBe(1);
+    source.destroy();
+    expect(ch.handlers.size).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Confirm all fail**
+
+Run: `bun test core/sources/__tests__/file-glob.test.ts 2>&1 | tail -10`
+Expected: module resolution error.
+
+---
+
+### Task 2.6: Implement `FileGlobSource`
+
+**Files:**
+- Create: `core/sources/file-glob.ts`
+
+- [ ] **Step 1: Write the file**
+
+```ts
+import { BaseSource } from "./base.js";
+import type {
+  FileChannel,
+  FileChangeEvent,
+} from "../types/source.js";
+import type { ViewerFileContent } from "../types/viewer-contract.js";
+
+export interface FileGlobConfig {
+  patterns: string[];
+  ignore?: string[];
+}
+
+/**
+ * Multi-file aggregate source backed by a FileChannel. Subscribes to the
+ * channel, filters incoming changes by its declared patterns, and emits
+ * the full snapshot of matching files as a single SourceEvent on each
+ * change.
+ *
+ * ## Why the whole snapshot, not just the delta?
+ *
+ * Existing viewers (all 6 write-back modes + diagram) consume a full
+ * `files: ViewerFileContent[]` array and do `files.find(...)` / filter.
+ * Emitting the full snapshot lets the P5 migration be a 1-line change
+ * (useSource(sources.files)) without restructuring any viewer's internal
+ * data flow. A future optimization could emit a delta shape, but it
+ * would force every viewer to rebuild its own snapshot cache. YAGNI.
+ *
+ * ## Write semantics
+ *
+ * file-glob is READ-ONLY via `source.write()`. A viewer that wants to
+ * write individual files should declare a separate `json-file` source
+ * per file, or call FileChannel.write() directly if it genuinely needs
+ * to write an arbitrary unstructured path (e.g. a binary asset). Calling
+ * write() on a FileGlobSource throws.
+ */
+export class FileGlobSource extends BaseSource<ViewerFileContent[]> {
+  private unsubscribe: (() => void) | null = null;
+  private matcher: (path: string) => boolean;
+  private ignoreMatcher: (path: string) => boolean;
+
+  constructor(
+    private config: FileGlobConfig,
+    private channel: FileChannel,
+  ) {
+    super();
+    this.matcher = compileGlobList(config.patterns);
+    this.ignoreMatcher = compileGlobList(config.ignore ?? []);
+    this.unsubscribe = channel.subscribe((batch) => this.onBatch(batch));
+    // Fire initial snapshot on the next microtask so synchronous
+    // subscribers see it.
+    queueMicrotask(() => this.fireInitial());
+  }
+
+  private fireInitial(): void {
+    if (this.isDestroyed) return;
+    const matching = this.filterSnapshot(this.channel.snapshot());
+    this.emit({ kind: "value", value: matching, origin: "initial" });
+  }
+
+  private onBatch(batch: FileChangeEvent[]): void {
+    if (this.isDestroyed) return;
+    const anyMatch = batch.some(
+      (ev) => this.matcher(ev.path) && !this.ignoreMatcher(ev.path),
+    );
+    if (!anyMatch) return;
+    // Determine the dominant origin for this emission. If any event in
+    // the batch is tagged "self", we tag the whole emission "self"
+    // (the viewer's own write round-tripped); otherwise "external".
+    // We do NOT combine self+external in one emission — the FileChannel
+    // guarantees that batches are coherent (one chokidar debounce window)
+    // and a mixed-origin batch would indicate a runtime bug we want to
+    // surface rather than paper over.
+    const hasSelf = batch.some((ev) => ev.origin === "self");
+    const origin: "self" | "external" = hasSelf ? "self" : "external";
+    const matching = this.filterSnapshot(this.channel.snapshot());
+    this.emit({ kind: "value", value: matching, origin });
+  }
+
+  private filterSnapshot(
+    files: ReadonlyArray<ViewerFileContent>,
+  ): ViewerFileContent[] {
+    return files.filter(
+      (f) => this.matcher(f.path) && !this.ignoreMatcher(f.path),
+    );
+  }
+
+  protected async doWrite(_value: ViewerFileContent[]): Promise<void> {
+    throw new Error(
+      "FileGlobSource is read-only via Source.write(). To write " +
+        "individual files, declare a json-file source per path or use " +
+        "FileChannel.write() directly.",
+    );
+  }
+
+  destroy(): void {
+    this.unsubscribe?.();
+    this.unsubscribe = null;
+    super.destroy();
+  }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Minimal glob matcher
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Compile a list of glob patterns into a single predicate.
+ *
+ * Supports the subset of glob syntax that Pneuma's existing watchPatterns
+ * use: `*` (any chars except /), `**` (any chars including /), `?`
+ * (single char), literal paths. No brace expansion, no character classes.
+ * If the list is empty, the predicate returns false (use this for the
+ * ignore list; patterns list callers should guarantee non-empty).
+ */
+function compileGlobList(patterns: string[]): (path: string) => boolean {
+  if (patterns.length === 0) return () => false;
+  const regexes = patterns.map(compileGlob);
+  return (path: string) => regexes.some((r) => r.test(path));
+}
+
+function compileGlob(pattern: string): RegExp {
+  // Normalize leading ./ — watchPatterns don't typically use it, but be safe.
+  let p = pattern.replace(/^\.\//, "");
+  // Escape regex specials except for the glob metachars we care about.
+  let rx = "";
+  let i = 0;
+  while (i < p.length) {
+    const ch = p[i];
+    if (ch === "*") {
+      if (p[i + 1] === "*") {
+        // ** — any characters including /
+        rx += ".*";
+        i += 2;
+        // Swallow a following / so `**/foo` matches `foo` too.
+        if (p[i] === "/") i++;
+      } else {
+        // * — any characters except /
+        rx += "[^/]*";
+        i++;
+      }
+    } else if (ch === "?") {
+      rx += "[^/]";
+      i++;
+    } else if ("\\^$.|+()[]{}".includes(ch)) {
+      rx += "\\" + ch;
+      i++;
+    } else {
+      rx += ch;
+      i++;
+    }
+  }
+  return new RegExp("^" + rx + "$");
+}
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `bun test core/sources/__tests__/file-glob.test.ts 2>&1 | tail -20`
+Expected: 8 pass, 0 fail. If the glob tests fail, the `compileGlob` function is the likely culprit — step through each failing pattern with a REPL to isolate.
+
+---
+
+### Task 2.7: Write failing tests for `JsonFileSource`
+
+**Files:**
+- Create: `core/sources/__tests__/json-file.test.ts`
+
+- [ ] **Step 1: Write the test file**
+
+```ts
+import { describe, test, expect, beforeEach } from "bun:test";
+import { JsonFileSource } from "../json-file.js";
+import type {
+  FileChannel,
+  FileChangeEvent,
+  SourceEvent,
+} from "../../types/source.js";
+import type { ViewerFileContent } from "../../types/viewer-contract.js";
+
+interface Project {
+  title: string;
+  count?: number;
+}
+
+class MockFileChannel implements FileChannel {
+  public handlers = new Set<(batch: FileChangeEvent[]) => void>();
+  public files: ViewerFileContent[] = [];
+  public writes: Array<{ path: string; content: string }> = [];
+  public writeError: Error | null = null;
+  public writeDelay = 0;
+
+  snapshot(): ReadonlyArray<ViewerFileContent> {
+    return this.files;
+  }
+  subscribe(handler: (batch: FileChangeEvent[]) => void): () => void {
+    this.handlers.add(handler);
+    return () => { this.handlers.delete(handler); };
+  }
+  async write(path: string, content: string): Promise<void> {
+    if (this.writeDelay > 0) await new Promise((r) => setTimeout(r, this.writeDelay));
+    if (this.writeError) throw this.writeError;
+    this.writes.push({ path, content });
+  }
+  push(batch: FileChangeEvent[]): void {
+    for (const h of this.handlers) h(batch);
+  }
+}
+
+const parse = (raw: string) => JSON.parse(raw) as Project;
+const serialize = (v: Project) => JSON.stringify(v);
+
+describe("JsonFileSource", () => {
+  let ch: MockFileChannel;
+
+  beforeEach(() => {
+    ch = new MockFileChannel();
+  });
+
+  test("initial snapshot with a parseable file fires initial event", async () => {
+    ch.files = [{ path: "project.json", content: '{"title":"Hello"}' }];
+    const s = new JsonFileSource<Project>(
+      { path: "project.json", parse, serialize },
+      ch,
+    );
+    const events: SourceEvent<Project>[] = [];
+    s.subscribe((e) => events.push(e));
+    await Promise.resolve();
+    expect(events).toHaveLength(1);
+    if (events[0].kind !== "value") throw new Error("expected value");
+    expect(events[0].origin).toBe("initial");
+    expect(events[0].value).toEqual({ title: "Hello" });
+  });
+
+  test("missing file on startup emits no initial event, current() is null", async () => {
+    const s = new JsonFileSource<Project>(
+      { path: "project.json", parse, serialize },
+      ch,
+    );
+    const events: SourceEvent<Project>[] = [];
+    s.subscribe((e) => events.push(e));
+    await Promise.resolve();
+    expect(events).toHaveLength(0);
+    expect(s.current()).toBeNull();
+  });
+
+  test("external update emits external event", async () => {
+    ch.files = [{ path: "project.json", content: '{"title":"A"}' }];
+    const s = new JsonFileSource<Project>(
+      { path: "project.json", parse, serialize },
+      ch,
+    );
+    await Promise.resolve();
+    const events: SourceEvent<Project>[] = [];
+    s.subscribe((e) => events.push(e));
+    ch.files = [{ path: "project.json", content: '{"title":"B"}' }];
+    ch.push([{ path: "project.json", content: '{"title":"B"}', origin: "external" }]);
+    expect(events).toHaveLength(1);
+    if (events[0].kind !== "value") throw new Error("expected value");
+    expect(events[0].origin).toBe("external");
+    expect(events[0].value).toEqual({ title: "B" });
+  });
+
+  test("write persists via channel and emits self event", async () => {
+    ch.files = [{ path: "project.json", content: '{"title":"A"}' }];
+    const s = new JsonFileSource<Project>(
+      { path: "project.json", parse, serialize },
+      ch,
+    );
+    await Promise.resolve();
+    const events: SourceEvent<Project>[] = [];
+    s.subscribe((e) => events.push(e));
+    await s.write({ title: "B" });
+    expect(ch.writes).toHaveLength(1);
+    expect(ch.writes[0]).toEqual({
+      path: "project.json",
+      content: '{"title":"B"}',
+    });
+    expect(events).toHaveLength(1);
+    if (events[0].kind !== "value") throw new Error("expected value");
+    expect(events[0].origin).toBe("self");
+    expect(events[0].value).toEqual({ title: "B" });
+    expect(s.current()).toEqual({ title: "B" });
+  });
+
+  test("write followed by the echo event emits only the self event (not a duplicate external)", async () => {
+    ch.files = [{ path: "project.json", content: '{"title":"A"}' }];
+    const s = new JsonFileSource<Project>(
+      { path: "project.json", parse, serialize },
+      ch,
+    );
+    await Promise.resolve();
+    const events: SourceEvent<Project>[] = [];
+    s.subscribe((e) => events.push(e));
+
+    // 1. viewer writes
+    await s.write({ title: "B" });
+    expect(events).toHaveLength(1);
+    expect((events[0] as any).origin).toBe("self");
+
+    // 2. FileChannel delivers the server-tagged echo. Because the server
+    // tags it origin: "self" via pendingSelfWrites, JsonFileSource should
+    // recognize it as an already-emitted self and drop it rather than
+    // re-emit another self event.
+    ch.files = [{ path: "project.json", content: '{"title":"B"}' }];
+    ch.push([{ path: "project.json", content: '{"title":"B"}', origin: "self" }]);
+    expect(events).toHaveLength(1);  // no duplicate
+  });
+
+  test("parse failure on initial load emits error event, not value", async () => {
+    ch.files = [{ path: "project.json", content: "{not json" }];
+    const s = new JsonFileSource<Project>(
+      { path: "project.json", parse, serialize },
+      ch,
+    );
+    const events: SourceEvent<Project>[] = [];
+    s.subscribe((e) => events.push(e));
+    await Promise.resolve();
+    expect(events).toHaveLength(1);
+    expect(events[0].kind).toBe("error");
+    expect(s.current()).toBeNull();
+  });
+
+  test("parse failure is non-fatal — a later valid external update succeeds", async () => {
+    ch.files = [{ path: "project.json", content: "{not json" }];
+    const s = new JsonFileSource<Project>(
+      { path: "project.json", parse, serialize },
+      ch,
+    );
+    await Promise.resolve();  // drain initial error
+    const events: SourceEvent<Project>[] = [];
+    s.subscribe((e) => events.push(e));
+    ch.files = [{ path: "project.json", content: '{"title":"Recovered"}' }];
+    ch.push([{ path: "project.json", content: '{"title":"Recovered"}', origin: "external" }]);
+    // The source had never successfully observed a value before, so this
+    // one is still the "first" — it fires with origin="initial".
+    expect(events).toHaveLength(1);
+    if (events[0].kind !== "value") throw new Error("expected value");
+    expect(events[0].origin).toBe("initial");
+    expect(events[0].value).toEqual({ title: "Recovered" });
+  });
+
+  test("write failure propagates and does not update current()", async () => {
+    ch.files = [{ path: "project.json", content: '{"title":"A"}' }];
+    const s = new JsonFileSource<Project>(
+      { path: "project.json", parse, serialize },
+      ch,
+    );
+    await Promise.resolve();
+    ch.writeError = new Error("disk full");
+    await expect(s.write({ title: "B" })).rejects.toThrow("disk full");
+    expect(s.current()).toEqual({ title: "A" });
+  });
+
+  test("only events for the declared path are processed", async () => {
+    ch.files = [{ path: "project.json", content: '{"title":"A"}' }];
+    const s = new JsonFileSource<Project>(
+      { path: "project.json", parse, serialize },
+      ch,
+    );
+    await Promise.resolve();
+    const events: SourceEvent<Project>[] = [];
+    s.subscribe((e) => events.push(e));
+    ch.push([{ path: "other.json", content: '{"title":"X"}', origin: "external" }]);
+    expect(events).toHaveLength(0);
+  });
+
+  test("destroy unsubscribes from channel", () => {
+    const s = new JsonFileSource<Project>(
+      { path: "project.json", parse, serialize },
+      ch,
+    );
+    expect(ch.handlers.size).toBe(1);
+    s.destroy();
+    expect(ch.handlers.size).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Confirm all fail**
+
+Run: `bun test core/sources/__tests__/json-file.test.ts 2>&1 | tail -10`
+Expected: module resolution error.
+
+---
+
+### Task 2.8: Implement `JsonFileSource`
+
+**Files:**
+- Create: `core/sources/json-file.ts`
+
+- [ ] **Step 1: Write the file**
+
+```ts
+import { BaseSource } from "./base.js";
+import type {
+  FileChannel,
+  FileChangeEvent,
+} from "../types/source.js";
+
+export interface JsonFileConfig<T> {
+  path: string;
+  parse: (raw: string) => T;
+  serialize: (value: T) => string;
+}
+
+/**
+ * Single-file structured source. Reads a file as raw text, calls `parse`
+ * to produce a typed value, and on write() calls `serialize` + persists
+ * via FileChannel.write().
+ *
+ * ## Origin handling
+ *
+ * JsonFileSource relies on the FileChannel / server tagging file change
+ * events with origin: "self" vs "external". When it receives an event
+ * tagged "self", it treats the content as the echo of its own write()
+ * and drops the event (since it has already emitted a self event from
+ * the write() call itself). When it receives an event tagged "external",
+ * it parses and emits as external.
+ *
+ * This means the CORRECTNESS of origin detection is entirely the
+ * responsibility of the server-side pendingSelfWrites machinery
+ * (server/file-watcher.ts + server/index.ts POST /api/files). This
+ * source trusts the tag.
+ *
+ * ## Parse errors
+ *
+ * Non-fatal. A parse failure emits a { kind: "error" } event; the
+ * source stays live and a later successful update still delivers a
+ * value event. If the first-ever value is observed post-error, it
+ * still fires with origin: "initial" (a parse error does not count
+ * as having observed an initial value).
+ */
+export class JsonFileSource<T> extends BaseSource<T> {
+  private unsubscribe: (() => void) | null = null;
+  private hasEmittedInitial = false;
+
+  constructor(
+    private config: JsonFileConfig<T>,
+    private channel: FileChannel,
+  ) {
+    super();
+    this.unsubscribe = channel.subscribe((batch) => this.onBatch(batch));
+    queueMicrotask(() => this.fireInitialFromSnapshot());
+  }
+
+  private fireInitialFromSnapshot(): void {
+    if (this.isDestroyed) return;
+    const file = this.channel.snapshot().find((f) => f.path === this.config.path);
+    if (!file) return;  // missing on startup is not an error — current() stays null
+    this.processContent(file.content, "initial");
+  }
+
+  private onBatch(batch: FileChangeEvent[]): void {
+    if (this.isDestroyed) return;
+    const relevant = batch.find((ev) => ev.path === this.config.path);
+    if (!relevant) return;
+    if (relevant.origin === "self") {
+      // Our own write has already emitted a self event from write().
+      // Drop the echo.
+      return;
+    }
+    // External change (or initial for a previously-missing file).
+    const origin = this.hasEmittedInitial ? "external" : "initial";
+    this.processContent(relevant.content, origin);
+  }
+
+  private processContent(raw: string, origin: "initial" | "external"): void {
+    let parsed: T;
+    try {
+      parsed = this.config.parse(raw);
+    } catch (err) {
+      this.emit({
+        kind: "error",
+        code: "E_PARSE",
+        message: (err as Error).message,
+        raw,
+      });
+      return;
+    }
+    this.hasEmittedInitial = true;
+    this.emit({ kind: "value", value: parsed, origin });
+  }
+
+  protected async doWrite(value: T): Promise<void> {
+    const content = this.config.serialize(value);
+    await this.channel.write(this.config.path, content);
+    // The write succeeded. Emit the self event now so the caller's
+    // await resolves with state already consistent. hasEmittedInitial
+    // is guaranteed true after a write because we are now observing
+    // a value.
+    this.hasEmittedInitial = true;
+    this.emit({ kind: "value", value, origin: "self" });
+  }
+
+  destroy(): void {
+    this.unsubscribe?.();
+    this.unsubscribe = null;
+    super.destroy();
+  }
+}
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `bun test core/sources/__tests__/json-file.test.ts 2>&1 | tail -20`
+Expected: 10 pass, 0 fail.
+
+---
+
+### Task 2.9: Write failing tests for `AggregateFileSource`
+
+**Files:**
+- Create: `core/sources/__tests__/aggregate-file.test.ts`
+
+`aggregate-file` is the provider that makes viewer **fully file-agnostic** for modes whose domain is a multi-file aggregate (slide → Deck, webcraft → Site, illustrate → Studio). The mode author provides a `load(files) → T` function that reconstructs the domain aggregate from a file snapshot, and a `save(value, current) → { writes, deletes }` function that decomposes a new aggregate into file-level operations. The viewer NEVER touches paths; it consumes `Source<T>` where `T` is the domain type.
+
+- [ ] **Step 1: Write the test file**
+
+```ts
+import { describe, test, expect, beforeEach } from "bun:test";
+import { AggregateFileSource } from "../aggregate-file.js";
+import type {
+  FileChannel,
+  FileChangeEvent,
+  SourceEvent,
+} from "../../types/source.js";
+import type { ViewerFileContent } from "../../types/viewer-contract.js";
+
+// A tiny toy domain: a "Deck" of slides where each slide is a file
+// at `slides/slide-<id>.html` and the deck order lives in `manifest.json`.
+interface Slide { id: string; html: string }
+interface Deck { order: string[]; slides: Record<string, Slide> }
+
+function loadDeck(files: ReadonlyArray<ViewerFileContent>): Deck | null {
+  const manifest = files.find((f) => f.path === "manifest.json");
+  if (!manifest) return null;
+  const parsed = JSON.parse(manifest.content) as { order: string[] };
+  const slides: Record<string, Slide> = {};
+  for (const id of parsed.order) {
+    const f = files.find((x) => x.path === `slides/slide-${id}.html`);
+    if (f) slides[id] = { id, html: f.content };
+  }
+  return { order: parsed.order, slides };
+}
+
+function saveDeck(
+  next: Deck,
+  current: ReadonlyArray<ViewerFileContent>,
+): { writes: Array<{ path: string; content: string }>; deletes: string[] } {
+  const writes: Array<{ path: string; content: string }> = [
+    { path: "manifest.json", content: JSON.stringify({ order: next.order }) },
+  ];
+  for (const id of next.order) {
+    const slide = next.slides[id];
+    if (slide) writes.push({ path: `slides/slide-${id}.html`, content: slide.html });
+  }
+  // Delete any slide file whose id is no longer in next.order
+  const keep = new Set(next.order.map((id) => `slides/slide-${id}.html`));
+  const deletes: string[] = [];
+  for (const f of current) {
+    if (f.path.startsWith("slides/slide-") && f.path.endsWith(".html") && !keep.has(f.path)) {
+      deletes.push(f.path);
+    }
+  }
+  return { writes, deletes };
+}
+
+class MockFileChannel implements FileChannel {
+  public handlers = new Set<(batch: FileChangeEvent[]) => void>();
+  public files: ViewerFileContent[] = [];
+  public writes: Array<{ path: string; content: string }> = [];
+  public deletes: string[] = [];
+
+  snapshot() { return this.files; }
+  subscribe(h: (b: FileChangeEvent[]) => void) {
+    this.handlers.add(h);
+    return () => { this.handlers.delete(h); };
+  }
+  async write(path: string, content: string) {
+    this.writes.push({ path, content });
+    const existing = this.files.find((f) => f.path === path);
+    if (existing) existing.content = content;
+    else this.files.push({ path, content });
+  }
+  async delete(path: string) {
+    this.deletes.push(path);
+    this.files = this.files.filter((f) => f.path !== path);
+  }
+  push(batch: FileChangeEvent[]) { for (const h of this.handlers) h(batch); }
+}
+
+describe("AggregateFileSource", () => {
+  let ch: MockFileChannel;
+
+  beforeEach(() => {
+    ch = new MockFileChannel();
+    ch.files = [
+      { path: "manifest.json", content: '{"order":["a","b"]}' },
+      { path: "slides/slide-a.html", content: "<p>A</p>" },
+      { path: "slides/slide-b.html", content: "<p>B</p>" },
+    ];
+  });
+
+  test("initial load reconstructs the domain aggregate from files", async () => {
+    const s = new AggregateFileSource<Deck>(
+      { patterns: ["manifest.json", "slides/**/*.html"], load: loadDeck, save: saveDeck },
+      ch,
+    );
+    const events: SourceEvent<Deck>[] = [];
+    s.subscribe((e) => events.push(e));
+    await Promise.resolve();
+    expect(events).toHaveLength(1);
+    if (events[0].kind !== "value") throw new Error("expected value");
+    expect(events[0].origin).toBe("initial");
+    expect(events[0].value.order).toEqual(["a", "b"]);
+    expect(events[0].value.slides.a.html).toBe("<p>A</p>");
+  });
+
+  test("external file change re-runs load and emits external", async () => {
+    const s = new AggregateFileSource<Deck>(
+      { patterns: ["manifest.json", "slides/**/*.html"], load: loadDeck, save: saveDeck },
+      ch,
+    );
+    await Promise.resolve();
+    const events: SourceEvent<Deck>[] = [];
+    s.subscribe((e) => events.push(e));
+
+    ch.files = ch.files.map((f) =>
+      f.path === "slides/slide-a.html" ? { ...f, content: "<p>A edited by agent</p>" } : f,
+    );
+    ch.push([{ path: "slides/slide-a.html", content: "<p>A edited by agent</p>", origin: "external" }]);
+
+    expect(events).toHaveLength(1);
+    if (events[0].kind !== "value") throw new Error("expected value");
+    expect(events[0].origin).toBe("external");
+    expect(events[0].value.slides.a.html).toBe("<p>A edited by agent</p>");
+  });
+
+  test("write decomposes the aggregate via save() and produces channel writes + deletes", async () => {
+    const s = new AggregateFileSource<Deck>(
+      { patterns: ["manifest.json", "slides/**/*.html"], load: loadDeck, save: saveDeck },
+      ch,
+    );
+    await Promise.resolve();
+
+    const events: SourceEvent<Deck>[] = [];
+    s.subscribe((e) => events.push(e));
+
+    // Delete slide "b", add a new slide "c"
+    const next: Deck = {
+      order: ["a", "c"],
+      slides: {
+        a: { id: "a", html: "<p>A</p>" },
+        c: { id: "c", html: "<p>C (new)</p>" },
+      },
+    };
+    await s.write(next);
+
+    // save() should produce: write manifest.json, write slide-a (unchanged),
+    // write slide-c (new), delete slide-b
+    const writePaths = ch.writes.map((w) => w.path).sort();
+    expect(writePaths).toContain("manifest.json");
+    expect(writePaths).toContain("slides/slide-c.html");
+    expect(ch.deletes).toEqual(["slides/slide-b.html"]);
+
+    // And a self-origin event fires with the new aggregate
+    expect(events).toHaveLength(1);
+    if (events[0].kind !== "value") throw new Error("expected value");
+    expect(events[0].origin).toBe("self");
+    expect(events[0].value.order).toEqual(["a", "c"]);
+  });
+
+  test("load failure emits error, source stays live for future events", async () => {
+    ch.files = [{ path: "manifest.json", content: "{not json" }];
+    const s = new AggregateFileSource<Deck>(
+      { patterns: ["manifest.json", "slides/**/*.html"], load: loadDeck, save: saveDeck },
+      ch,
+    );
+    const events: SourceEvent<Deck>[] = [];
+    s.subscribe((e) => events.push(e));
+    await Promise.resolve();
+    expect(events).toHaveLength(1);
+    expect(events[0].kind).toBe("error");
+
+    // Recover with a valid manifest
+    ch.files = [
+      { path: "manifest.json", content: '{"order":["a"]}' },
+      { path: "slides/slide-a.html", content: "<p>A</p>" },
+    ];
+    ch.push([
+      { path: "manifest.json", content: '{"order":["a"]}', origin: "external" },
+    ]);
+    // First successful load post-error still fires as "initial"
+    const valueEvents = events.filter((e) => e.kind === "value");
+    expect(valueEvents).toHaveLength(1);
+    if (valueEvents[0].kind !== "value") throw new Error("expected value");
+    expect(valueEvents[0].origin).toBe("initial");
+  });
+
+  test("destroy unsubscribes from channel", () => {
+    const s = new AggregateFileSource<Deck>(
+      { patterns: ["manifest.json", "slides/**/*.html"], load: loadDeck, save: saveDeck },
+      ch,
+    );
+    expect(ch.handlers.size).toBe(1);
+    s.destroy();
+    expect(ch.handlers.size).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+Run: `bun test core/sources/__tests__/aggregate-file.test.ts 2>&1 | tail -10`
+Expected: module resolution error.
+
+---
+
+### Task 2.10: Implement `AggregateFileSource`
+
+**Files:**
+- Create: `core/sources/aggregate-file.ts`
+
+- [ ] **Step 1: Write the file**
+
+```ts
+import { BaseSource } from "./base.js";
+import type {
+  FileChannel,
+  FileChangeEvent,
+} from "../types/source.js";
+import type { ViewerFileContent } from "../types/viewer-contract.js";
+
+export interface AggregateFileConfig<T> {
+  /** All file path globs this aggregate depends on. Used to scope watching. */
+  patterns: string[];
+  /** Optional ignore globs. */
+  ignore?: string[];
+  /**
+   * Build the aggregate from the current file snapshot. Return null if the
+   * aggregate cannot be built (e.g. required files missing) — the source
+   * will stay in "no initial yet" state and a later snapshot change may
+   * succeed. Throw to emit an error event without killing the source.
+   */
+  load: (files: ReadonlyArray<ViewerFileContent>) => T | null;
+  /**
+   * Decompose a new aggregate value back into file-level operations.
+   * Called from write(). Receives the current (pre-write) snapshot so
+   * save can compute diffs (e.g. which slide files to delete when an
+   * id has been removed from a Deck).
+   */
+  save: (
+    value: T,
+    current: ReadonlyArray<ViewerFileContent>,
+  ) => {
+    writes: Array<{ path: string; content: string }>;
+    deletes: string[];
+  };
+}
+
+/**
+ * Multi-file domain aggregate source.
+ *
+ * Used when a mode's domain is a structured aggregate (a Deck, a Site,
+ * a Studio) that happens to be persisted across multiple files. The
+ * viewer consumes `Source<T>` where T is the domain type and never
+ * sees file paths; the provider handles translation to/from files.
+ *
+ * Origin handling: when a file change batch arrives, the provider
+ * re-runs `load()` against the full current snapshot. If the batch
+ * contains any `origin: "self"` entries, the emission is tagged "self"
+ * (our own write round-tripped); otherwise "external". The first
+ * successful load ever emits "initial" regardless of the triggering
+ * origin.
+ *
+ * Parse/load errors are non-fatal: they emit `{ kind: "error" }` and
+ * leave the source alive for future updates.
+ */
+export class AggregateFileSource<T> extends BaseSource<T> {
+  private unsubscribe: (() => void) | null = null;
+  private matcher: (path: string) => boolean;
+  private ignoreMatcher: (path: string) => boolean;
+  private hasEmittedInitial = false;
+
+  constructor(
+    private config: AggregateFileConfig<T>,
+    private channel: FileChannel,
+  ) {
+    super();
+    this.matcher = compileGlobList(config.patterns);
+    this.ignoreMatcher = compileGlobList(config.ignore ?? []);
+    this.unsubscribe = channel.subscribe((batch) => this.onBatch(batch));
+    queueMicrotask(() => this.tryLoad("initial"));
+  }
+
+  private onBatch(batch: FileChangeEvent[]): void {
+    if (this.isDestroyed) return;
+    const relevant = batch.some(
+      (ev) => this.matcher(ev.path) && !this.ignoreMatcher(ev.path),
+    );
+    if (!relevant) return;
+    const hasSelf = batch.some((ev) => ev.origin === "self");
+    const origin: "self" | "external" = hasSelf ? "self" : "external";
+    // If we've never successfully loaded, the first success still fires
+    // as "initial" — we treat initial-after-error as the first real observation.
+    const effectiveOrigin = this.hasEmittedInitial ? origin : "initial";
+    this.tryLoad(effectiveOrigin);
+  }
+
+  private tryLoad(origin: "initial" | "self" | "external"): void {
+    if (this.isDestroyed) return;
+    const files = this.channel.snapshot().filter(
+      (f) => this.matcher(f.path) && !this.ignoreMatcher(f.path),
+    );
+    let value: T | null;
+    try {
+      value = this.config.load(files);
+    } catch (err) {
+      this.emit({
+        kind: "error",
+        code: "E_LOAD",
+        message: (err as Error).message,
+      });
+      return;
+    }
+    if (value === null) {
+      // load returned null — aggregate not yet ready (missing required
+      // files). Silent: don't emit, don't error. A later file change
+      // may produce a valid aggregate.
+      return;
+    }
+    this.hasEmittedInitial = true;
+    this.emit({ kind: "value", value, origin });
+  }
+
+  protected async doWrite(value: T): Promise<void> {
+    const currentFiles = this.channel.snapshot().filter(
+      (f) => this.matcher(f.path) && !this.ignoreMatcher(f.path),
+    );
+    let ops: { writes: Array<{ path: string; content: string }>; deletes: string[] };
+    try {
+      ops = this.config.save(value, currentFiles);
+    } catch (err) {
+      this.emit({
+        kind: "error",
+        code: "E_SAVE",
+        message: (err as Error).message,
+      });
+      throw err;
+    }
+    // Execute the file operations in order: writes first, then deletes.
+    // A single save() producing both writes and deletes means the viewer
+    // has computed a complete new state; ordering only matters for
+    // observable intermediate states which we don't expose.
+    for (const w of ops.writes) {
+      await this.channel.write(w.path, w.content);
+    }
+    for (const d of ops.deletes) {
+      await this.channel.delete(d);
+    }
+    // Emit the self event after all file ops have been ack'd.
+    this.hasEmittedInitial = true;
+    this.emit({ kind: "value", value, origin: "self" });
+  }
+
+  destroy(): void {
+    this.unsubscribe?.();
+    this.unsubscribe = null;
+    super.destroy();
+  }
+}
+
+// Shared with file-glob — kept inline here to avoid cross-module imports
+// in this leaf file. If a third provider needs it, lift to sources/glob.ts.
+function compileGlobList(patterns: string[]): (path: string) => boolean {
+  if (patterns.length === 0) return () => false;
+  const regexes = patterns.map(compileGlob);
+  return (path: string) => regexes.some((r) => r.test(path));
+}
+
+function compileGlob(pattern: string): RegExp {
+  let p = pattern.replace(/^\.\//, "");
+  let rx = "";
+  let i = 0;
+  while (i < p.length) {
+    const ch = p[i];
+    if (ch === "*") {
+      if (p[i + 1] === "*") {
+        rx += ".*";
+        i += 2;
+        if (p[i] === "/") i++;
+      } else {
+        rx += "[^/]*";
+        i++;
+      }
+    } else if (ch === "?") {
+      rx += "[^/]";
+      i++;
+    } else if ("\\^$.|+()[]{}".includes(ch)) {
+      rx += "\\" + ch;
+      i++;
+    } else {
+      rx += ch;
+      i++;
+    }
+  }
+  return new RegExp("^" + rx + "$");
+}
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `bun test core/sources/__tests__/aggregate-file.test.ts 2>&1 | tail -20`
+Expected: 5 pass, 0 fail.
+
+---
+
+### Task 2.11: Create sources barrel + built-in registry
+
+**Files:**
+- Create: `core/sources/index.ts`
+
+- [ ] **Step 1: Write the file**
+
+```ts
+import type { SourceProvider, SourceContext, Source } from "../types/source.js";
+import type { ViewerFileContent } from "../types/viewer-contract.js";
+import { MemorySource, type MemorySourceConfig } from "./memory.js";
+import { FileGlobSource, type FileGlobConfig } from "./file-glob.js";
+import { JsonFileSource, type JsonFileConfig } from "./json-file.js";
+import { AggregateFileSource, type AggregateFileConfig } from "./aggregate-file.js";
+
+export { BaseSource } from "./base.js";
+export { MemorySource, type MemorySourceConfig } from "./memory.js";
+export { FileGlobSource, type FileGlobConfig } from "./file-glob.js";
+export { JsonFileSource, type JsonFileConfig } from "./json-file.js";
+export { AggregateFileSource, type AggregateFileConfig } from "./aggregate-file.js";
+
+/**
+ * The four built-in providers, ready to register with a SourceRegistry.
+ * Ordering matters only for debug output; providers are keyed by `kind`.
+ */
+export const BUILT_IN_PROVIDERS: SourceProvider[] = [
+  {
+    kind: "memory",
+    create<T>(config: unknown, _ctx: SourceContext): Source<T> {
+      return new MemorySource<T>((config ?? {}) as MemorySourceConfig<T>);
+    },
+  },
+  {
+    kind: "file-glob",
+    create<T>(config: unknown, ctx: SourceContext): Source<T> {
+      if (!ctx.files) {
+        throw new Error(
+          "file-glob source requires SourceContext.files (FileChannel). " +
+            "This usually means the provider is being instantiated outside " +
+            "the browser runtime.",
+        );
+      }
+      const fgc = config as FileGlobConfig;
+      // The generic T is pinned to ViewerFileContent[] at the call site,
+      // but we return Source<T> here because the registry signature is
+      // erased. Callers passing the wrong T get a TS error at the
+      // manifest declaration site, not here.
+      return new FileGlobSource(fgc, ctx.files) as unknown as Source<T>;
+    },
+  },
+  {
+    kind: "json-file",
+    create<T>(config: unknown, ctx: SourceContext): Source<T> {
+      if (!ctx.files) {
+        throw new Error(
+          "json-file source requires SourceContext.files (FileChannel).",
+        );
+      }
+      const jfc = config as JsonFileConfig<T>;
+      return new JsonFileSource<T>(jfc, ctx.files);
+    },
+  },
+  {
+    kind: "aggregate-file",
+    create<T>(config: unknown, ctx: SourceContext): Source<T> {
+      if (!ctx.files) {
+        throw new Error(
+          "aggregate-file source requires SourceContext.files (FileChannel).",
+        );
+      }
+      const afc = config as AggregateFileConfig<T>;
+      return new AggregateFileSource<T>(afc, ctx.files);
+    },
+  },
+];
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `bun run tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 3: Run the full sources test suite**
+
+Run: `bun test core/sources/ 2>&1 | tail -15`
+Expected: 44 tests passing (16 base + 5 memory + 8 file-glob + 10 json-file + 5 aggregate-file).
+
+---
+
+### Task 2.12: Commit P2
+
+- [ ] **Step 1: Stage and commit**
+
+```bash
+git add \
+  core/sources/base.ts \
+  core/sources/memory.ts \
+  core/sources/file-glob.ts \
+  core/sources/json-file.ts \
+  core/sources/aggregate-file.ts \
+  core/sources/index.ts \
+  core/sources/__tests__/base.test.ts \
+  core/sources/__tests__/memory.test.ts \
+  core/sources/__tests__/file-glob.test.ts \
+  core/sources/__tests__/json-file.test.ts \
+  core/sources/__tests__/aggregate-file.test.ts
+
+git commit -m "$(cat <<'EOF'
+feat(source): BaseSource + four built-in providers (P2)
+
+Implements the four invariants of Source<T> in a single abstract base
+(BaseSource) that concrete providers extend. Adds four built-in
+providers covering the full domain-to-storage spectrum for every
+current viewer mode.
+
+- core/sources/base.ts: Promise-queue write serialization with
+  time-locked Promises, origin-tagged emit, idempotent destroy,
+  listener isolation on throw
+- core/sources/memory.ts: ephemeral in-process reference impl
+- core/sources/file-glob.ts: multi-file aggregate (domain IS files),
+  read-only via write(); glob compiled with minimal subset matcher
+  (*, **, ?) covering all existing watchPatterns usage
+- core/sources/json-file.ts: single structured file, self-echo drop
+  based on FileChannel origin tag, non-fatal parse errors
+- core/sources/aggregate-file.ts: multi-file domain aggregate —
+  load(files) → T and save(T, current) → { writes, deletes }. Lets
+  slide / webcraft / illustrate viewers consume typed domain objects
+  (Deck, Site, Studio) without touching file paths. Requires the
+  FileChannel.delete() method which is wired in P3 Task 3.3.
+- core/sources/index.ts: BUILT_IN_PROVIDERS registry (4 kinds)
+- 44 bun:test cases across five __tests__ files
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+
+## Phase 3: Runtime integration
+
+Phase 3 wires the contract into the real runtime: server-side origin tagging, the browser-side FileChannel, the SourceRegistry, the manifest synthesis fallback, the `sources` prop on ViewerPreviewProps, and the `useSource` React hook. By the end of P3, every mode continues to work identically (because `useViewerProps` still hands `files` through) but a new `sources.files` prop also exists and is identical in content.
+
+P3 does NOT migrate any mode. Mode migrations are P5.
+
+### Task 3.1: Server-side `pendingSelfWrites` in the file watcher
+
+**Files:**
+- Modify: `server/file-watcher.ts`
+
+- [ ] **Step 1: Add the pendingSelfWrites module state**
+
+Open `server/file-watcher.ts`. At the top of the file, below the existing imports, add:
+
+```ts
+/**
+ * pendingSelfWrites is the ONLY place in the system where viewer-origin
+ * writes are identified. When the /api/files POST handler receives a
+ * write, it calls `registerSelfWrite(path, content)` here. When chokidar
+ * subsequently fires for that path, we look up the entry and tag the
+ * outgoing FileUpdate with origin: "self" if the content matches. Entries
+ * auto-expire after PENDING_SELF_WRITE_TTL_MS to guarantee an unmatched
+ * registration doesn't poison a later legitimate external edit.
+ */
+const PENDING_SELF_WRITE_TTL_MS = 5000;
+
+interface PendingSelfWrite {
+  content: string;
+  expiresAt: number;
+}
+
+// path -> queue of pending entries (one path can have multiple writes
+// in flight back-to-back; each chokidar echo consumes the oldest match)
+const pendingSelfWrites = new Map<string, PendingSelfWrite[]>();
+
+export function registerSelfWrite(relPath: string, content: string): void {
+  const entry: PendingSelfWrite = {
+    content,
+    expiresAt: Date.now() + PENDING_SELF_WRITE_TTL_MS,
+  };
+  const existing = pendingSelfWrites.get(relPath) ?? [];
+  existing.push(entry);
+  pendingSelfWrites.set(relPath, existing);
+}
+
+/**
+ * Consume a pending self-write entry if one exists matching this content.
+ * Returns true if matched (→ origin: "self"); false otherwise (→
+ * origin: "external").
+ *
+ * The matching strategy is content equality. An expired entry is dropped
+ * without matching so a stale registration cannot mis-tag a later edit.
+ */
+function consumeSelfWrite(relPath: string, content: string): boolean {
+  const queue = pendingSelfWrites.get(relPath);
+  if (!queue || queue.length === 0) return false;
+  const now = Date.now();
+  // Drop expired entries from the head.
+  while (queue.length > 0 && queue[0].expiresAt < now) {
+    queue.shift();
+  }
+  if (queue.length === 0) {
+    pendingSelfWrites.delete(relPath);
+    return false;
+  }
+  // Pop the oldest matching entry.
+  const idx = queue.findIndex((e) => e.content === content);
+  if (idx < 0) return false;
+  queue.splice(idx, 1);
+  if (queue.length === 0) pendingSelfWrites.delete(relPath);
+  return true;
+}
+```
+
+- [ ] **Step 2: Extend the `FileUpdate` type with `origin`**
+
+Still in `server/file-watcher.ts`, find the `FileUpdate` interface (around line 70). Change:
+
+```ts
+export interface FileUpdate {
+  path: string;
+  content: string;
+}
+```
+
+to:
+
+```ts
+export interface FileUpdate {
+  path: string;
+  content: string;
+  /**
+   * Origin tag added by the file watcher. "self" if this change matches
+   * a pending registerSelfWrite entry (i.e. it's the echo of a viewer
+   * write routed through /api/files); "external" otherwise. Always
+   * present on updates emitted after P3.
+   */
+  origin: "self" | "external";
+}
+```
+
+- [ ] **Step 3: Tag outgoing updates in the chokidar handler**
+
+Still in `server/file-watcher.ts`, find the `startFileWatcher` function. Inside the chokidar event handler (around line 160 — the place where a file change becomes a `FileUpdate` object), change the object literal from:
+
+```ts
+updates.push({ path: relPath, content });
+```
+
+to:
+
+```ts
+const origin: "self" | "external" = consumeSelfWrite(relPath, content) ? "self" : "external";
+updates.push({ path: relPath, content, origin });
+```
+
+Also update the image special-case branch (around line 165 — where `content: ""` is pushed for an image change) to include `origin: "external"`, since image changes are never self-writes from a viewer:
+
+```ts
+updates.push({ path: relPath, content: "", origin: "external" });
+```
+
+- [ ] **Step 4: Typecheck**
+
+Run: `bun run tsc --noEmit 2>&1 | tee /tmp/tsc.log | tail -20`
+Expected: errors in `bin/pneuma.ts` and `src/ws.ts` about `FileUpdate` missing `origin` when constructed at the broadcast sites. That's expected — Task 3.2 fixes them. Proceed if the only errors are the expected ones.
+
+---
+
+### Task 3.2: Wire `origin` through the broadcast and browser store
+
+**Files:**
+- Modify: `bin/pneuma.ts` (two broadcast sites)
+- Modify: `src/ws.ts` (content_update handler)
+- Modify: `src/store/workspace-slice.ts` (updateFiles signature)
+
+- [ ] **Step 1: Update `bin/pneuma.ts` broadcast callback**
+
+Find both `startFileWatcher(workspace, manifest.viewer, (files) => {` call sites (around lines 1518 and 1790). Neither site needs code changes per se because `files: FileUpdate[]` now carries origin inside each entry — the broadcast forwards whatever shape the watcher emits. BUT the WS message shape changes to include per-file origin.
+
+Update the broadcast message construction at both sites from:
+
+```ts
+wsBridge.broadcastToSession(sessionId, { type: "content_update", files });
+```
+
+to:
+
+```ts
+wsBridge.broadcastToSession(sessionId, {
+  type: "content_update",
+  files,  // each entry is { path, content, origin }
+});
+```
+
+(If the line was already exactly this shape, leave it — the change is that `files` now carries origin, not that the message structure changes. Confirm both sites compile.)
+
+- [ ] **Step 2: Update `src/ws.ts` content_update handler**
+
+Find the `case "content_update":` block (around lines 630–639). Change the filtering loop from:
+
+```ts
+case "content_update": {
+  if (store.replayMode) break;
+  const IMAGE_RE = /\.(png|jpe?g|gif|webp|svg)$/i;
+  const contentFiles = data.files.filter((f: { path: string; content: string }) => !IMAGE_RE.test(f.path));
+  const hasImageChange = data.files.some((f: { path: string; content: string }) => IMAGE_RE.test(f.path));
+  if (contentFiles.length > 0) store.updateFiles(contentFiles);
+  if (hasImageChange) store.bumpImageTick();
+  break;
+}
+```
+
+to:
+
+```ts
+case "content_update": {
+  if (store.replayMode) break;
+  const IMAGE_RE = /\.(png|jpe?g|gif|webp|svg)$/i;
+  type Incoming = { path: string; content: string; origin?: "self" | "external" };
+  const contentFiles = (data.files as Incoming[])
+    .filter((f) => !IMAGE_RE.test(f.path))
+    .map((f) => ({ ...f, origin: f.origin ?? "external" }));
+  const hasImageChange = (data.files as Incoming[]).some((f) => IMAGE_RE.test(f.path));
+  if (contentFiles.length > 0) store.updateFiles(contentFiles);
+  if (hasImageChange) store.bumpImageTick();
+  break;
+}
+```
+
+The `origin: f.origin ?? "external"` default exists for robustness against old server versions that don't yet tag — it's a belt-and-suspenders fallback during rolling upgrades.
+
+- [ ] **Step 3: Update `workspace-slice.ts` to accept and forward origin**
+
+In `src/store/workspace-slice.ts`:
+
+(a) Add an import of a local event bus at the top:
+
+```ts
+import { fileEventBus } from "../runtime/file-event-bus.js";
+```
+
+(b) Update the `FileContent` type used by the slice to carry optional origin. Find (around lines 1–6):
+
+```ts
+import type { FileContent, ContentSet, WorkspaceItem } from "../types.js";
+```
+
+Leave this. Then, in the slice body, change the `updateFiles` signature from:
+
+```ts
+updateFiles: (files: FileContent[]) => void;
+```
+
+to:
+
+```ts
+updateFiles: (files: Array<FileContent & { origin?: "self" | "external" }>) => void;
+```
+
+(c) In the `updateFiles` implementation (around lines 58–113), after the `for (const u of updates)` loop and before `return`, add a forwarding call to the event bus:
+
+```ts
+// Forward to file-event-bus so FileGlobSource / JsonFileSource
+// subscribers see the change. The bus is browser-side only and
+// its dispatch is synchronous — providers observe the change on
+// the same tick the store update happens.
+fileEventBus.publish(
+  updates.map((u) => ({
+    path: u.path,
+    content: u.content,
+    origin: u.origin ?? "external",
+  })),
+);
+```
+
+- [ ] **Step 4: Create the event bus file**
+
+**Files:**
+- Create: `src/runtime/file-event-bus.ts`
+
+```ts
+import type { FileChangeEvent } from "../../core/types/source.js";
+
+/**
+ * Browser-side singleton pub/sub for file change events. The workspace
+ * slice's updateFiles() publishes to this bus; the FileChannel
+ * implementation (src/runtime/file-channel.ts) subscribes and re-emits
+ * to its own subscribers (which are Source instances).
+ *
+ * We use a module-level singleton because there is only ever one
+ * workspace per browser tab in Pneuma. A multi-workspace future would
+ * need to scope this to a session id.
+ */
+class FileEventBus {
+  private handlers = new Set<(batch: FileChangeEvent[]) => void>();
+
+  subscribe(handler: (batch: FileChangeEvent[]) => void): () => void {
+    this.handlers.add(handler);
+    return () => {
+      this.handlers.delete(handler);
+    };
+  }
+
+  publish(batch: FileChangeEvent[]): void {
+    // Snapshot to allow handlers to subscribe/unsubscribe during delivery.
+    for (const handler of Array.from(this.handlers)) {
+      try {
+        handler(batch);
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error("[file-event-bus] handler threw", err);
+      }
+    }
+  }
+}
+
+export const fileEventBus = new FileEventBus();
+```
+
+- [ ] **Step 5: Typecheck**
+
+Run: `bun run tsc --noEmit 2>&1 | tail -20`
+Expected: no errors. If you see errors about `FileContent` shape, ensure the origin field is optional in both the import and the slice signature.
+
+- [ ] **Step 6: Do NOT commit yet.** P3 commits once the full runtime is wired.
+
+---
+
+### Task 3.3: Wire `/api/files` POST + add `DELETE /api/files` for self-tagged mutations
+
+**Files:**
+- Modify: `server/file-watcher.ts` (extend to register self-deletes)
+- Modify: `server/index.ts` (POST + new DELETE route)
+
+- [ ] **Step 1: Extend `server/file-watcher.ts` with a `registerSelfDelete` + delete-event handling**
+
+In `server/file-watcher.ts`, add a second TTL map for pending self-deletes alongside `pendingSelfWrites`:
+
+```ts
+const pendingSelfDeletes = new Map<string, number /* expiresAt */>();
+
+export function registerSelfDelete(relPath: string): void {
+  pendingSelfDeletes.set(relPath, Date.now() + PENDING_SELF_WRITE_TTL_MS);
+}
+
+function consumeSelfDelete(relPath: string): boolean {
+  const exp = pendingSelfDeletes.get(relPath);
+  if (!exp) return false;
+  if (exp < Date.now()) {
+    pendingSelfDeletes.delete(relPath);
+    return false;
+  }
+  pendingSelfDeletes.delete(relPath);
+  return true;
+}
+```
+
+In the chokidar handler, add an `unlink` event branch (currently the watcher only handles `add`/`change`). When a file is deleted, emit a `FileUpdate` with empty content and `origin: consumeSelfDelete(relPath) ? "self" : "external"`. Extend the `FileUpdate` type to include an optional `deleted: true` discriminator so downstream consumers can distinguish "content became empty string" from "file gone":
+
+```ts
+export interface FileUpdate {
+  path: string;
+  content: string;
+  origin: "self" | "external";
+  deleted?: boolean;   // true for unlink events; content is "" in that case
+}
+```
+
+The chokidar wiring:
+
+```ts
+watcher.on("unlink", (absPath) => {
+  const relPath = path.relative(workspace, absPath);
+  if (!matchesWatchPatterns(relPath)) return;
+  const origin: "self" | "external" = consumeSelfDelete(relPath) ? "self" : "external";
+  enqueueUpdate({ path: relPath, content: "", origin, deleted: true });
+});
+```
+
+- [ ] **Step 2: Import helpers in `server/index.ts`**
+
+```ts
+import { startFileWatcher, startProxyWatcher, registerSelfWrite, registerSelfDelete } from "./file-watcher.js";
+```
+
+- [ ] **Step 2: Call `registerSelfWrite` before writing to disk**
+
+Find the `/api/files` POST handler (around lines 1715–1738). After the `pathStartsWith` check passes and BEFORE the `writeFileSync` call, add:
+
+```ts
+// Register this write as self-originated so the chokidar echo is
+// tagged origin: "self" when it arrives. Registration happens BEFORE
+// the disk write so there's no window where the echo could arrive
+// ahead of the registration.
+//
+// For data-URL content we register the decoded binary, because that's
+// what chokidar will read back from disk.
+const contentForTag = dataUrlMatch
+  ? Buffer.from(dataUrlMatch[1], "base64").toString("binary")
+  : body.content;
+registerSelfWrite(relPath, contentForTag);
+```
+
+Wait — there's a subtle issue. chokidar reads the file as UTF-8 text for content files (see `server/file-watcher.ts` around line 150). A binary file written via data URL will be read back as text with mojibake characters; the `binary` → `utf-8` encoding mismatch means the hash won't match. For now, only text writes need self-tagging. Binary writes (images) already trigger the cache-bust-only path in the watcher (empty content) and don't need origin tracking. Simplify: only register when NOT a data URL.
+
+Replace the block with:
+
+```ts
+// Register this write as self-originated so the chokidar echo is
+// tagged origin: "self" when it arrives. Binary writes (data URLs)
+// take the image-cache-bust path in the watcher and don't need
+// origin tracking.
+if (!dataUrlMatch) {
+  registerSelfWrite(relPath, body.content);
+}
+```
+
+- [ ] **Step 3: Add the `DELETE /api/files` route**
+
+Below the `app.post("/api/files", ...)` route, add:
+
+```ts
+app.delete("/api/files", async (c) => {
+  const relPath = c.req.query("path");
+  if (!relPath || typeof relPath !== "string") {
+    return c.json({ error: "Missing path query parameter" }, 400);
+  }
+  const absPath = join(workspace, relPath);
+  if (!pathStartsWith(absPath, workspace)) {
+    return c.json({ error: "Forbidden" }, 403);
+  }
+  try {
+    // Register the self-delete BEFORE unlinking so the chokidar unlink
+    // event is tagged origin: "self" when it arrives.
+    registerSelfDelete(relPath);
+    if (existsSync(absPath)) {
+      unlinkSync(absPath);
+    }
+    return c.json({ ok: true });
+  } catch (err) {
+    return c.json({ error: "Failed to delete file" }, 500);
+  }
+});
+```
+
+Add `existsSync` and `unlinkSync` to the `node:fs` imports at the top of `server/index.ts` if not already present.
+
+- [ ] **Step 4: Typecheck and smoke-test**
+
+Run: `bun run tsc --noEmit 2>&1 | tail -10`
+Expected: clean.
+
+Start dev server: `bun run dev doc --port 17996 --no-open`, wait for "listening", then in another terminal:
+
+```bash
+curl -sX POST http://localhost:17996/api/files \
+  -H "Content-Type: application/json" \
+  -d '{"path":"smoke.md","content":"hello world"}'
+curl -sX DELETE "http://localhost:17996/api/files?path=smoke.md"
+```
+
+Expected: both return `{"ok":true}`. Open the dev server's browser tab, verify `smoke.md` appears then disappears. Kill the dev server.
+
+---
+
+### Task 3.4: Implement browser-side `FileChannel`
+
+**Files:**
+- Create: `src/runtime/file-channel.ts`
+
+The FileChannel is the bridge that turns the existing store + ws + POST /api/files plumbing into the `FileChannel` shape that providers consume via `SourceContext.files`.
+
+- [ ] **Step 1: Write the file**
+
+```ts
+import type {
+  FileChannel,
+  FileChangeEvent,
+} from "../../core/types/source.js";
+import type { ViewerFileContent } from "../../core/types/viewer-contract.js";
+import { fileEventBus } from "./file-event-bus.js";
+import { useStore } from "../store/index.js";
+
+/**
+ * Get the API base URL (dev proxy vs prod same-origin). Mirrors the
+ * helper used inline in several mode viewers — centralized here so
+ * every source gets the same resolution.
+ */
+function getApiBase(): string {
+  if (import.meta.env.DEV) {
+    return `http://${location.hostname}:${import.meta.env.VITE_API_PORT || "17007"}`;
+  }
+  return "";
+}
+
+/**
+ * Browser-side FileChannel implementation. Backed by:
+ *   - snapshot: the workspace slice `files` array
+ *   - subscribe: fileEventBus
+ *   - write: POST /api/files
+ *
+ * One instance per active mode. The runtime creates it in useViewerProps
+ * and destroys it on mode switch.
+ */
+export class BrowserFileChannel implements FileChannel {
+  private unsubBus: (() => void) | null = null;
+  private handlers = new Set<(batch: FileChangeEvent[]) => void>();
+
+  constructor() {
+    this.unsubBus = fileEventBus.subscribe((batch) => this.dispatch(batch));
+  }
+
+  snapshot(): ReadonlyArray<ViewerFileContent> {
+    // Read directly from the store — synchronous, same source of truth
+    // that useViewerProps uses to build props.files.
+    const files = useStore.getState().files;
+    return files.map((f) => ({ path: f.path, content: f.content }));
+  }
+
+  subscribe(handler: (batch: FileChangeEvent[]) => void): () => void {
+    this.handlers.add(handler);
+    return () => {
+      this.handlers.delete(handler);
+    };
+  }
+
+  async write(path: string, content: string): Promise<void> {
+    const res = await fetch(`${getApiBase()}/api/files`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ path, content }),
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      throw new Error(`POST /api/files failed: ${res.status} ${text}`);
+    }
+  }
+
+  async delete(path: string): Promise<void> {
+    const url = `${getApiBase()}/api/files?path=${encodeURIComponent(path)}`;
+    const res = await fetch(url, { method: "DELETE" });
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      throw new Error(`DELETE /api/files failed: ${res.status} ${text}`);
+    }
+  }
+
+  private dispatch(batch: FileChangeEvent[]): void {
+    for (const handler of Array.from(this.handlers)) {
+      try {
+        handler(batch);
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error("[file-channel] handler threw", err);
+      }
+    }
+  }
+
+  destroy(): void {
+    this.unsubBus?.();
+    this.unsubBus = null;
+    this.handlers.clear();
+  }
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `bun run tsc --noEmit 2>&1 | tail -10`
+Expected: clean.
+
+---
+
+### Task 3.5: Implement `SourceRegistry`
+
+**Files:**
+- Create: `core/source-registry.ts`
+- Create: `core/__tests__/source-registry.test.ts`
+
+- [ ] **Step 1: Write the failing test file first**
+
+```ts
+import { describe, test, expect } from "bun:test";
+import { SourceRegistry } from "../source-registry.js";
+import { BUILT_IN_PROVIDERS } from "../sources/index.js";
+import type {
+  Source,
+  SourceProvider,
+  SourceContext,
+  FileChannel,
+} from "../types/source.js";
+import type { ModeManifest } from "../types/mode-manifest.js";
+
+function noopCtx(files?: FileChannel): SourceContext {
+  return {
+    workspace: "/tmp/test",
+    log: () => {},
+    signal: new AbortController().signal,
+    files,
+  };
+}
+
+describe("SourceRegistry", () => {
+  test("registers built-in providers and looks them up by kind", () => {
+    const reg = new SourceRegistry();
+    for (const p of BUILT_IN_PROVIDERS) reg.register(p);
+    expect(reg.has("memory")).toBe(true);
+    expect(reg.has("file-glob")).toBe(true);
+    expect(reg.has("json-file")).toBe(true);
+    expect(reg.has("redis")).toBe(false);
+  });
+
+  test("instantiates a memory source from a manifest declaration", async () => {
+    const reg = new SourceRegistry();
+    for (const p of BUILT_IN_PROVIDERS) reg.register(p);
+    const manifest: Pick<ModeManifest, "sources"> = {
+      sources: {
+        state: { kind: "memory", config: { initial: 42 } },
+      },
+    };
+    const instances = reg.instantiateAll(manifest.sources ?? {}, noopCtx());
+    expect(instances.state).toBeDefined();
+    await Promise.resolve();
+    expect(instances.state.current()).toBe(42);
+  });
+
+  test("instantiateAll throws if an unknown kind is declared", () => {
+    const reg = new SourceRegistry();
+    for (const p of BUILT_IN_PROVIDERS) reg.register(p);
+    expect(() =>
+      reg.instantiateAll(
+        { x: { kind: "does-not-exist", config: {} } },
+        noopCtx(),
+      ),
+    ).toThrow(/does-not-exist/);
+  });
+
+  test("destroyAll destroys every instance", async () => {
+    const reg = new SourceRegistry();
+    for (const p of BUILT_IN_PROVIDERS) reg.register(p);
+    const instances = reg.instantiateAll(
+      { a: { kind: "memory" }, b: { kind: "memory" } },
+      noopCtx(),
+    );
+    reg.destroyAll(instances);
+    // After destroy, current() is null even if an initial was queued
+    await Promise.resolve();
+    expect(instances.a.current()).toBeNull();
+    expect(instances.b.current()).toBeNull();
+  });
+
+  test("registering a provider with a duplicate kind throws", () => {
+    const reg = new SourceRegistry();
+    const p: SourceProvider = {
+      kind: "memory",
+      create: () => ({
+        current: () => null,
+        subscribe: () => () => {},
+        write: async () => {},
+        destroy: () => {},
+      }),
+    };
+    reg.register(p);
+    expect(() => reg.register(p)).toThrow(/memory/);
+  });
+
+  test("synthesizeDefault creates a file-glob source from viewer.watchPatterns if sources is absent", () => {
+    const reg = new SourceRegistry();
+    for (const p of BUILT_IN_PROVIDERS) reg.register(p);
+    const manifestLike = {
+      viewer: {
+        watchPatterns: ["**/*.md"],
+        ignorePatterns: ["node_modules/**"],
+      },
+      sources: undefined,
+    };
+    const effective = SourceRegistry.effectiveSources(manifestLike as unknown as ModeManifest);
+    expect(effective.files.kind).toBe("file-glob");
+    const cfg = effective.files.config as { patterns: string[]; ignore?: string[] };
+    expect(cfg.patterns).toEqual(["**/*.md"]);
+    expect(cfg.ignore).toEqual(["node_modules/**"]);
+  });
+
+  test("effectiveSources preserves an explicit sources block unchanged", () => {
+    const manifestLike = {
+      viewer: { watchPatterns: ["**/*.md"], ignorePatterns: [] },
+      sources: { custom: { kind: "memory", config: { initial: 1 } } },
+    };
+    const effective = SourceRegistry.effectiveSources(manifestLike as unknown as ModeManifest);
+    expect(effective).toEqual({
+      custom: { kind: "memory", config: { initial: 1 } },
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Confirm tests fail**
+
+Run: `bun test core/__tests__/source-registry.test.ts 2>&1 | tail -10`
+Expected: module resolution error.
+
+- [ ] **Step 3: Implement `core/source-registry.ts`**
+
+```ts
+import type {
+  Source,
+  SourceProvider,
+  SourceContext,
+  SourceDescriptor,
+} from "./types/source.js";
+import type { ModeManifest } from "./types/mode-manifest.js";
+
+export class SourceRegistry {
+  private providers = new Map<string, SourceProvider>();
+
+  register(provider: SourceProvider): void {
+    if (this.providers.has(provider.kind)) {
+      throw new Error(
+        `SourceRegistry: provider kind "${provider.kind}" is already registered`,
+      );
+    }
+    this.providers.set(provider.kind, provider);
+  }
+
+  has(kind: string): boolean {
+    return this.providers.has(kind);
+  }
+
+  instantiate(
+    descriptor: SourceDescriptor,
+    ctx: SourceContext,
+  ): Source<unknown> {
+    const provider = this.providers.get(descriptor.kind);
+    if (!provider) {
+      throw new Error(
+        `SourceRegistry: no provider registered for kind "${descriptor.kind}"`,
+      );
+    }
+    return provider.create<unknown>(descriptor.config, ctx);
+  }
+
+  instantiateAll(
+    descriptors: Record<string, SourceDescriptor>,
+    ctx: SourceContext,
+  ): Record<string, Source<unknown>> {
+    const out: Record<string, Source<unknown>> = {};
+    for (const [id, desc] of Object.entries(descriptors)) {
+      out[id] = this.instantiate(desc, ctx);
+    }
+    return out;
+  }
+
+  destroyAll(instances: Record<string, Source<unknown>>): void {
+    for (const instance of Object.values(instances)) {
+      try {
+        instance.destroy();
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error("[source-registry] destroy threw", err);
+      }
+    }
+  }
+
+  /**
+   * Compute the effective `sources` declaration for a manifest. If the
+   * manifest declares `sources` explicitly, returns it unchanged. If not,
+   * synthesizes a single `files` source from `viewer.watchPatterns` /
+   * `viewer.ignorePatterns` for backward compatibility. This is how every
+   * pre-migration mode continues to work without touching its manifest.
+   */
+  static effectiveSources(
+    manifest: ModeManifest,
+  ): Record<string, SourceDescriptor> {
+    if (manifest.sources && Object.keys(manifest.sources).length > 0) {
+      return manifest.sources;
+    }
+    return {
+      files: {
+        kind: "file-glob",
+        config: {
+          patterns: manifest.viewer.watchPatterns,
+          ignore: manifest.viewer.ignorePatterns,
+        },
+      },
+    };
+  }
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `bun test core/__tests__/source-registry.test.ts 2>&1 | tail -15`
+Expected: 7 pass, 0 fail.
+
+---
+
+### Task 3.6: Expose `sources` and `fileChannel` on `ViewerPreviewProps`
+
+**Files:**
+- Modify: `core/types/viewer-contract.ts`
+
+- [ ] **Step 1: Add the import**
+
+Near the top of the file, add:
+
+```ts
+import type { Source, FileChannel } from "./source.js";
+```
+
+- [ ] **Step 2: Add `sources` and `fileChannel` to `ViewerPreviewProps`**
+
+Find the `ViewerPreviewProps` interface (around lines 190–233). Add both new fields just after the existing `files` field:
+
+```ts
+  /**
+   * @deprecated Since P3 of the source-abstraction work. Still populated
+   * for backward compatibility during the P3→P5 migration window. Will
+   * be removed in the final P5 commit. New or migrated viewers should
+   * consume props.sources instead.
+   */
+  files: ViewerFileContent[];
+
+  /**
+   * Source map. Keys come from `manifest.sources` (or the synthesized
+   * default `{ files: file-glob }` for unmigrated modes). Viewers
+   * consume sources via the `useSource` hook from src/hooks/useSource.ts.
+   * Each Source<T> delivers typed, origin-tagged events and, for
+   * write-capable providers, exposes a write() method.
+   */
+  sources: Record<string, Source<unknown>>;
+
+  /**
+   * Direct file I/O channel for viewers with dynamic write targets
+   * (e.g., a text editor where the active file is user-selected).
+   * Writes through this channel are origin-tagged server-side
+   * identically to Source.write() — viewers do not need to
+   * maintain echo-detection state.
+   *
+   * Viewers with a static, declared write target should use a
+   * `json-file` source in their manifest instead of this prop.
+   *
+   * Introduced in P3 for use by all P5 mode migrations. Modes that
+   * never write through the viewer (illustrate, remotion, mode-maker,
+   * diagram) can ignore this prop — it's still present on every
+   * viewer because ViewerPreviewProps has no per-mode conditional
+   * typing.
+   */
+  fileChannel: FileChannel;
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run: `bun run tsc --noEmit 2>&1 | tail -20`
+Expected: errors in `src/App.tsx` about `sources` and `fileChannel` being missing from the return object of `useViewerProps`. That's expected — Task 3.7 fixes it.
+
+---
+
+### Task 3.7: Build and destroy sources in `useViewerProps`
+
+**Files:**
+- Modify: `src/App.tsx`
+
+This is the most architecturally critical task in P3 — it's where mode lifecycle meets source lifecycle.
+
+- [ ] **Step 1: Add imports to `src/App.tsx`**
+
+Near the top of the file, among the existing imports, add:
+
+```ts
+import { SourceRegistry } from "../core/source-registry.js";
+import { BUILT_IN_PROVIDERS } from "../core/sources/index.js";
+import { BrowserFileChannel } from "./runtime/file-channel.js";
+import type { Source, FileChannel } from "../core/types/source.js";
+```
+
+- [ ] **Step 2: Add a `useSourceInstances` hook above `useViewerProps`**
+
+Insert this helper hook just before the `useViewerProps` function definition (around line 70):
+
+```ts
+/**
+ * Instantiate sources AND the FileChannel for the current mode. Returns
+ * both as a single object so useViewerProps can pass each through to the
+ * viewer as a separate prop. Rebuilds (destroying the old set) whenever
+ * the active mode changes.
+ *
+ * This is the lifecycle boundary for sources. When a user switches modes
+ * in the launcher, the old mode's sources are destroyed here and the new
+ * mode's sources are created against a fresh FileChannel + SourceRegistry.
+ * Sources and the FileChannel never outlive their mode.
+ */
+function useSourceInstances(): {
+  sources: Record<string, Source<unknown>>;
+  channel: FileChannel;
+} {
+  const manifest = useStore((s) => s.modeManifest);
+  const [state, setState] = useState<{
+    sources: Record<string, Source<unknown>>;
+    channel: FileChannel;
+  }>(() => ({ sources: {}, channel: new BrowserFileChannel() }));
+
+  useEffect(() => {
+    if (!manifest) {
+      setState({ sources: {}, channel: new BrowserFileChannel() });
+      return;
+    }
+    const channel = new BrowserFileChannel();
+    const registry = new SourceRegistry();
+    for (const provider of BUILT_IN_PROVIDERS) registry.register(provider);
+    const ctx = {
+      workspace: "",  // workspace is known to the server; providers
+                       // that need it get it via FileChannel instead
+      log: (msg: string) => { console.debug("[source]", msg); },
+      signal: new AbortController().signal,
+      files: channel,
+    };
+    const effective = SourceRegistry.effectiveSources(manifest);
+    const built = registry.instantiateAll(effective, ctx);
+    setState({ sources: built, channel });
+    return () => {
+      registry.destroyAll(built);
+      (channel as BrowserFileChannel).destroy();
+    };
+  }, [manifest]);
+
+  return state;
+}
+```
+
+- [ ] **Step 3: Wire `sources` and `fileChannel` into the props returned by `useViewerProps`**
+
+Near the top of `useViewerProps` (around line 70), add:
+
+```ts
+const { sources, channel: fileChannel } = useSourceInstances();
+```
+
+In the return statement (around line 155), add both fields to the returned object:
+
+```ts
+return {
+  files,
+  sources,      // ← new in P3
+  fileChannel,  // ← new in P3
+  activeFile,
+  // ... rest unchanged
+};
+```
+
+- [ ] **Step 4: Add the `modeManifest` store field if it doesn't already exist**
+
+Search for `modeManifest` in `src/store/`:
+
+```bash
+bun --bun rg "modeManifest" src/store/
+```
+
+If it already exists (likely — it should be set alongside `modeViewer` in the mode loading flow), skip this step. If not, add it to the appropriate slice (probably `src/store/workspace-slice.ts` or a dedicated `mode-slice.ts`):
+
+```ts
+interface ModeSlice {
+  modeManifest: ModeManifest | null;
+  setModeManifest: (m: ModeManifest | null) => void;
+}
+```
+
+And set it at the same point `setModeViewer` is called in `App.tsx` line ~205:
+
+```ts
+useStore.getState().setModeViewer(def.viewer);
+useStore.getState().setModeManifest(def.manifest);  // ← new
+useStore.getState().setModeDisplayName(def.manifest.displayName);
+```
+
+- [ ] **Step 5: Typecheck and dev-smoke**
+
+Run: `bun run tsc --noEmit 2>&1 | tail -10`
+Expected: clean.
+
+Run: `bun run dev doc --port 17996`, open the browser, verify the doc mode still renders markdown correctly. This exercises P3 end-to-end for the synthesis fallback path (doc hasn't declared `sources` yet, so the runtime synthesizes a `file-glob` source identical to its current `watchPatterns`). The viewer should still see `props.files` populated by the old path; the new `props.sources.files` should exist and mirror it.
+
+Kill the dev server.
+
+---
+
+### Task 3.8: Create the `useSource` React hook
+
+**Files:**
+- Create: `src/hooks/useSource.ts`
+- Create: `src/hooks/__tests__/useSource.test.ts`
+
+- [ ] **Step 1: Write the failing test file**
+
+```ts
+import { describe, test, expect } from "bun:test";
+import { renderHook, act } from "@testing-library/react";
+import { useSource } from "../useSource.js";
+import { MemorySource } from "../../../core/sources/memory.js";
+
+describe("useSource", () => {
+  test("returns null before any value is delivered", () => {
+    const source = new MemorySource<number>({});
+    const { result } = renderHook(() => useSource(source));
+    expect(result.current.value).toBeNull();
+  });
+
+  test("delivers the initial value once the source emits initial", async () => {
+    const source = new MemorySource<number>({ initial: 42 });
+    const { result } = renderHook(() => useSource(source));
+    // Allow the microtask queue to drain so the initial event fires.
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(result.current.value).toBe(42);
+  });
+
+  test("write() is a bound reference to the source's write", async () => {
+    const source = new MemorySource<number>({ initial: 0 });
+    const { result } = renderHook(() => useSource(source));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    await act(async () => {
+      await result.current.write(7);
+    });
+    expect(result.current.value).toBe(7);
+  });
+
+  test("status reports last origin for observability", async () => {
+    const source = new MemorySource<number>({ initial: 1 });
+    const { result } = renderHook(() => useSource(source));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(result.current.status.lastOrigin).toBe("initial");
+    await act(async () => {
+      await result.current.write(2);
+    });
+    expect(result.current.status.lastOrigin).toBe("self");
+  });
+
+  test("unmount unsubscribes from the source", () => {
+    const source = new MemorySource<number>({ initial: 1 });
+    const { unmount } = renderHook(() => useSource(source));
+    // MemorySource doesn't expose listener count, but we can prove
+    // unsubscribe happened by triggering a write after unmount and
+    // verifying no error from stale React state.
+    unmount();
+    expect(() => source.write(2)).not.toThrow();
+  });
+});
+```
+
+Note: this test file uses `@testing-library/react`. Check if it's already a dependency:
+
+```bash
+grep -l "@testing-library/react" package.json
+```
+
+If not, defer this test file to after P3 (or use a simpler manual subscription test). For now, write the impl (step 2) and defer the test to the next commit after confirming library availability.
+
+- [ ] **Step 2: Implement `src/hooks/useSource.ts`**
+
+```ts
+import { useMemo, useSyncExternalStore, useRef } from "react";
+import type { Source, SourceEvent } from "../../core/types/source.js";
+
+export interface SourceStatus {
+  /**
+   * The origin of the most recently delivered value event, or null if
+   * no value has been observed yet.
+   */
+  lastOrigin: "initial" | "self" | "external" | null;
+  /**
+   * The most recent error event, or null. Cleared on the next successful
+   * value event.
+   */
+  lastError: { code: string; message: string } | null;
+}
+
+export interface UseSourceResult<T> {
+  /** Latest value, or null before the initial event. */
+  value: T | null;
+  /** Bound write method — identical semantics to source.write(). */
+  write: (value: T) => Promise<void>;
+  /** Observability state. */
+  status: SourceStatus;
+}
+
+/**
+ * React binding for Source<T>.
+ *
+ * Uses useSyncExternalStore so React's concurrent rendering and
+ * StrictMode double-invocation behave correctly — the subscription
+ * is re-attached cleanly on remount without causing the source to
+ * re-emit.
+ *
+ * The returned { value, write, status } is a stable shape. `value`
+ * changes when new events arrive; `write` is a bound reference that
+ * does not change identity across renders (so downstream effects
+ * depending on [write] don't re-run gratuitously).
+ */
+export function useSource<T>(source: Source<T>): UseSourceResult<T> {
+  // A mutable status ref so status updates don't cause a re-render
+  // on their own — status is a secondary observation surface, the
+  // primary re-render driver is `value`.
+  const statusRef = useRef<SourceStatus>({
+    lastOrigin: null,
+    lastError: null,
+  });
+
+  // useSyncExternalStore needs a stable subscribe function per source.
+  const subscribe = useMemo(() => {
+    return (notify: () => void) => {
+      const off = source.subscribe((event: SourceEvent<T>) => {
+        if (event.kind === "value") {
+          statusRef.current = {
+            lastOrigin: event.origin,
+            lastError: null,
+          };
+        } else if (event.kind === "error") {
+          statusRef.current = {
+            ...statusRef.current,
+            lastError: { code: event.code, message: event.message },
+          };
+        }
+        notify();
+      });
+      return off;
+    };
+  }, [source]);
+
+  const value = useSyncExternalStore(
+    subscribe,
+    () => source.current(),
+    () => source.current(),
+  );
+
+  const write = useMemo(() => source.write.bind(source), [source]);
+
+  return {
+    value,
+    write,
+    status: statusRef.current,
+  };
+}
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run: `bun run tsc --noEmit 2>&1 | tail -10`
+Expected: clean.
+
+- [ ] **Step 4: Defer the hook test file if testing-library isn't installed**
+
+Check:
+
+```bash
+grep '"@testing-library/react"' package.json
+```
+
+If absent, DO NOT add it in this plan — adding a dep is a separate decision. Instead, leave the hook untested at P3 and verify correctness manually in P5 when each mode migrates to it. P5's per-mode dev-smoke is sufficient coverage.
+
+---
+
+### Task 3.9: P3 verification and commit
+
+**Files:** none modified.
+
+- [ ] **Step 1: Typecheck the whole repo**
+
+```bash
+bun run tsc --noEmit 2>&1 | tail -20
+```
+Expected: clean.
+
+- [ ] **Step 2: Run the test suite**
+
+```bash
+bun test 2>&1 | tail -15
+```
+Expected: all tests passing, including the new source-registry tests.
+
+- [ ] **Step 3: Manual smoke: every mode loads and renders correctly**
+
+For each of these modes, run the dev server, open the browser, verify the viewer loads and shows the current workspace content:
+
+```bash
+bun run dev doc --port 17996
+bun run dev diagram --port 17996
+bun run dev draw --port 17996
+bun run dev illustrate --port 17996
+bun run dev slide --port 17996
+bun run dev webcraft --port 17996
+bun run dev gridboard --port 17996
+bun run dev mode-maker --port 17996
+# remotion needs claude-code backend; skip if not available
+```
+
+For each: the viewer must render content identical to pre-P3 (no visible change). If any mode crashes, the problem is almost certainly in `useSourceInstances` — the synthesis fallback path is probably mis-configured. Use chrome-devtools-mcp to capture console errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add \
+  server/file-watcher.ts \
+  server/index.ts \
+  bin/pneuma.ts \
+  src/ws.ts \
+  src/store/workspace-slice.ts \
+  src/runtime/file-event-bus.ts \
+  src/runtime/file-channel.ts \
+  core/source-registry.ts \
+  core/__tests__/source-registry.test.ts \
+  core/types/viewer-contract.ts \
+  src/App.tsx \
+  src/hooks/useSource.ts
+
+git commit -m "$(cat <<'EOF'
+feat(source): runtime integration + pendingSelfWrites origin tagging (P3)
+
+Wires the Source contract into the real runtime without migrating any
+mode. Every existing mode continues to receive props.files populated
+exactly as before; a new props.sources map also exists, synthesized via
+SourceRegistry.effectiveSources() from viewer.watchPatterns for any
+manifest that hasn't declared sources explicitly.
+
+- server/file-watcher.ts: pendingSelfWrites map with 5s TTL, FileUpdate
+  now carries origin: "self" | "external"
+- server/index.ts: POST /api/files calls registerSelfWrite before writing
+- bin/pneuma.ts, src/ws.ts, src/store/workspace-slice.ts: origin flows
+  through the content_update broadcast → store → fileEventBus
+- src/runtime/file-event-bus.ts: browser-side singleton pub/sub
+- src/runtime/file-channel.ts: BrowserFileChannel wraps store + WS + POST
+- core/source-registry.ts: SourceRegistry with built-in providers and
+  effectiveSources() synthesis fallback
+- src/App.tsx: useSourceInstances hook rebuilds per-mode sources map
+- src/hooks/useSource.ts: React binding via useSyncExternalStore
+- core/types/viewer-contract.ts: sources field added, files deprecated
+
+All 8 existing viewer modes smoke-tested to render identically to pre-P3.
+No mode has been migrated to consume props.sources yet — that's P5.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+
+## Phase 4: Plugin extension point
+
+Phase 4 opens the SourceRegistry to third-party plugin-provided providers. A plugin that wants to ship, say, a Redis or Yjs source provider declares them in `PluginManifest.sources` and the runtime registers them alongside the built-ins during plugin activation. This phase is small — the registry is already abstracted in P3; P4 just threads the registration through `PluginRegistry`.
+
+### Task 4.1: Add `sources` to `PluginManifest`
+
+**Files:**
+- Modify: `core/types/plugin.ts`
+
+- [ ] **Step 1: Add the import**
+
+At the top of `core/types/plugin.ts`, add:
+
+```ts
+import type { SourceProvider } from "./source.js";
+```
+
+- [ ] **Step 2: Add the field**
+
+In the `PluginManifest` interface (around lines 61–109), add the optional field before the closing brace:
+
+```ts
+  /**
+   * Source providers contributed by this plugin. Registered on the
+   * session's SourceRegistry during plugin activation, making them
+   * available to every mode (builtin + external) that declares
+   * `sources: { ..., [id]: { kind: "<your-kind>" } }` in its manifest.
+   *
+   * Naming: use a plugin-scoped kind to avoid collisions with built-ins.
+   * For example, a Redis provider from a plugin named "@acme/pneuma-redis"
+   * should register as kind "acme-redis" rather than just "redis".
+   * Collision with an existing kind causes registration to throw
+   * (SourceRegistry.register does not silently overwrite).
+   */
+  sources?: SourceProvider[];
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run: `bun run tsc --noEmit 2>&1 | tail -10`
+Expected: clean.
+
+---
+
+### Task 4.2: Thread plugin-provided providers into `SourceRegistry`
+
+**Files:**
+- Modify: `core/plugin-registry.ts`
+- Modify: `src/App.tsx` (accept plugin providers when building the per-mode registry)
+
+- [ ] **Step 1: Extend `LoadedPlugin` to expose `sources`**
+
+In `core/types/plugin.ts`, find the `LoadedPlugin` interface (around lines 149–156). Add:
+
+```ts
+  /** Source providers from this plugin. Empty if the plugin doesn't ship any. */
+  sources: SourceProvider[];
+```
+
+- [ ] **Step 2: Populate `sources` in `PluginRegistry.loadPlugin`**
+
+In `core/plugin-registry.ts`, find the `loadPlugin` method (around lines 106–143). In the object returned as `LoadedPlugin`, add:
+
+```ts
+sources: manifest.sources ?? [],
+```
+
+- [ ] **Step 3: Expose a method to collect all source providers across loaded plugins**
+
+Still in `core/plugin-registry.ts`, add a method at the bottom of the class body:
+
+```ts
+/**
+ * Collect every source provider contributed by currently-loaded
+ * plugins. The runtime calls this when building a per-mode
+ * SourceRegistry to register plugin providers alongside the
+ * built-ins. Duplicate kinds across plugins cause SourceRegistry.register
+ * to throw — plugins must namespace their kinds.
+ */
+collectSourceProviders(): SourceProvider[] {
+  const out: SourceProvider[] = [];
+  for (const plugin of this.loadedPlugins) {
+    out.push(...plugin.sources);
+  }
+  return out;
+}
+```
+
+Also add the import at the top of the file:
+
+```ts
+import type { SourceProvider } from "./types/source.js";
+```
+
+Note: if `this.loadedPlugins` doesn't exist as a field (it may be named differently — `this.plugins`, `this.registry`, etc.), use whatever the file's existing convention is. The key behavior is "iterate all currently-loaded plugins and flatten their sources arrays".
+
+- [ ] **Step 4: Wire plugin providers into `useSourceInstances`**
+
+In `src/App.tsx`, modify the `useSourceInstances` hook created in Task 3.7. The current implementation builds a registry from `BUILT_IN_PROVIDERS` only. Extend it to also register providers from plugins.
+
+At the top of the file, add:
+
+```ts
+import { pluginRegistry } from "./plugins/browser-plugin-registry.js";  // or wherever the plugin registry singleton lives in the browser
+```
+
+(The plugin system in this repo may be server-authoritative with the browser receiving plugin metadata via WS. If plugin providers are server-side only, skip this step and document in the task's final commit that P4's browser-side integration is deferred until plugin providers can run in the browser context. For the P4 commit, the server-side collection via `PluginRegistry.collectSourceProviders()` is sufficient infrastructure.)
+
+If the plugin runtime IS browser-capable, extend the hook's registry construction:
+
+```ts
+const registry = new SourceRegistry();
+for (const provider of BUILT_IN_PROVIDERS) registry.register(provider);
+for (const provider of pluginRegistry.collectSourceProviders()) {
+  try {
+    registry.register(provider);
+  } catch (err) {
+    // Duplicate kind from a misbehaving plugin — log and continue.
+    console.error("[source] plugin provider registration failed", err);
+  }
+}
+```
+
+- [ ] **Step 5: Typecheck**
+
+Run: `bun run tsc --noEmit 2>&1 | tail -10`
+Expected: clean.
+
+---
+
+### Task 4.3: Unit-test plugin provider collection
+
+**Files:**
+- Modify: `core/__tests__/plugin-registry.test.ts` (add a test case)
+
+- [ ] **Step 1: Add a test**
+
+Open the existing `core/__tests__/plugin-registry.test.ts`. Add a new test case at the bottom of the appropriate `describe` block:
+
+```ts
+test("collectSourceProviders flattens providers from all loaded plugins", async () => {
+  // This test assumes the test file has helpers for constructing a
+  // PluginRegistry with in-memory plugin manifests. If those helpers
+  // don't exist, add a minimal inline one here.
+  const reg = new PluginRegistry();
+  // ... register two plugins, one declaring a `sources` array of length 2,
+  //     the other declaring a `sources` array of length 1
+  const providers = reg.collectSourceProviders();
+  expect(providers).toHaveLength(3);
+  const kinds = providers.map((p) => p.kind).sort();
+  expect(kinds).toContain("test-a");
+});
+```
+
+The exact test body depends on the existing file's setup conventions. Open the file, find how other tests instantiate a `PluginRegistry`, and pattern-match. The assertion is: if 2 plugins declare 2+1 source providers respectively, `collectSourceProviders()` returns all 3.
+
+- [ ] **Step 2: Run the test**
+
+Run: `bun test core/__tests__/plugin-registry.test.ts 2>&1 | tail -15`
+Expected: all plugin-registry tests passing including the new one.
+
+---
+
+### Task 4.4: Commit P4
+
+```bash
+git add \
+  core/types/plugin.ts \
+  core/plugin-registry.ts \
+  src/App.tsx \
+  core/__tests__/plugin-registry.test.ts
+
+git commit -m "$(cat <<'EOF'
+feat(source): plugin extension point for custom source providers (P4)
+
+Opens the SourceRegistry to third-party providers. Plugins declare
+providers in PluginManifest.sources; PluginRegistry.collectSourceProviders
+flattens them, useSourceInstances registers them alongside built-ins on
+the per-mode SourceRegistry.
+
+- core/types/plugin.ts: sources?: SourceProvider[] on PluginManifest,
+  sources: SourceProvider[] on LoadedPlugin
+- core/plugin-registry.ts: collectSourceProviders() method
+- src/App.tsx: useSourceInstances registers plugin providers after
+  built-ins
+- core/__tests__/plugin-registry.test.ts: coverage for the flatten
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+
+## Phase 5: Migrate all viewer modes to `props.sources`
+
+Phase 5 is the load-bearing phase of the entire plan. Every existing viewer migrates from `props.files` to `props.sources.<id>` (or whatever sources the mode declares). Every inline `saveFile` helper and every echo-guard ref gets deleted. After P5 completes, the `files` prop is removed from `ViewerPreviewProps` and from `useViewerProps` — no code in the repo reads it anymore.
+
+### Mode categorization by domain shape
+
+Each mode's migration shape depends on **what its domain actually is**, not on whether it has a viewer. Three categories; use the table to decide which pattern applies.
+
+| Mode | Domain shape | Provider | Migration pattern |
+|---|---|---|---|
+| **mode-maker** | A mode package's file tree — **domain is files** | `file-glob` | Pattern A: read-only migration |
+| **evolve** | No viewer | `sources: {}` | Pattern B: opt out |
+| **illustrate** | A Studio (content sets + image rows) — **domain is a multi-file aggregate** | `aggregate-file` | Pattern C: domain-typed migration |
+| **remotion** | TSX source tree — **domain is files** | `file-glob` | Pattern A |
+| **diagram** | An active drawio XML — domain is single file (1:1) | `file-glob` | Pattern A (+ delete `lastFileContentRef`) |
+| **doc** | A set of markdown docs + active selection — **domain is files** | `file-glob` + `fileChannel` for dynamic-target writes | Pattern D: file-shaped writes |
+| **draw** | An active excalidraw canvas (1:1) | `file-glob` + `fileChannel` | Pattern D |
+| **gridboard** | A Board (tiles + theme) — domain is a single structured aggregate, nearly 1:1 with `board.json` | `file-glob` + `fileChannel` (or `json-file` as a follow-up) | Pattern D |
+| **slide** | A Deck (ordered slides + theme + title) — **domain is multi-file aggregate** | `aggregate-file` | Pattern C |
+| **webcraft** | A Site (pages + assets + manifest) — **domain is multi-file aggregate** | `aggregate-file` | Pattern C |
+
+**Task order** (complexity low → high, so early bugs don't block later work):
+
+1. mode-maker (Pattern A)
+2. evolve (Pattern B)
+3. illustrate (Pattern C)
+4. remotion (Pattern A)
+5. diagram (Pattern A)
+6. doc (Pattern D)
+7. draw (Pattern D)
+8. gridboard (Pattern D)
+9. slide (Pattern C)
+10. webcraft (Pattern C)
+11. Final cleanup
+
+### Shared migration patterns
+
+**Pattern A — Read-only via `file-glob`**. Used when the domain IS files. The viewer consumes `Source<ViewerFileContent[]>` via `useSource`. No write path change (Pattern A modes don't write from the viewer). Steps:
+
+1. Add `sources: { files: { kind: "file-glob", config: { patterns: [...] } } }` to the manifest, lifting patterns from `viewer.watchPatterns`.
+2. In the viewer, replace `{ files, ... }: ViewerPreviewProps` destructure with `{ sources, ... }`; compute `const files = useSource(sources.files as Source<ViewerFileContent[]>).value ?? []`.
+3. Delete any `lastFileContentRef` / skip-on-no-change guards — React + `useSource` handle idempotency via `useSyncExternalStore`.
+4. Typecheck, dev smoke, commit.
+
+**Pattern B — Opt out with empty sources**. Used when the mode has no viewer. Declare `sources: {}` on the manifest. Done.
+
+**Pattern C — Domain-typed via `aggregate-file`**. Used when the domain is a multi-file aggregate. The viewer consumes `Source<T>` where `T` is the mode's domain type (`Studio`, `Deck`, `Site`). The viewer NEVER touches file paths or JSON stringification — the provider's `load(files) → T` and `save(T, current) → { writes, deletes }` pure functions handle all translation. Steps:
+
+1. Create `modes/<mode>/domain.ts` that defines the domain type `T` and exports two pure functions:
+   - `load(files: ReadonlyArray<ViewerFileContent>): T | null` — reconstruct the aggregate from the current file snapshot. Return null if required files are missing (source will stay in "no initial yet" state until files arrive). Throw to emit an `error` event.
+   - `save(value: T, current: ReadonlyArray<ViewerFileContent>): { writes; deletes }` — decompose the new aggregate into file-level operations. Use `current` to compute diffs (e.g. detect slide ids that were removed and need their files deleted).
+2. Add `sources: { <id>: { kind: "aggregate-file", config: { patterns: [...], load, save } } }` to the manifest, importing `load` and `save` from `./domain.js`.
+3. In the viewer, replace `{ files, ... }` with `{ sources, ... }`; wire `const { value, write, status } = useSource(sources.<id> as Source<T>)`. The viewer now renders from `value` (the domain aggregate) directly — `files.find(...)` and JSON stringification disappear from the viewer code.
+4. Replace every existing `fetch('/api/files', ...)` / inline `saveFile` call with a domain-level `await write(nextAggregate)`. The provider's `save()` figures out which files to write and delete.
+5. Delete any echo-guard refs (`lastSavedContentRef`, `isUpdatingFromFileRef`, `lastAppliedRef`, etc.). `status.lastOrigin === "self"` is the correct way to distinguish echoes from external changes.
+6. Typecheck, dev smoke (exercise both agent edits and viewer edits), commit.
+
+**Pattern D — File-shaped writes via `file-glob` + `fileChannel`**. Used when the domain IS a file (single active file, 1:1 aggregate, or a mode whose write target is dynamic and changes at runtime). Steps:
+
+1. Add `sources: { files: { kind: "file-glob", config: { patterns: [...] } } }` to the manifest.
+2. In the viewer, destructure `{ sources, fileChannel, ... }` and consume `sources.files` via `useSource` like Pattern A.
+3. Replace inline `saveFile` helpers with `await fileChannel.write(path, content)` at each call site. The viewer still knows its target path (it's the active file) — what's gone is the echo-detection machinery.
+4. Delete echo-guard refs. Use `status.lastOrigin` from `useSource` where you need to distinguish self from external (e.g. to skip a full re-render on self-save).
+5. Typecheck, dev smoke (exercise both agent edits and viewer edits, especially concurrent edit + save scenarios), commit.
+
+Every mode task below references one of these patterns and provides only the mode-specific details (which refs to delete, which file paths to lift, for Pattern C which domain type + load/save to define).
+
+### Task 5.1: Migrate `mode-maker`
+
+**Files:**
+- Modify: `modes/mode-maker/manifest.ts`
+- Modify: `modes/mode-maker/viewer/ModeMakerPreview.tsx`
+
+`mode-maker` is a read-only viewer that shows a tree of files in the mode-under-development. No writes. Simplest possible migration.
+
+- [ ] **Step 1: Add `sources` to the manifest**
+
+In `modes/mode-maker/manifest.ts`, inside the `modeMakerManifest` object, add the `sources` field just after the existing `viewer` block:
+
+```ts
+viewer: {
+  watchPatterns: [
+    "manifest.ts", "manifest.js",
+    "pneuma-mode.ts", "pneuma-mode.js",
+    "viewer/**/*.tsx", "viewer/**/*.ts", "viewer/**/*.js",
+    "skill/**/*.md", "skill/**/*",
+    "seed/**/*",
+  ],
+  ignorePatterns: [".build/**"],
+},
+sources: {
+  files: {
+    kind: "file-glob",
+    config: {
+      patterns: [
+        "manifest.ts", "manifest.js",
+        "pneuma-mode.ts", "pneuma-mode.js",
+        "viewer/**/*.tsx", "viewer/**/*.ts", "viewer/**/*.js",
+        "skill/**/*.md", "skill/**/*",
+        "seed/**/*",
+      ],
+      ignore: [".build/**"],
+    },
+  },
+},
+```
+
+- [ ] **Step 2: Update the viewer**
+
+Open `modes/mode-maker/viewer/ModeMakerPreview.tsx`. Find the component signature (the props destructure) — it currently takes `{ files, ... }: ViewerPreviewProps`. Change to:
+
+```tsx
+import type { Source } from "../../../core/types/source.js";
+import type { ViewerFileContent } from "../../../core/types/viewer-contract.js";
+import { useSource } from "../../../src/hooks/useSource.js";
+
+export default function ModeMakerPreview({
+  sources,
+  // ... other existing props except `files`
+}: ViewerPreviewProps) {
+  const filesSource = sources.files as Source<ViewerFileContent[]>;
+  const { value: filesValue } = useSource(filesSource);
+  const files: ViewerFileContent[] = filesValue ?? [];
+  // ... rest of the component unchanged; all references to `files` now
+  //     resolve to the local `const files` above instead of the prop
+}
+```
+
+Search the file for every remaining occurrence of `files` (in loops, effects, derived state). They all continue to work unchanged because `files` is still a `ViewerFileContent[]` in local scope.
+
+- [ ] **Step 3: Typecheck**
+
+Run: `bun run tsc --noEmit 2>&1 | tail -10`
+Expected: clean.
+
+- [ ] **Step 4: Dev smoke**
+
+```bash
+bun run dev mode-maker --port 17996 --workspace /tmp/mode-maker-smoke
+```
+
+In the browser, verify the mode-maker viewer renders the default scaffolded files. Use chrome-devtools-mcp to screenshot. Compare to a pre-P5 screenshot (e.g., from git stash of `main`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add modes/mode-maker/manifest.ts modes/mode-maker/viewer/ModeMakerPreview.tsx
+git commit -m "$(cat <<'EOF'
+refactor(mode-maker): migrate viewer to props.sources (P5.1)
+
+Reads files exclusively through sources.files. No behavioral change.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 5.2: Migrate `evolve`
+
+**Files:**
+- Modify: `modes/evolve/manifest.ts`
+
+Evolve has no viewer — it's a headless agent-only mode. But it still has a manifest with a `viewer: { watchPatterns: [] }` block. Add an empty sources to make the migration complete and uniform.
+
+- [ ] **Step 1: Add `sources` to the manifest**
+
+In `modes/evolve/manifest.ts`, after the `viewer` block, add:
+
+```ts
+sources: {},
+```
+
+An empty `sources` object is explicitly different from an absent one: the P5 final-cleanup task will remove the synthesis fallback, so modes that have no file-backed viewer need to declare the empty object to opt out of auto-synthesis.
+
+- [ ] **Step 2: Typecheck and commit**
+
+```bash
+bun run tsc --noEmit 2>&1 | tail -5
+git add modes/evolve/manifest.ts
+git commit -m "refactor(evolve): opt out of source synthesis with empty sources (P5.2)
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5.3: Migrate `illustrate`
+
+**Files:**
+- Create: `modes/illustrate/domain.ts`
+- Modify: `modes/illustrate/manifest.ts`
+- Modify: `modes/illustrate/viewer/IllustratePreview.tsx`
+
+**Pattern: C (aggregate-file).** Illustrate's domain is a **Studio** — a collection of image rows organized across one or more content sets. Currently the viewer parses `manifest.json` to find rows and loads image files from `images/**/*`. That parse-and-reassemble logic is a `load()` function in disguise. Lift it out of the viewer.
+
+- [ ] **Step 1: Define the domain type and pure functions in `modes/illustrate/domain.ts`**
+
+```ts
+import type { ViewerFileContent } from "../../core/types/viewer-contract.js";
+
+export interface ImageEntry {
+  id: string;
+  path: string;      // relative to the workspace, e.g. "images/hero.png"
+  alt?: string;
+  prompt?: string;
+}
+
+export interface ImageRow {
+  id: string;
+  title?: string;
+  images: ImageEntry[];
+}
+
+export interface ContentSetSummary {
+  prefix: string;
+  label: string;
+  rows: ImageRow[];
+}
+
+export interface Studio {
+  contentSets: ContentSetSummary[];
+  activeContentSet: string | null;
+}
+
+/**
+ * Reconstruct the Studio aggregate from the workspace file snapshot.
+ * Returns null when no manifest.json is present (source stays in "no
+ * initial yet" state until the agent creates one).
+ */
+export function loadStudio(files: ReadonlyArray<ViewerFileContent>): Studio | null {
+  // Look for top-level and content-set-scoped manifests.
+  const manifests = files.filter((f) => f.path.endsWith("manifest.json"));
+  if (manifests.length === 0) return null;
+  // ... parse each manifest into ContentSetSummary, reading image metadata
+  //     from rows[].images[].path fields and verifying the referenced files
+  //     exist in `files`. Build the full Studio aggregate and return it.
+  //     Use the existing parsing code from the current IllustratePreview as
+  //     the starting point — it's the same logic, just moved here.
+  throw new Error("TODO: port the existing useResilientParse logic from IllustratePreview.tsx to this pure function");
+}
+
+/**
+ * Decompose a new Studio back into file operations. For the initial
+ * migration this is write-only (the viewer currently never writes),
+ * so save() returns the minimum necessary to serialize the studio
+ * back to a manifest.json. When the mode later gains UI-level editing
+ * (drag to reorder rows, delete an image), extend save() to produce
+ * the corresponding delete entries.
+ */
+export function saveStudio(
+  next: Studio,
+  current: ReadonlyArray<ViewerFileContent>,
+): { writes: Array<{ path: string; content: string }>; deletes: string[] } {
+  // For the P5 migration, illustrate is effectively read-only — agents
+  // generate images, viewer just displays them. So save() is trivial:
+  // serialize the active content set's manifest and return no deletes.
+  // A future UI-editing upgrade extends this.
+  throw new Error("TODO: implement save() when viewer gains editing capabilities");
+}
+```
+
+**Note**: the two `throw new Error("TODO: ...")` bodies are placeholders that the executor fills in by porting logic from the CURRENT `IllustratePreview.tsx`. They are not the spec leaving details unfilled — the logic already exists in the viewer; it just needs to be moved to domain.ts verbatim. The executor reads the existing `useResilientParse` code in IllustratePreview and translates each `files.find(...)` into a `files.find(...)` in `loadStudio`. Because the viewer is currently read-only, `saveStudio` can throw `"not yet implemented"` until a later plan introduces editing.
+
+- [ ] **Step 2: Update `modes/illustrate/manifest.ts`**
+
+```ts
+import { loadStudio, saveStudio } from "./domain.js";
+import type { Studio } from "./domain.js";
+
+// ... in the manifest:
+sources: {
+  studio: {
+    kind: "aggregate-file",
+    config: {
+      patterns: ["**/manifest.json", "**/images/**/*"],
+      load: loadStudio,
+      save: saveStudio,
+    },
+  },
+},
+```
+
+- [ ] **Step 3: Update `IllustratePreview.tsx`**
+
+```tsx
+import type { Source } from "../../../core/types/source.js";
+import type { Studio } from "../domain.js";
+import { useSource } from "../../../src/hooks/useSource.js";
+
+export default function IllustratePreview({
+  sources,
+  // other existing props minus `files`
+}: ViewerPreviewProps) {
+  const studioSource = sources.studio as Source<Studio>;
+  const { value: studio } = useSource(studioSource);
+  if (!studio) return <EmptyState />;
+  // Render directly from `studio.contentSets`, `studio.activeContentSet`,
+  // etc. Delete every `files.find(...)` / `useResilientParse` usage — the
+  // parsing is now in loadStudio(), run once per external event.
+}
+```
+
+- [ ] **Step 4: Typecheck, smoke, commit**
+
+```bash
+bun run tsc --noEmit 2>&1 | tail -5
+bun run dev illustrate --port 17996 --workspace /tmp/illustrate-smoke
+# Verify: content sets load, images render, content-set switching works
+git add modes/illustrate/domain.ts modes/illustrate/manifest.ts modes/illustrate/viewer/IllustratePreview.tsx
+git commit -m "refactor(illustrate): domain-typed migration to aggregate-file source (P5.3)
+
+Viewer consumes Source<Studio> directly; all manifest parsing lives
+in domain.loadStudio as a pure function. No more files.find() or
+useResilientParse in the viewer code.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5.4: Migrate `remotion`
+
+**Files:**
+- Modify: `modes/remotion/manifest.ts`
+- Modify: `modes/remotion/viewer/RemotionPreview.tsx` (or the actual entry file)
+
+Read-only. Only runs on claude-code backend; may skip end-to-end smoke if backend not available.
+
+- [ ] **Step 1: Add `sources` to the manifest**
+
+```ts
+sources: {
+  files: {
+    kind: "file-glob",
+    config: {
+      patterns: [
+        "src/**/*.tsx", "src/**/*.ts", "src/**/*.css", "public/**",
+        "*/src/**/*.tsx", "*/src/**/*.ts", "*/src/**/*.css", "*/public/**",
+      ],
+    },
+  },
+},
+```
+
+- [ ] **Step 2: Update the viewer**
+
+Locate the remotion preview entry component. Apply the same destructure-and-useSource pattern as Task 5.1.
+
+- [ ] **Step 3: Typecheck + (optional) smoke + commit**
+
+```bash
+bun run tsc --noEmit 2>&1 | tail -5
+# Smoke test only if claude-code backend is configured; otherwise rely on
+# tsc + other mode smoke tests to catch regressions in the shared path.
+git add modes/remotion/manifest.ts modes/remotion/viewer/
+git commit -m "refactor(remotion): migrate viewer to props.sources (P5.4)
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5.5: Migrate `diagram`
+
+**Files:**
+- Modify: `modes/diagram/manifest.ts`
+- Modify: `modes/diagram/viewer/DiagramPreview.tsx`
+
+Diagram reads `.drawio` files. It has a streaming-write path from the agent (via `streamingFileWrite` from the store) but no user-initiated `POST /api/files`. It DOES have `lastFileContentRef` + `currentFilePathRef` as skip-on-no-change guards at line 139, 382 — we delete those because `useSource` already provides change detection via React's reconciliation of the `value`.
+
+- [ ] **Step 1: Add `sources` to the manifest**
+
+```ts
+sources: {
+  files: {
+    kind: "file-glob",
+    config: {
+      patterns: ["**/*.drawio"],
+    },
+  },
+},
+```
+
+- [ ] **Step 2: Update `DiagramPreview.tsx`**
+
+(a) Change the props destructure:
+
+```tsx
+import type { Source } from "../../../core/types/source.js";
+import type { ViewerFileContent } from "../../../core/types/viewer-contract.js";
+import { useSource } from "../../../src/hooks/useSource.js";
+
+export default function DiagramPreview({
+  sources,
+  selection,
+  // ... other existing props minus `files`
+}: ViewerPreviewProps) {
+  const filesSource = sources.files as Source<ViewerFileContent[]>;
+  const { value: filesValue } = useSource(filesSource);
+  const files: ViewerFileContent[] = filesValue ?? [];
+  // ... rest of component unchanged
+```
+
+(b) Delete `lastFileContentRef` declaration (line ~139) and the string-compare effect that uses it (line ~382 area):
+
+```tsx
+// DELETE: const lastFileContentRef = useRef<string | null>(null);
+// DELETE: const currentFilePathRef = useRef<string | null>(null);
+
+// DELETE the effect body that reads:
+//   if (content === lastFileContentRef.current && filePath === currentFilePathRef.current) return;
+//   lastFileContentRef.current = content;
+//   currentFilePathRef.current = filePath;
+```
+
+The parse-and-render effect that was gated by that check should now run unconditionally when `files` (the local value from `useSource`) changes. React's memoization of `useMemo(() => parseDrawioFile(files), [files])` is enough to skip redundant parsing when the array identity is unchanged. If `parseDrawioFile` is still expensive on every `files` change (because the source emits a new array reference even when content is unchanged), memoize by content hash instead:
+
+```tsx
+const parsed = useMemo(() => {
+  const f = files.find((x) => x.path === activeFile || x.path.endsWith(".drawio"));
+  return f ? parseDrawioFile(f) : null;
+}, [files, activeFile]);
+```
+
+- [ ] **Step 3: Typecheck, smoke, commit**
+
+```bash
+bun run tsc --noEmit 2>&1 | tail -5
+bun run dev diagram --port 17996 --workspace /tmp/diagram-smoke
+# Verify the diagram renders, agent edits arrive, nothing thrashes
+git add modes/diagram/manifest.ts modes/diagram/viewer/DiagramPreview.tsx
+git commit -m "$(cat <<'EOF'
+refactor(diagram): migrate to props.sources, delete lastFileContentRef (P5.5)
+
+The ref-based skip-on-no-change guard is no longer needed — useSource +
+useMemo on the parsed result handles redundant work without hand-rolled
+string comparison.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 5.6: Migrate `doc`
+
+**Files:**
+- Modify: `modes/doc/manifest.ts`
+- Modify: `modes/doc/viewer/DocPreview.tsx`
+
+First real write-back migration. Doc writes via the inline `saveFile` helper (lines 213–225), debounced 800ms, with `lastExternalRef` (line 744) as a string-compare echo guard (lines 748–755). The migration deletes all of that.
+
+Doc's domain model is "the currently active markdown file". The active file is dynamic (user switches files), so a declarative `json-file` source pinned to a single path won't work. Doc uses:
+- `sources.files` (a `file-glob`) to READ the full workspace file list
+- `props.fileChannel.write(activePath, content)` to WRITE the active file directly
+
+`fileChannel` was already added to `ViewerPreviewProps` in Task 3.6 and populated by `useViewerProps` in Task 3.7 — this task just consumes it.
+
+- [ ] **Step 1: Update `modes/doc/manifest.ts`**
+
+```ts
+sources: {
+  files: {
+    kind: "file-glob",
+    config: {
+      patterns: ["**/*.md"],
+    },
+  },
+},
+```
+
+- [ ] **Step 2: Update `modes/doc/viewer/DocPreview.tsx`**
+
+(a) Change props destructure:
+
+```tsx
+import type { Source } from "../../../core/types/source.js";
+import type { ViewerFileContent } from "../../../core/types/viewer-contract.js";
+import { useSource } from "../../../src/hooks/useSource.js";
+
+export default function DocPreview({
+  sources,
+  fileChannel,
+  selection,
+  // ... rest of existing props minus `files`
+}: ViewerPreviewProps) {
+  const filesSource = sources.files as Source<ViewerFileContent[]>;
+  const { value: filesValue } = useSource(filesSource);
+  const files: ViewerFileContent[] = filesValue ?? [];
+  // ... rest of component
+```
+
+(b) Replace the inline `saveFile` helper. Find the helper definition around lines 213–225:
+
+```tsx
+// DELETE:
+async function saveFile(path: string, content: string): Promise<boolean> {
+  try {
+    const baseUrl = import.meta.env.DEV ? `http://${location.hostname}:${import.meta.env.VITE_API_PORT || "17007"}` : "";
+    const res = await fetch(`${baseUrl}/api/files`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ path, content }),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+```
+
+Every call site that used `saveFile(path, content)` becomes:
+
+```tsx
+try {
+  await fileChannel.write(path, content);
+} catch (err) {
+  console.error("[doc] save failed", err);
+}
+```
+
+The call site is inside the debounced `scheduleSave()` callback around line 761. The local `saveFile` helper (now deleted) was module-scoped, outside the component. The new call must be inside the component so it can access `fileChannel`. Move the save logic inline into `scheduleSave`:
+
+```tsx
+const scheduleSave = useCallback((path: string, content: string) => {
+  if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+  saveTimerRef.current = setTimeout(async () => {
+    try {
+      await fileChannel.write(path, content);
+    } catch (err) {
+      console.error("[doc] save failed", err);
+    }
+  }, 800);
+}, [fileChannel]);
+```
+
+(c) Delete `lastExternalRef` (line 744) and the effect body that used it (lines 748–755):
+
+```tsx
+// DELETE: const lastExternalRef = useRef<string | null>(null);
+// DELETE: useEffect(() => {
+//   if (!file) return;
+//   if (file.content !== lastExternalRef.current) {
+//     textareaRef.current.value = file.content;
+//     lastExternalRef.current = file.content;
+//     lastSavedForActionRef.current = file.content;
+//   }
+// }, [file.content]);
+```
+
+The new approach: let React reconcile the textarea's `value` prop against the latest source value. If the textarea is a controlled component (`<textarea value={...} />`), it just renders the latest value. If it's uncontrolled (`<textarea ref={...} />` and direct `.value` assignment), replace the effect body with an `origin`-aware version:
+
+```tsx
+const { value: filesValue, status } = useSource(filesSource);
+// ... existing file selection logic produces `file`
+
+useEffect(() => {
+  if (!file || !textareaRef.current) return;
+  // Only overwrite the textarea content when the source emits a
+  // non-self event. Self-origin events are the echo of our own debounced
+  // save — we already have the latest local content; reassigning would
+  // reset cursor/selection unnecessarily. External events are genuine
+  // new content (from the agent) and should replace local state.
+  if (status.lastOrigin === "self") return;
+  if (textareaRef.current.value !== file.content) {
+    textareaRef.current.value = file.content;
+  }
+}, [file?.content, status.lastOrigin]);
+```
+
+This is a strict improvement over the pre-P5 behavior: `lastExternalRef` would overwrite the user's unsaved edits on an incoming external change. The new logic still does that (because external origin IS authoritative), but it does NOT overwrite on self-origin echoes (which was the real "overwrite my typing" bug). If the user wants to reject external changes while editing, that's a follow-up conflict-UI task, not a P5 regression.
+
+(d) Remove `lastSavedForActionRef` if its sole use was inside the deleted effect. If it's still referenced elsewhere (diff computation for user-action notifications around lines 766–791), leave it alone — it's a separate concern.
+
+- [ ] **Step 3: Typecheck and smoke**
+
+```bash
+bun run tsc --noEmit 2>&1 | tail -10
+bun run dev doc --port 17996 --workspace /tmp/doc-smoke
+```
+
+In the browser: create a new `.md` file via the UI, type something, wait 1 second, verify the file appears in `/tmp/doc-smoke/`. Edit the file externally (e.g., `echo '# external' > /tmp/doc-smoke/test.md`), verify the viewer reflects the change. Use chrome-devtools-mcp to screenshot the editor.
+
+Critical check: type in the editor, THEN edit the file externally with a short delay, THEN continue typing — the viewer should not freeze or lose the external change, and the user's unsaved text should not be silently overwritten if it's still in flight in the debounce window.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add modes/doc/manifest.ts modes/doc/viewer/DocPreview.tsx
+
+git commit -m "$(cat <<'EOF'
+refactor(doc): migrate to props.sources + fileChannel, delete echo ref (P5.6)
+
+Replaces the inline saveFile helper with fileChannel.write() and deletes
+lastExternalRef. The new origin-aware effect no longer overwrites the
+textarea on self-origin echoes — fixes the latent "lose local edit on
+self-write" bug.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+
+### Task 5.7: Migrate `draw`
+
+**Files:**
+- Modify: `modes/draw/manifest.ts`
+- Modify: `modes/draw/viewer/DrawPreview.tsx`
+
+Draw is the most fragile pre-P5 mode: it has both `lastSavedContentRef` (line 259, ordering-critical at line 370) and `isUpdatingFromFileRef` (line 263, 346–350) plus a remount-key dance (`setExcalidrawKey`). All of that goes.
+
+- [ ] **Step 1: Add `sources` to `modes/draw/manifest.ts`**
+
+```ts
+sources: {
+  files: {
+    kind: "file-glob",
+    config: { patterns: ["**/*.excalidraw"] },
+  },
+},
+```
+
+- [ ] **Step 2: Update `DrawPreview.tsx`**
+
+(a) Props destructure — add `sources` and `fileChannel`, remove `files`:
+
+```tsx
+import type { Source } from "../../../core/types/source.js";
+import type { ViewerFileContent } from "../../../core/types/viewer-contract.js";
+import { useSource } from "../../../src/hooks/useSource.js";
+
+export default function DrawPreview({
+  sources,
+  fileChannel,
+  // ... other existing props minus `files`
+}: ViewerPreviewProps) {
+  const filesSource = sources.files as Source<ViewerFileContent[]>;
+  const { value: filesValue, status } = useSource(filesSource);
+  const files: ViewerFileContent[] = filesValue ?? [];
+  // ... rest of component unchanged below
+```
+
+(b) Delete `lastSavedContentRef` and `isUpdatingFromFileRef` declarations (around lines 259, 263):
+
+```tsx
+// DELETE: const lastSavedContentRef = useRef<string>("");
+// DELETE: const isUpdatingFromFileRef = useRef<boolean>(false);
+// Keep: currentFilePathRef (still needed for the active file target)
+```
+
+(c) Rewrite the incoming-change effect (around lines 335–351). The old logic:
+
+```tsx
+// OLD (DELETE):
+useEffect(() => {
+  if (!excalidrawData) return;
+  const newContent = serializeToFile(
+    excalidrawData.elements,
+    excalidrawData.appState,
+    excalidrawData.excalidrawFiles,
+  );
+  if (newContent === lastSavedContentRef.current) return;
+  isUpdatingFromFileRef.current = true;
+  setExcalidrawKey((k) => k + 1);
+  setTimeout(() => { isUpdatingFromFileRef.current = false; }, 500);
+}, [excalidrawData]);
+```
+
+New logic — remount only on external origin, not self:
+
+```tsx
+useEffect(() => {
+  if (!excalidrawData) return;
+  // External changes rebuild the Excalidraw state from the incoming
+  // file. Self-origin echoes are our own save coming back — Excalidraw's
+  // in-memory state already reflects them, so we skip the remount and
+  // avoid the visual flash + cursor loss.
+  if (status.lastOrigin === "self") return;
+  setExcalidrawKey((k) => k + 1);
+}, [excalidrawData, status.lastOrigin]);
+```
+
+(d) Rewrite the save callback (around lines 358–371). Old logic:
+
+```tsx
+// OLD (DELETE):
+const handleChange = useCallback((elements, appState, excalidrawFiles) => {
+  if (isUpdatingFromFileRef.current) return;
+  if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+  saveTimerRef.current = setTimeout(async () => {
+    const content = serializeToFile(elements, appState, excalidrawFiles);
+    lastSavedContentRef.current = content;  // ← LOAD-BEARING ORDERING
+    await fetch(`${getApiBase()}/api/files`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ path: currentFilePathRef.current, content }),
+    });
+  }, 500);
+}, []);
+```
+
+New logic:
+
+```tsx
+const handleChange = useCallback((elements, appState, excalidrawFiles) => {
+  if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+  saveTimerRef.current = setTimeout(async () => {
+    const content = serializeToFile(elements, appState, excalidrawFiles);
+    const path = currentFilePathRef.current;
+    if (!path) return;
+    try {
+      await fileChannel.write(path, content);
+    } catch (err) {
+      console.error("[draw] save failed", err);
+    }
+  }, 500);
+}, [fileChannel]);
+```
+
+Notice what's gone:
+- No `isUpdatingFromFileRef` guard — concurrent writes are already serialized by the source system's writeQueue semantics *for declared sources*, and for `fileChannel.write` the server's `pendingSelfWrites` guarantees echo tagging regardless of timing.
+- No `lastSavedContentRef.current = content` line. The origin tag from the server is what drives the "did my save echo back" decision, not a local ref.
+- No load-bearing ordering. The save-before-fetch dance is gone.
+
+(e) Delete the inline `saveFile` helper function at the top of the file (lines 94–106):
+
+```tsx
+// DELETE the whole module-scoped saveFile function
+```
+
+- [ ] **Step 3: Typecheck and smoke**
+
+```bash
+bun run tsc --noEmit 2>&1 | tail -10
+bun run dev draw --port 17996 --workspace /tmp/draw-smoke
+```
+
+Manual test flow:
+1. Open the browser, draw a few shapes, wait for the debounced save (500ms).
+2. Edit `/tmp/draw-smoke/drawing.excalidraw` externally (e.g., with a text editor — tweak an element's position). Save.
+3. Verify the viewer remounts with the external changes.
+4. Draw again; verify no remount flash occurs on the self-echo.
+5. chrome-devtools-mcp screenshot before/after.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add modes/draw/manifest.ts modes/draw/viewer/DrawPreview.tsx
+git commit -m "$(cat <<'EOF'
+refactor(draw): migrate to props.sources + fileChannel (P5.7)
+
+Deletes the load-bearing lastSavedContentRef = content before fetch
+ordering and the isUpdatingFromFileRef 500ms busy flag. Origin is
+determined server-side via pendingSelfWrites; the viewer now only
+remounts Excalidraw on external-origin events, eliminating the visual
+flash on self-saves.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 5.8: Migrate `gridboard`
+
+**Files:**
+- Modify: `modes/gridboard/manifest.ts`
+- Modify: `modes/gridboard/viewer/GridBoardPreview.tsx`
+
+GridBoard writes `board.json` + capture images on drag/resize/lock. Saves are awaited and synchronous so there's no echo-guard in the current code. Migration is mostly mechanical: replace the inline `saveFile` helper with `fileChannel.write`.
+
+- [ ] **Step 1: Add `sources` to `modes/gridboard/manifest.ts`**
+
+```ts
+sources: {
+  files: {
+    kind: "file-glob",
+    config: {
+      patterns: [
+        "board.json",
+        "theme.css",
+        "tiles/**/*.tsx",
+        "tiles/**/*.ts",
+        "tiles/**/*.css",
+      ],
+    },
+  },
+},
+```
+
+- [ ] **Step 2: Update `GridBoardPreview.tsx`**
+
+(a) Destructure `sources` + `fileChannel`:
+
+```tsx
+import type { Source } from "../../../core/types/source.js";
+import type { ViewerFileContent } from "../../../core/types/viewer-contract.js";
+import { useSource } from "../../../src/hooks/useSource.js";
+
+export default function GridBoardPreview({
+  sources,
+  fileChannel,
+  // ... other existing props minus `files`
+}: ViewerPreviewProps) {
+  const filesSource = sources.files as Source<ViewerFileContent[]>;
+  const { value: filesValue } = useSource(filesSource);
+  const files: ViewerFileContent[] = filesValue ?? [];
+  // ... rest of component
+```
+
+(b) Delete the module-scoped `saveFile` helper (lines 165–171):
+
+```tsx
+// DELETE the whole function
+```
+
+(c) Replace every `saveFile(path, content)` call site (grep for them — around lines 530, 672, 886, 947) with:
+
+```tsx
+await fileChannel.write(path, content);
+```
+
+All call sites are already inside `async` functions that `await` the result, so the signature change is zero-effort — just swap the function name and make sure `fileChannel` is in scope (it comes from the outer component props, so any callback that uses `saveFile` needs to capture `fileChannel`).
+
+If a call site is in a `useCallback` with a `[]` deps array, add `fileChannel` to the deps.
+
+- [ ] **Step 3: Typecheck + smoke + commit**
+
+```bash
+bun run tsc --noEmit 2>&1 | tail -5
+bun run dev gridboard --port 17996 --workspace /tmp/gridboard-smoke
+# Drag a tile, resize, lock — verify persistence to board.json
+# Edit board.json externally, verify the viewer reflects the change
+git add modes/gridboard/manifest.ts modes/gridboard/viewer/GridBoardPreview.tsx
+git commit -m "$(cat <<'EOF'
+refactor(gridboard): migrate to props.sources + fileChannel (P5.8)
+
+Replaces inline saveFile helper with fileChannel.write() at all four
+call sites. No behavioral change — gridboard had no echo guard to
+begin with and was correct by accident of synchronous awaited saves.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 5.9: Migrate `slide`
+
+**Files:**
+- Create: `modes/slide/domain.ts`
+- Modify: `modes/slide/manifest.ts`
+- Modify: `modes/slide/viewer/SlidePreview.tsx`
+
+**Pattern: C (aggregate-file).** Slide's domain is a **Deck** — an ordered list of slides + theme + title — serialized as `manifest.json` + `slides/*.html` + `theme.css`. The current SlidePreview.tsx stringifies `manifest.json` inline in three places (reorder, delete, implied by debounced text edit). That's domain leakage into the viewer. Lift it.
+
+- [ ] **Step 1: Define the domain type and pure functions in `modes/slide/domain.ts`**
+
+```ts
+import type { ViewerFileContent } from "../../core/types/viewer-contract.js";
+
+export interface Slide {
+  id: string;          // stable identifier, usually derived from the file name
+  file: string;        // relative path e.g. "slides/slide-01.html"
+  html: string;        // the slide's HTML body
+  title?: string;      // derived from first <h1> or stored in manifest
+}
+
+export interface Deck {
+  title: string;       // from manifest.json top-level
+  theme: string;       // contents of theme.css (raw CSS)
+  slides: Slide[];     // ordered as per manifest.json's slides array
+}
+
+/**
+ * Reconstruct a Deck from the current file snapshot.
+ *
+ * Returns null if manifest.json is missing (source stays in "no
+ * initial yet" until agent creates one). Throws if manifest.json
+ * exists but is malformed — parse errors become error events.
+ *
+ * Implementation note: the parsing logic already exists in the
+ * current SlidePreview.tsx's useResilientParse + manifest parse
+ * block. Port that logic here verbatim — same JSON.parse, same
+ * field extraction. Then index slides by `manifest.slides[].file`
+ * and look up each file's content from `files` to populate
+ * slides[].html. If a slide file referenced by the manifest is
+ * missing, skip it (don't fail the whole parse).
+ */
+export function loadDeck(files: ReadonlyArray<ViewerFileContent>): Deck | null {
+  const manifest = files.find((f) => f.path === "manifest.json" || f.path.endsWith("/manifest.json"));
+  if (!manifest) return null;
+  const parsed = JSON.parse(manifest.content);  // throws on bad JSON → error event
+  if (typeof parsed !== "object" || parsed === null) {
+    throw new Error("manifest.json is not an object");
+  }
+  const title = typeof parsed.title === "string" ? parsed.title : "Untitled";
+  const theme = files.find((f) => f.path === "theme.css" || f.path.endsWith("/theme.css"))?.content ?? "";
+  const slideEntries: Array<{ file: string; id?: string; title?: string }> =
+    Array.isArray(parsed.slides) ? parsed.slides : [];
+  const slides: Slide[] = slideEntries
+    .map((entry) => {
+      const file = entry.file;
+      const html = files.find((f) => f.path === file || f.path.endsWith("/" + file))?.content;
+      if (html === undefined) return null;
+      return {
+        id: entry.id ?? file,
+        file,
+        html,
+        title: entry.title,
+      };
+    })
+    .filter((s): s is Slide => s !== null);
+  return { title, theme, slides };
+}
+
+/**
+ * Decompose a new Deck back into file operations.
+ *
+ * Computes the diff against the current snapshot to produce:
+ *   - writes for manifest.json (always), theme.css (if changed),
+ *     and every slide file whose html differs from current
+ *   - deletes for slide files that existed in current but are
+ *     no longer in `next.slides` (user deleted or reordered out)
+ *
+ * Implementation note: the viewer used to do this in three places
+ * (handleReorderSlide, handleDeleteSlide, handleTextEdit). That
+ * logic collapses into one function here. The provider's write()
+ * executes all writes before all deletes in order, then emits a
+ * single self event — viewer no longer sees three separate saves.
+ */
+export function saveDeck(
+  next: Deck,
+  current: ReadonlyArray<ViewerFileContent>,
+): { writes: Array<{ path: string; content: string }>; deletes: string[] } {
+  const writes: Array<{ path: string; content: string }> = [];
+
+  // 1. manifest.json — always write (reflects current title + order)
+  const manifestJson = JSON.stringify(
+    {
+      title: next.title,
+      slides: next.slides.map((s) => ({ file: s.file, id: s.id, title: s.title })),
+    },
+    null,
+    2,
+  ) + "\n";
+  writes.push({ path: "manifest.json", content: manifestJson });
+
+  // 2. theme.css — write only if changed
+  const currentTheme = current.find((f) => f.path === "theme.css" || f.path.endsWith("/theme.css"));
+  if (currentTheme?.content !== next.theme) {
+    writes.push({ path: "theme.css", content: next.theme });
+  }
+
+  // 3. Each slide — write only if html differs
+  for (const slide of next.slides) {
+    const existing = current.find((f) => f.path === slide.file || f.path.endsWith("/" + slide.file));
+    if (existing?.content !== slide.html) {
+      writes.push({ path: slide.file, content: slide.html });
+    }
+  }
+
+  // 4. Deletes — slide files that existed but are no longer referenced
+  const keep = new Set(next.slides.map((s) => s.file));
+  const deletes = current
+    .filter((f) => f.path.startsWith("slides/") && f.path.endsWith(".html"))
+    .map((f) => f.path)
+    .filter((p) => !keep.has(p) && !keep.has(p.replace(/^.*slides\//, "slides/")));
+
+  return { writes, deletes };
+}
+```
+
+- [ ] **Step 2: Update `modes/slide/manifest.ts`**
+
+```ts
+import { loadDeck, saveDeck } from "./domain.js";
+import type { Deck } from "./domain.js";
+
+// ... in manifest body:
+sources: {
+  deck: {
+    kind: "aggregate-file",
+    config: {
+      patterns: [
+        "**/slides/*.html",
+        "**/manifest.json",
+        "**/theme.css",
+      ],
+      load: loadDeck,
+      save: saveDeck,
+    },
+  },
+  // Keep a file-glob for assets which stay file-shaped (images, fonts, etc.)
+  assets: {
+    kind: "file-glob",
+    config: { patterns: ["**/assets/**/*"] },
+  },
+},
+```
+
+- [ ] **Step 3: Rewrite `SlidePreview.tsx` to consume `Source<Deck>` directly**
+
+The viewer's data source becomes `useSource(sources.deck as Source<Deck>)`. Every place that currently does `files.find((f) => f.path === "manifest.json")` is replaced by reading `deck.title`, `deck.slides`, `deck.theme` directly. The three separate write paths (reorder, delete, text edit) collapse into one pattern:
+
+```tsx
+// Reorder: compute nextSlides, then:
+await writeDeck({ ...deck, slides: nextSlides });
+
+// Delete a slide: filter it out, then:
+await writeDeck({ ...deck, slides: deck.slides.filter((s) => s.id !== deletedId) });
+
+// Debounced text edit: replace html on one slide, then:
+await writeDeck({
+  ...deck,
+  slides: deck.slides.map((s) => s.id === editedId ? { ...s, html: newHtml } : s),
+});
+```
+
+The viewer no longer knows manifest.json exists. The provider's `save()` figures out that changing `deck.slides[2].html` means writing `slides/slide-03.html`; changing the slide order means writing manifest.json; removing a slide means both writing manifest.json AND deleting the old file. **All the domain→files translation is in `saveDeck`, exactly once.**
+
+Delete the following from SlidePreview.tsx:
+- The three inline `fetch('/api/files', ...)` blocks (lines 639–646, 674–681, 700–707)
+- The module-scoped `baseUrl` resolution
+- Any `pendingChangesRef` / batching that only existed to collect text edits before POSTing
+- The `useResilientParse` call for manifest.json — loadDeck covers it
+
+- [ ] **Step 4: Typecheck, smoke, commit**
+
+```bash
+bun run tsc --noEmit 2>&1 | tail -5
+bun run dev slide --port 17996 --workspace /tmp/slide-smoke
+```
+
+Manual test:
+1. Drag-reorder two slides — verify `manifest.json` reflects new order, slide files unchanged.
+2. Delete a slide — verify both manifest update AND the slide file is removed from disk.
+3. Double-click to edit a slide's text — verify only that slide's file is rewritten, manifest unchanged.
+4. Let the agent add a new slide externally — verify the viewer picks it up via loadDeck and renders it.
+
+```bash
+git add modes/slide/domain.ts modes/slide/manifest.ts modes/slide/viewer/SlidePreview.tsx
+git commit -m "$(cat <<'EOF'
+refactor(slide): domain-typed migration to aggregate-file source (P5.9)
+
+Introduces modes/slide/domain.ts with the Deck type plus loadDeck /
+saveDeck pure functions. SlidePreview now consumes Source<Deck>
+directly — zero files.find() calls, zero JSON.stringify, zero inline
+POST /api/files. The three write paths (reorder / delete / text edit)
+collapse into writeDeck(nextDeck); the provider's save() computes the
+diff and produces the correct set of writes + deletes.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 5.10: Migrate `webcraft`
+
+**Files:**
+- Create: `modes/webcraft/domain.ts`
+- Modify: `modes/webcraft/manifest.ts`
+- Modify: `modes/webcraft/viewer/WebPreview.tsx`
+
+**Pattern: C (aggregate-file).** Webcraft's domain is a **Site** — a set of HTML pages + their CSS/JS/assets, usually organized by `manifest.json` and optionally scoped by content sets. The viewer currently does `useResilientParse` on manifest.json to find pages, falls back to globbing `*.html`, then writes edits via debounced fetch. All of that (parse, fallback, serialize) becomes `loadSite` / `saveSite` in a pure domain module.
+
+- [ ] **Step 1: Define the Site domain in `modes/webcraft/domain.ts`**
+
+```ts
+import type { ViewerFileContent } from "../../core/types/viewer-contract.js";
+
+export interface Page {
+  file: string;        // e.g. "index.html" or "pneuma/about.html" when scoped
+  title: string;
+  html: string;        // the full HTML document
+}
+
+export interface StaticAsset {
+  path: string;        // css/js/font/image path as written in manifest or globbed
+  content: string;     // raw text for text assets; empty for binary (image cache-bust)
+}
+
+export interface Site {
+  contentSet: string | null;  // the active content-set prefix, e.g. "pneuma" — or null for top-level
+  manifest: { pages: Array<{ file: string; title?: string }> } | null;
+  pages: Page[];              // all pages visible under the active content set
+  assets: StaticAsset[];      // CSS/JS/fonts/images matched by file-glob, for preview bundling
+}
+
+/**
+ * Reconstruct a Site from the workspace snapshot, scoped by the active
+ * content set (passed via a closure if needed, or computed from the
+ * current active content set elsewhere in runtime — for the first cut,
+ * load() sees the entire workspace and the viewer filters).
+ *
+ * Implementation note: port the useResilientParse + fallback-to-html-glob
+ * logic from current WebPreview.tsx verbatim. Return null only if the
+ * workspace is completely empty.
+ */
+export function loadSite(files: ReadonlyArray<ViewerFileContent>): Site | null {
+  if (files.length === 0) return null;
+  // 1. Find top-level manifest.json (or nested one — current code handles both)
+  const manifestFile = files.find((f) => f.path === "manifest.json" || f.path.endsWith("/manifest.json"));
+  let manifest: Site["manifest"] = null;
+  if (manifestFile) {
+    try {
+      const parsed = JSON.parse(manifestFile.content);
+      const entries = parsed.pages || parsed.files;
+      if (Array.isArray(entries)) {
+        manifest = { pages: entries.map((p: { file?: string; path?: string; title?: string }) => ({
+          file: p.file || p.path || "",
+          title: p.title,
+        })).filter((p) => p.file.length > 0) };
+      }
+    } catch {
+      // Fall through to HTML glob fallback
+    }
+  }
+  // 2. Build pages list — from manifest if present, else from all .html files
+  const pages: Page[] = [];
+  const pageEntries = manifest?.pages ?? files
+    .filter((f) => /\.html$/i.test(f.path))
+    .map((f) => ({ file: f.path, title: undefined as string | undefined }));
+  for (const entry of pageEntries) {
+    const htmlFile = files.find((f) => f.path === entry.file || f.path.endsWith("/" + entry.file));
+    if (!htmlFile) continue;
+    pages.push({
+      file: entry.file,
+      title: entry.title || entry.file.replace(/\.html$/i, "").replace(/^.*\//, ""),
+      html: htmlFile.content,
+    });
+  }
+  // 3. Collect static assets (everything else that isn't HTML or manifest.json)
+  const assets: StaticAsset[] = files
+    .filter((f) => !/\.html$/i.test(f.path) && !f.path.endsWith("manifest.json"))
+    .map((f) => ({ path: f.path, content: f.content }));
+  return { contentSet: null, manifest, pages, assets };
+}
+
+/**
+ * Decompose a new Site back into file operations. For the current
+ * webcraft write flow, only Page.html changes come from the viewer
+ * (via iframe text edits); manifest.json and assets are written by
+ * the agent directly and shouldn't be round-tripped through save().
+ *
+ * save() therefore computes a minimal diff: write only the pages
+ * whose html has changed vs the current snapshot. Deletes are
+ * empty (webcraft viewer doesn't delete pages today). When the
+ * viewer later gains structural editing (add/remove pages), extend
+ * save() to also rewrite manifest.json and produce delete entries.
+ */
+export function saveSite(
+  next: Site,
+  current: ReadonlyArray<ViewerFileContent>,
+): { writes: Array<{ path: string; content: string }>; deletes: string[] } {
+  const writes: Array<{ path: string; content: string }> = [];
+  for (const page of next.pages) {
+    // Find the current content — respecting content-set scoping
+    const existing = current.find(
+      (f) => f.path === page.file || f.path.endsWith("/" + page.file),
+    );
+    if (!existing || existing.content !== page.html) {
+      // Preserve content-set prefix if the existing file had one
+      const targetPath = existing?.path ?? (next.contentSet ? `${next.contentSet}/${page.file}` : page.file);
+      writes.push({ path: targetPath, content: page.html });
+    }
+  }
+  return { writes, deletes: [] };
+}
+```
+
+- [ ] **Step 2: Update `modes/webcraft/manifest.ts`**
+
+```ts
+import { loadSite, saveSite } from "./domain.js";
+import type { Site } from "./domain.js";
+
+// ... in manifest body:
+sources: {
+  site: {
+    kind: "aggregate-file",
+    config: {
+      patterns: [
+        "**/*.html", "**/*.css", "**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx",
+        "**/*.json", "**/*.svg", "**/*.png", "**/*.jpg", "**/*.jpeg",
+        "**/*.gif", "**/*.webp", "**/*.woff", "**/*.woff2",
+      ],
+      load: loadSite,
+      save: saveSite,
+    },
+  },
+},
+```
+
+- [ ] **Step 3: Rewrite `WebPreview.tsx` to consume `Source<Site>`**
+
+The viewer destructures `{ sources, ... }` and consumes `const { value: site, write: writeSite, status } = useSource(sources.site as Source<Site>)`. All `useResilientParse` usage is deleted — loadSite produced the parsed `site.manifest` and `site.pages` already.
+
+The iframe-message-driven text edit handler becomes:
+
+```tsx
+const handleTextEdit = useCallback((pageFile: string, newHtml: string) => {
+  if (!site) return;
+  const nextPages = site.pages.map((p) => p.file === pageFile ? { ...p, html: newHtml } : p);
+  writeSite({ ...site, pages: nextPages }).catch((err) => {
+    console.error("[webcraft] save failed", err);
+  });
+}, [site, writeSite]);
+```
+
+And the iframe `srcdoc` reload gate becomes origin-aware:
+
+```tsx
+useEffect(() => {
+  if (!iframeRef.current || !site) return;
+  // Skip iframe reload on self-origin echoes — we already have the
+  // latest content in local React state, reloading would wipe cursor
+  // and scroll position. External edits (agent) still trigger reload.
+  if (status.lastOrigin === "self") return;
+  iframeRef.current.srcdoc = buildSrcdoc(site, currentFile);
+}, [site, status.lastOrigin, currentFile]);
+```
+
+Delete from WebPreview.tsx:
+- The inline `fetch('/api/files', ...)` block (lines 1004–1008)
+- `apiBase` resolution
+- `useResilientParse` for manifest.json — replaced by `site.manifest`
+- Any fallback-to-html-glob logic — replaced by `site.pages`
+- `stableSrcdocRef` iframe-stability hack that only existed to mask self-echo flashes
+
+(c) Consider whether the `srcdoc` reassignment on every `files` prop change (line 927) can be made origin-aware. Currently it always reloads the iframe; that's wasteful on self-origin echoes. The improvement:
+
+```tsx
+// Around the srcdoc assignment — gate on origin.
+// OLD:
+//   if (iframeRef.current) iframeRef.current.srcdoc = srcdoc;
+// NEW:
+if (iframeRef.current && status.lastOrigin !== "self") {
+  iframeRef.current.srcdoc = srcdoc;
+}
+```
+
+where `status` comes from `const { value: filesValue, status } = useSource(filesSource)`. This means a self-echo no longer reloads the iframe — the in-DOM state is already current. External edits still reload as before.
+
+- [ ] **Step 3: Typecheck + smoke + commit**
+
+```bash
+bun run tsc --noEmit 2>&1 | tail -5
+bun run dev webcraft --port 17996 --workspace /tmp/webcraft-smoke
+```
+
+Manual test:
+1. Edit text in the preview iframe; wait 1s; verify the HTML file updates.
+2. Verify no flash / reload occurs on self-save (this is the new behavior — used to flash).
+3. Edit the HTML file externally; verify the iframe reloads with the new content.
+4. Switch active content set; verify correct path scoping.
+
+```bash
+git add modes/webcraft/manifest.ts modes/webcraft/viewer/WebPreview.tsx
+git commit -m "$(cat <<'EOF'
+refactor(webcraft): migrate to props.sources + fileChannel (P5.10)
+
+Routes handleTextEdit through fileChannel.write. Gates srcdoc reload
+on origin !== "self", eliminating the flash-on-self-save regression
+the pre-P5 code papered over with a debounced write queue.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 5.11: Final cleanup — remove `files` from `ViewerPreviewProps` and `useViewerProps`
+
+**Files:**
+- Modify: `core/types/viewer-contract.ts`
+- Modify: `src/App.tsx`
+- Modify: `core/source-registry.ts` (remove the synthesis fallback — every mode now declares sources explicitly)
+
+At this point every mode consumes `props.sources` and no mode reads `props.files`. Time to delete it.
+
+- [ ] **Step 1: Delete `files` from `ViewerPreviewProps`**
+
+In `core/types/viewer-contract.ts`, remove the `files: ViewerFileContent[]` field (the one marked `@deprecated` from Task 3.6).
+
+- [ ] **Step 2: Delete `files` from `useViewerProps` return**
+
+In `src/App.tsx`, in the `useViewerProps` return object, remove the `files` field. Also remove the `rawFiles`, `activeContentSet`, and `files` useMemo block that computes the content-set-scoped array (around lines 90–100), IF no other part of the return object needs it.
+
+**Important subtlety:** the content-set-scoped path stripping (the `files` memo that applied `pfx = activeContentSet + "/"` and sliced paths) was viewer-facing behavior. Each migrated viewer is now reading files through `useSource(sources.files)`, which delivers RAW paths — unscoped. The viewers that care about content sets (slide, webcraft, illustrate with content sets enabled) need to apply the same scoping themselves, or the `file-glob` provider needs to do it.
+
+The cleanest fix: move content-set scoping into the `file-glob` provider via a runtime decorator. The runtime wraps the provider in a `ScopedSource` that applies path stripping before each emission. This keeps viewers unchanged from their pre-P5 read pattern and the `file-glob` provider remains content-set-ignorant.
+
+Add to `src/App.tsx` `useSourceInstances` (after building the built + channel):
+
+```tsx
+// Decorate file-glob instances with a content-set path scoper.
+const activeContentSet = useStore.getState().activeContentSet;
+const scoped: Record<string, Source<unknown>> = {};
+for (const [id, src] of Object.entries(built)) {
+  scoped[id] = activeContentSet
+    ? wrapWithContentSetScope(src as Source<ViewerFileContent[]>, activeContentSet) as unknown as Source<unknown>
+    : src;
+}
+```
+
+And a helper (also in `src/App.tsx` or a new `src/runtime/scoped-source.ts`):
+
+```tsx
+function wrapWithContentSetScope(
+  inner: Source<ViewerFileContent[]>,
+  prefix: string,
+): Source<ViewerFileContent[]> {
+  const pfx = prefix + "/";
+  const strip = (files: ViewerFileContent[]): ViewerFileContent[] =>
+    files
+      .filter((f) => f.path.startsWith(pfx))
+      .map((f) => ({ path: f.path.slice(pfx.length), content: f.content }));
+
+  const listeners = new Set<(e: SourceEvent<ViewerFileContent[]>) => void>();
+  const innerOff = inner.subscribe((e) => {
+    if (e.kind === "value") {
+      for (const l of listeners) l({ ...e, value: strip(e.value) });
+    } else {
+      for (const l of listeners) l(e);
+    }
+  });
+
+  return {
+    current: () => {
+      const v = inner.current();
+      return v ? strip(v) : null;
+    },
+    subscribe: (l) => {
+      listeners.add(l);
+      return () => listeners.delete(l);
+    },
+    write: async (v) => {
+      // Unscoped write — re-prepend the prefix to each path.
+      // file-glob is read-only anyway, so write throws; keep the
+      // signature honest.
+      await inner.write(v);
+    },
+    destroy: () => {
+      listeners.clear();
+      innerOff();
+      // Note: we do NOT destroy `inner` — the registry owns its lifetime.
+    },
+  };
+}
+```
+
+Subtler still: the `useSourceInstances` hook currently rebuilds only on `manifest` change. If `activeContentSet` changes, the hook doesn't re-run. Add `activeContentSet` to the dependency array of the effect:
+
+```tsx
+const manifest = useStore((s) => s.modeManifest);
+const activeContentSet = useStore((s) => s.activeContentSet);
+// ...
+useEffect(() => { /* build/teardown */ }, [manifest, activeContentSet]);
+```
+
+And inside the effect, the registry construction uses the current `activeContentSet` closure.
+
+- [ ] **Step 3: Remove the synthesis fallback**
+
+In `core/source-registry.ts`, change `effectiveSources` from:
+
+```ts
+static effectiveSources(manifest: ModeManifest): Record<string, SourceDescriptor> {
+  if (manifest.sources && Object.keys(manifest.sources).length > 0) {
+    return manifest.sources;
+  }
+  return {
+    files: {
+      kind: "file-glob",
+      config: {
+        patterns: manifest.viewer.watchPatterns,
+        ignore: manifest.viewer.ignorePatterns,
+      },
+    },
+  };
+}
+```
+
+to:
+
+```ts
+static effectiveSources(manifest: ModeManifest): Record<string, SourceDescriptor> {
+  if (!manifest.sources) {
+    throw new Error(
+      `ModeManifest "${manifest.name}" is missing the required \`sources\` ` +
+        `field. Every mode must explicitly declare its data channels ` +
+        `(see docs/superpowers/plans/2026-04-13-source-abstraction.md).`,
+    );
+  }
+  return manifest.sources;
+}
+```
+
+Empty `sources: {}` is still legal — that's the evolve case.
+
+- [ ] **Step 4: Update `core/__tests__/source-registry.test.ts`**
+
+The test `synthesizeDefault creates a file-glob source from viewer.watchPatterns if sources is absent` now expects a throw. Replace:
+
+```ts
+test("effectiveSources throws if manifest.sources is absent", () => {
+  const manifestLike = {
+    name: "test",
+    viewer: { watchPatterns: ["**/*.md"], ignorePatterns: [] },
+    sources: undefined,
+  };
+  expect(() =>
+    SourceRegistry.effectiveSources(manifestLike as unknown as ModeManifest),
+  ).toThrow(/sources/);
+});
+```
+
+Run: `bun test core/__tests__/source-registry.test.ts` — expected all tests passing with the updated assertion.
+
+- [ ] **Step 5: Full typecheck, full test suite, full mode smoke**
+
+```bash
+bun run tsc --noEmit 2>&1 | tail -20
+bun test 2>&1 | tail -15
+```
+
+Expected: tsc clean, all tests passing. If any mode is still reading `props.files`, tsc will fail (the field no longer exists on the type). That's the mechanical enforcement — fix any holdouts.
+
+Then re-smoke every mode:
+
+```bash
+for mode in mode-maker evolve illustrate diagram doc draw gridboard slide webcraft; do
+  echo "=== $mode ==="
+  bun run dev $mode --port 17996 --workspace /tmp/$mode-smoke &
+  sleep 5
+  # chrome-devtools-mcp navigate and screenshot
+  kill %1
+done
+```
+
+(In practice, smoke each mode one at a time, interactively, rather than via a loop — the launcher test in P6 will catch any cross-mode regression.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add \
+  core/types/viewer-contract.ts \
+  src/App.tsx \
+  core/source-registry.ts \
+  core/__tests__/source-registry.test.ts \
+  src/runtime/scoped-source.ts
+
+git commit -m "$(cat <<'EOF'
+refactor(source): remove deprecated files prop, require explicit sources (P5.11)
+
+- Deletes ViewerPreviewProps.files (deprecated since P3)
+- Deletes useViewerProps's files remap and content-set scoping in the
+  prop path; scoping now happens via ScopedSource wrapper inside
+  useSourceInstances
+- SourceRegistry.effectiveSources throws if a mode omits `sources`;
+  synthesis fallback is gone
+- Every mode has an explicit sources declaration after tasks 5.1-5.10
+
+End of P5. Next: P6 end-to-end verification before P7's ClipCraft
+migration guide.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+
+## Phase 6: End-to-end verification
+
+P6 is the gate before P7. Nothing lands on main until every check here is green. This phase has no commits — it's pure verification + a single "release-candidate" tag at the end if everything passes.
+
+### Task 6.1: Whole-repo typecheck
+
+- [ ] **Step 1: Run**
+
+```bash
+bun run tsc --noEmit 2>&1 | tee /tmp/p6-tsc.log
+```
+
+Expected: zero errors. If any error exists, it is a regression introduced in P5 and must be traced back to its commit and fixed (do NOT paper over with `any` or `@ts-ignore`).
+
+### Task 6.2: Full test suite
+
+- [ ] **Step 1: Run**
+
+```bash
+bun test 2>&1 | tee /tmp/p6-tests.log | tail -30
+```
+
+Expected: all suites passing. Count of tests should match: existing pre-plan count + 7 (source-types) + 16 (base) + 5 (memory) + 8 (file-glob) + 10 (json-file) + 7 (source-registry) + 1 (plugin-registry new test). That's +54 tests minimum from this plan. Confirm the delta is roughly right — if the new count is LOWER than expected, a test file wasn't picked up; investigate.
+
+### Task 6.3: Per-mode interactive smoke
+
+For each mode, start the dev server in a clean workspace, exercise the golden path in the browser, and capture a screenshot via chrome-devtools-mcp. Compare against the pre-P5 screenshot baseline (if available from an earlier commit's manual test).
+
+- [ ] **Mode: mode-maker**
+
+```bash
+mkdir -p /tmp/p6-mode-maker && bun run dev mode-maker --port 17996 --workspace /tmp/p6-mode-maker
+```
+Check: scaffolded files appear in the file tree, `manifest.ts` renders, no console errors.
+Screenshot: `chrome-devtools-mcp` → `take_screenshot` at `http://localhost:17996`.
+
+- [ ] **Mode: evolve**
+
+Evolve has no viewer. Skip the browser smoke; just confirm the server starts without throwing:
+
+```bash
+bun run dev evolve --port 17996 --workspace /tmp/p6-evolve 2>&1 | head -30
+# Expect: "listening" log, no stack traces
+# Ctrl-C to stop
+```
+
+- [ ] **Mode: illustrate**
+
+```bash
+mkdir -p /tmp/p6-illustrate && bun run dev illustrate --port 17996 --workspace /tmp/p6-illustrate
+```
+Check: manifest.json loads, image rows render, content set switcher works.
+
+- [ ] **Mode: diagram**
+
+```bash
+mkdir -p /tmp/p6-diagram && bun run dev diagram --port 17996 --workspace /tmp/p6-diagram
+```
+Check: seeded `.drawio` renders, can zoom/pan, agent-authored streaming updates still work (simulate by writing to a .drawio file from another terminal).
+
+- [ ] **Mode: doc**
+
+```bash
+mkdir -p /tmp/p6-doc && bun run dev doc --port 17996 --workspace /tmp/p6-doc
+```
+Critical checks:
+1. Type in the editor → file appears on disk after 1s (debounced save).
+2. External edit (`echo '# external' > /tmp/p6-doc/test.md`) → viewer reflects it.
+3. Concurrent test: type continuously, then external edit arrives → verify no crash and that SELF-ORIGIN echoes don't reset the cursor.
+
+- [ ] **Mode: draw**
+
+```bash
+mkdir -p /tmp/p6-draw && bun run dev draw --port 17996 --workspace /tmp/p6-draw
+```
+Critical checks:
+1. Draw shapes → file updates after 500ms.
+2. External edit → viewer remounts Excalidraw with new state.
+3. No visual flash on self-save (the regression we fixed in P5.7).
+
+- [ ] **Mode: gridboard**
+
+```bash
+mkdir -p /tmp/p6-gridboard && bun run dev gridboard --port 17996 --workspace /tmp/p6-gridboard
+```
+Checks: drag a tile, resize, lock — all persist to `board.json`.
+
+- [ ] **Mode: slide**
+
+```bash
+mkdir -p /tmp/p6-slide && bun run dev slide --port 17996 --workspace /tmp/p6-slide
+```
+Checks: reorder slides, delete a slide, edit text in a slide — all three write paths work.
+
+- [ ] **Mode: webcraft**
+
+```bash
+mkdir -p /tmp/p6-webcraft && bun run dev webcraft --port 17996 --workspace /tmp/p6-webcraft
+```
+Critical checks:
+1. Edit text in the preview iframe → HTML file updates.
+2. NO flash/reload on self-save (this was the big improvement).
+3. External edit → iframe reloads.
+4. Switch content set → correct scoping.
+
+- [ ] **Mode: remotion** (optional — claude-code backend only)
+
+If claude-code is configured:
+```bash
+mkdir -p /tmp/p6-remotion && bun run dev remotion --port 17996 --workspace /tmp/p6-remotion
+```
+Check: Remotion Player renders, composition list updates on src/ changes.
+
+If not configured: document skip, rely on tsc + unit tests for remotion.
+
+### Task 6.4: Launcher walkthrough
+
+- [ ] **Step 1: Start launcher**
+
+```bash
+bun run dev --port 17996
+```
+
+- [ ] **Step 2: Open browser at `http://localhost:17996`**
+
+- [ ] **Step 3: For each mode in the built-in section, click once, verify spawn**
+
+Click doc → verify child session opens on auto-incremented port, viewer renders. Close. Click diagram → same. Repeat for every built-in mode. Confirm: no launcher crashes, no browser console errors about missing `files` or `sources` props, no stale dist/ fallback.
+
+- [ ] **Step 4: Switch between modes via Recent Sessions**
+
+Verify: a prior doc session resumes with content intact. Switch to a prior gridboard session; verify it loads correctly. This exercises the session registry path + source rebuilding on mode change.
+
+- [ ] **Step 5: Tag a release candidate**
+
+If everything above is green:
+
+```bash
+git tag -a p6-green -m "P6 end-to-end verification complete — all modes migrated to source abstraction"
+```
+
+Do NOT push the tag (per the plan's no-manual-tag rule). The tag is local, just to mark the verified state in case you need to bisect forward from P7.
+
+---
+
+## Phase 7: ClipCraft migration guide
+
+P7 is one task: write a document that the ClipCraft mode author (on a separate branch) can follow to adopt the new source abstraction in place of their current three-ref + null-reset implementation.
+
+### Task 7.1: Author `clipcraft-source-migration.md`
+
+**Files:**
+- Create: `docs/superpowers/plans/clipcraft-source-migration.md`
+
+- [ ] **Step 1: Write the guide**
+
+```markdown
+# ClipCraft Source Migration Guide
+
+> **Audience:** the author of the ClipCraft mode, whose branch currently lives in `feat/clipcraft-by-pneuma-craft`. This document explains how to replace the `useProjectSync` + `externalEdit.ts` + three-ref dance with a single `json-file` source declaration against the new source abstraction that landed on `main` as `feat/source-abstraction`.
+>
+> **Prerequisite:** rebase your ClipCraft branch onto the new main first. The source abstraction is already in place for every other mode; your branch will fail to compile until `ViewerPreviewProps.files` is removed and `ViewerPreviewProps.sources` is required.
+
+## What you delete
+
+| File / Symbol | Why |
+|---|---|
+| `useProjectSync` hook | Replaced by a one-line `useSource(props.sources.project)` call. |
+| `ClipCraftPreview.lastAppliedRef` | Replaced by server-side `pendingSelfWrites` origin tagging. |
+| `useProjectSync.hydratedDiskRef` | Same — `useSyncExternalStore` inside `useSource` handles React 19 StrictMode double-invocation correctly, no ref dance needed. |
+| `ClipCraftPreview.providerKey` bump + remount | Keep (conceptually) but trigger it on `status.lastOrigin === "external"` instead of on a string-compare of `lastAppliedRef`. The remount is still needed because the Zustand craft store is live state that can't safely receive duplicate commands. |
+| `modes/clipcraft/viewer/externalEdit.ts` | Delete the whole file. |
+| `currentTitleRef` | Still needed until craft gets a project-level title concept. Leave it alone. |
+| `ClipCraftPreview.onExternalEdit` null-reset of `lastAppliedRef.current` | Gone — the ref is gone. This is the load-bearing coupling you hit in Plan 3b; it no longer exists to get wrong. |
+
+## What you add
+
+### 1. Declare the project source in `manifest.ts`
+
+```ts
+import type { ProjectFile } from "./types.js";
+import { parseProjectFile, formatProjectJson } from "./serialization.js";
+
+const clipcraftManifest: ModeManifest = {
+  // ... existing fields ...
+
+  sources: {
+    project: {
+      kind: "json-file",
+      config: {
+        path: "project.json",
+        parse: (raw: string): ProjectFile => {
+          const result = parseProjectFile(raw);
+          if (!result.ok) throw new Error(result.error);
+          return result.value;
+        },
+        serialize: (v: ProjectFile) => formatProjectJson(v),
+      },
+    },
+    // You can still declare a file-glob if you want to render other
+    // files in the workspace (e.g., an exported .mp4 list). But
+    // project.json is the canonical write target.
+    files: {
+      kind: "file-glob",
+      config: { patterns: ["**/*"] },
+    },
+  },
+};
+```
+
+### 2. Replace `useProjectSync` with a thin inline binding
+
+Your current hook returns whatever bag of state ClipCraftPreview needs. The new shape: consume the source directly in `ClipCraftPreview`, dispatch to the Zustand store on `initial` events, bump `providerKey` on `external` events, write via `source.write` on debounced autosave.
+
+```tsx
+export function ClipCraftPreview({
+  sources,
+  // ... other props
+}: ViewerPreviewProps) {
+  const projectSource = sources.project as Source<ProjectFile>;
+  const { value: project, status, write: writeProject } = useSource(projectSource);
+
+  const dispatchEnvelope = usePneumaCraftStore((s) => s.dispatchEnvelope);
+  const coreState = usePneumaCraftStore((s) => s.coreState);
+  const composition = usePneumaCraftStore((s) => s.composition);
+  const eventCount = useEventLog().length;
+  const currentTitleRef = useRef<string>("Untitled");
+  const [providerKey, setProviderKey] = useState(0);
+  const lastHydratedRef = useRef<"initial" | "external" | null>(null);
+
+  // Hydrate the craft store from initial or external loads.
+  // Skip self-origin events — they're echoes of our own autosave,
+  // and the craft store already reflects them (we dispatched the
+  // envelopes before writing).
+  useEffect(() => {
+    if (!project) return;
+    if (status.lastOrigin === "self") return;
+    if (status.lastOrigin === "initial") {
+      currentTitleRef.current = project.title;
+      for (const env of projectFileToCommands(project)) {
+        try { dispatchEnvelope(env); } catch (e) { console.warn("[clipcraft] dispatch failed", e); }
+      }
+      lastHydratedRef.current = "initial";
+      return;
+    }
+    if (status.lastOrigin === "external") {
+      // Remount: the craft store is live and may have uncommitted state.
+      // Bumping providerKey gives us a fresh store; the initial-hydration
+      // branch above then re-plays the new project into it.
+      setProviderKey((k) => k + 1);
+      lastHydratedRef.current = "external";
+    }
+  }, [project, status.lastOrigin, dispatchEnvelope]);
+
+  // Autosave.
+  useEffect(() => {
+    if (!project) return;
+    const timer = setTimeout(async () => {
+      const file = serializeProject(coreState, composition, currentTitleRef.current);
+      try {
+        await writeProject(file);
+      } catch (err) {
+        console.error("[clipcraft] autosave failed", err);
+      }
+    }, 500);
+    return () => clearTimeout(timer);
+  }, [eventCount, coreState, composition, writeProject, project]);
+
+  return (
+    <PneumaCraftProvider key={providerKey}>
+      <ClipCraftCanvas />
+    </PneumaCraftProvider>
+  );
+}
+```
+
+### 3. Delete the dead files
+
+```bash
+rm modes/clipcraft/viewer/hooks/useProjectSync.ts
+rm modes/clipcraft/viewer/externalEdit.ts
+git add -A
+git commit -m "refactor(clipcraft): delete useProjectSync + externalEdit (migrated to source abstraction)"
+```
+
+## Why this is correct
+
+The ClipCraft original proposal's four pieces of state:
+
+| Ref/State | Old owner | New owner |
+|---|---|---|
+| `lastAppliedRef` | parent component, across remounts | server-side `pendingSelfWrites` map |
+| `hydratedDiskRef` | hook instance, per-remount | React's `useSyncExternalStore` (inside `useSource`) |
+| `providerKey: number` | parent state | **STAY** — still needed for craft store rebuild on external |
+| `currentTitleRef` | hook instance | **STAY** — title side-channel until craft gets title concept |
+
+The two load-bearing pieces (`lastAppliedRef` + `hydratedDiskRef`) are gone because both were reverse-engineering origin information that the server already knows. The `providerKey` remount dance stays because remount-on-external-edit is ClipCraft's strategy for state-machine rebuild — that's a semantic decision the transport can't replace. But the **trigger** for the remount is now a clean `status.lastOrigin === "external"` check, not a string-compare against a ref.
+
+The E2E regression Plan 3b shipped (the load-bearing ordering between `lastAppliedRef.current = null` and `setProviderKey(...)`) is structurally impossible now. The ordering that had to be correct doesn't exist.
+
+## Things the abstraction does NOT solve
+
+- **Diff-and-dispatch.** The craft store is still rebuilt from scratch on external edit. Preserving undo history / PlaybackEngine position across agent edits is a separate future plan.
+- **Title side-channel.** `currentTitleRef` stays because craft has no title concept.
+- **Serialization determinism.** `formatProjectJson` still needs to be byte-deterministic or parse-failure edge cases can leak into `origin: "error"` events. Check your serializer.
+
+## Verification
+
+After the refactor lands:
+
+```bash
+bun run tsc --noEmit
+bun test
+bun run dev clipcraft --port 17996 --workspace /tmp/clipcraft-smoke
+```
+
+Manual test:
+1. Create a project, make edits, verify autosave (`cat /tmp/clipcraft-smoke/project.json`).
+2. Edit `project.json` externally with a new composition; verify the craft store remounts and reflects the change.
+3. Type in a text field WHILE an external edit arrives — verify no crash, no stale-ref infinite remount.
+4. Run the E2E test Plan 3b added. It should pass without any of the previous "load-bearing ordering" comments being load-bearing.
+```
+
+- [ ] **Step 2: Commit the guide**
+
+```bash
+git add docs/superpowers/plans/clipcraft-source-migration.md
+git commit -m "$(cat <<'EOF'
+docs(source): ClipCraft migration guide (P7)
+
+Step-by-step for migrating ClipCraft off the three-ref + null-reset
+dance documented in 2026-04-13-mode-sync-transport.md onto the new
+json-file source. Targets the author of feat/clipcraft-by-pneuma-craft,
+not executed by this branch.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 3: Final state — ready to merge `feat/source-abstraction` to main**
+
+At this point the branch is ready for a PR:
+- P1 contract + docs committed
+- P2 providers + tests committed
+- P3 runtime integration committed
+- P4 plugin extension committed
+- P5 all 9 mode migrations + final cleanup committed
+- P6 E2E verification passed (no commits, local tag only)
+- P7 ClipCraft guide committed
+
+Present the branch to the user for review. Recommend opening the PR with the P1 commit hash as the "start here" anchor, so reviewers can follow the natural P1→P7 narrative.
+
+---
+
+## Self-review checklist
+
+After the plan has been reviewed and before execution starts:
+
+- [ ] Every phase ends with a commit, and the commit message names the phase (P1–P7).
+- [ ] Every code step shows real code, not placeholders.
+- [ ] The Source contract described in Task 1.1 matches what Tasks 2.2, 2.4, 2.6, 2.8 actually implement (same method names, same event shape).
+- [ ] Every new file created in earlier tasks is referenced by at least one later task (no orphan files).
+- [ ] Every mode migration in P5 deletes the specific refs and call sites that the P5 intro table identified.
+- [ ] `fileChannel` prop is introduced in P5.6 and its consumers are all of P5.6–P5.10.
+- [ ] The content-set scoping fix in P5.11 applies to every viewer that previously relied on `useViewerProps` remapping (slide, webcraft, illustrate if content-sets enabled).
+- [ ] The synthesis fallback in P3 is removed in P5.11.
+- [ ] P6 smoke covers every mode P5 migrated.
+- [ ] P7 references the original mode-sync-transport.md plan that this effort superseded.
+
+---
+
+## Out of scope (explicit reminders)
+
+- **Splitting webcraft into `manifest` + `pages` + `assets` sources.** Webcraft migrates as a single `files` file-glob to preserve behavior. Domain refactoring is a follow-up.
+- **Removing `viewer.watchPatterns` from the manifest.** Kept in place; it's still what drives server-side chokidar. `sources` is additive.
+- **A React context for source access (`<SourceProvider>`).** Prop drilling via `props.sources` is enough. Adding a context is a separate polish task.
+- **Dynamic source instantiation** (create a source mid-session for a user-selected file). Not needed — use `fileChannel.write()` for dynamic targets.
+- **Backwards compatibility beyond this branch.** No deprecation windows, no dual-prop period after P5.11. The branch ships the abstraction whole.
+- **ClipCraft code changes.** P7 produces a guide only. The branch never touches `modes/clipcraft/`.
+
+---
+

--- a/docs/superpowers/plans/clipcraft-source-migration.md
+++ b/docs/superpowers/plans/clipcraft-source-migration.md
@@ -1,0 +1,307 @@
+# ClipCraft Source Migration Guide
+
+> **Audience:** the author of the ClipCraft mode, whose branch lives in `feat/clipcraft-by-pneuma-craft`. This document explains how to replace the `useProjectSync` + `externalEdit.ts` + three-ref dance with a single `json-file` source declaration against the source abstraction that landed on `main` via `feat/source-abstraction` (commits `90429bc`..`ba4928b`).
+>
+> **Prerequisite:** rebase your ClipCraft branch onto the new `main` first. The source abstraction is already in place for every other mode; your branch will fail to compile because `ViewerPreviewProps.files` no longer exists — every mode now receives `props.sources` + `props.fileChannel` instead.
+>
+> **Companion reading:** `docs/superpowers/plans/2026-04-13-source-abstraction.md` (the full plan, still on the branch as historical context), `docs/reference/viewer-agent-protocol.md` (the "Sources — Viewer 的数据通道" section), and the original `docs/superpowers/plans/2026-04-13-mode-sync-transport.md` (superseded, but its analysis of the ClipCraft three-ref dance is still the clearest description of the failure mode).
+
+## What you delete
+
+Every piece of state the original three-ref dance needed is replaced by infrastructure that already exists on `main`:
+
+| Old | Why it existed | New owner |
+|---|---|---|
+| `ClipCraftPreview.lastAppliedRef: string \| null` | Parent-component ref that survived provider remount so the next hydration could tell "did I already apply this exact content?" — reverse-engineered echo detection | **Server-side `pendingSelfWrites` map** (`server/file-watcher.ts`). The runtime tags every chokidar echo of a viewer-originated write with `origin: "self"` at the source, before the event ever reaches the browser. |
+| `useProjectSync.hydratedDiskRef: string \| null` | Hook-instance ref to handle React 19 StrictMode double-invocation of effects | **`useSyncExternalStore` inside `useSource`**. StrictMode re-subscribes cleanly without re-emitting initial; `current()` is the stable source of truth for first render. |
+| `ClipCraftPreview.onExternalEdit` null-reset of `lastAppliedRef.current` before `setProviderKey` | Load-bearing ordering — the original bug in Plan 3b — that had to run in exactly the right sequence to avoid infinite remount | **Gone entirely.** The ordering that had to be correct doesn't exist anymore. |
+| `modes/clipcraft/viewer/externalEdit.ts` (the file) | `isExternalEdit()` pure helper + supporting machinery | **Delete the whole file.** Replaced by `status.lastOrigin === "external"` from `useSource`. |
+| `useProjectSync` hook (the file) | Coordinated the 3-ref dance + autosave debounce + dispatchEnvelope loop | Replaced by inline subscribe + write effects in `ClipCraftPreview`. See Step 2 below. |
+| Module-scoped `writeProjectFile` helper (if you have one) that calls `POST /api/files` | The ClipCraft side of the echo loop | Replaced by `source.write(value)` — the `json-file` provider handles serialization + persistence + self-event emission atomically. |
+
+## What stays
+
+Not everything from the three-ref dance was about echo detection. These stay because they're semantic decisions, not plumbing:
+
+| Kept | Reason |
+|---|---|
+| `providerKey: number` state in the parent | You still need to remount the Zustand craft store on external edits — the craft state machine can't safely receive duplicate commands against a live store, so "nuke and rehydrate from the new project" remains the right strategy. What changes is the **trigger**: a clean `status.lastOrigin === "external"` check, not a string-compare against a ref. |
+| `currentTitleRef: string` | The craft store has no project-level title concept; the title lives as a side-channel in the viewer until craft gains one. Not related to the echo problem — leave it alone. |
+| 500ms autosave debounce | Still needed so rapid local edits don't thrash the disk. Just move the debounce to wrap `source.write(...)` instead of wrapping the old fetch. |
+
+## What you add
+
+### Step 1: Declare a `json-file` source in `manifest.ts`
+
+ClipCraft's domain is a single structured aggregate (`ProjectFile`) persisted at `project.json`. That's exactly what `json-file` is for:
+
+```ts
+// modes/clipcraft/manifest.ts
+import { parseProjectFile, formatProjectJson } from "./serialization.js";
+import type { ProjectFile } from "./types.js";
+
+const clipcraftManifest: ModeManifest = {
+  // ... existing fields (name, version, displayName, description, skill, viewer, agent, ...) ...
+
+  sources: {
+    project: {
+      kind: "json-file",
+      config: {
+        path: "project.json",
+        parse: (raw: string): ProjectFile => {
+          const result = parseProjectFile(raw);
+          if (!result.ok) throw new Error(result.error);
+          return result.value;
+        },
+        serialize: (value: ProjectFile): string => formatProjectJson(value),
+      },
+    },
+    // If ClipCraft's viewer also needs to render a list of exported .mp4 files
+    // or any other workspace-adjacent content (timeline thumbnails, asset
+    // library, etc.), declare a second file-glob source alongside `project`.
+    // Otherwise leave sources to just the single `project` entry.
+  },
+};
+
+export default clipcraftManifest;
+```
+
+Key points:
+- **`parse` throws on invalid content.** The `json-file` provider catches the throw and emits a `{ kind: "error", code: "E_PARSE" }` event, leaving the source live for future updates. Your viewer's error UI (if any) reads from `useSource`'s `status.lastError`.
+- **`serialize` must be deterministic.** Same `ProjectFile` input → byte-identical string output every time. If `formatProjectJson` has any nondeterminism (timestamps, Map iteration order, floating-point format), fix that first — otherwise the server-side `pendingSelfWrites` content-equality match will miss echoes and you'll see phantom "external" events for your own writes.
+
+### Step 2: Replace `useProjectSync` with a thin inline binding in `ClipCraftPreview`
+
+The old hook returned a bag of state and effects. The new shape uses `useSource` directly. Here's the complete replacement shape — port the inner details to match your existing craft store calls:
+
+```tsx
+// modes/clipcraft/viewer/ClipCraftPreview.tsx
+import { useEffect, useRef, useState } from "react";
+import { useSource } from "../../../src/hooks/useSource.js";
+import type { Source } from "../../../core/types/source.js";
+import type { ViewerPreviewProps } from "../../../core/types/viewer-contract.js";
+import type { ProjectFile } from "./types.js";
+import {
+  usePneumaCraftStore,
+  useEventLog,
+  serializeProject,
+  projectFileToCommands,
+} from "./craft-integration.js"; // your existing craft store glue
+
+export function ClipCraftPreview({ sources }: ViewerPreviewProps) {
+  const projectSource = sources.project as Source<ProjectFile>;
+  const { value: project, write: writeProject, status } = useSource(projectSource);
+
+  const dispatchEnvelope = usePneumaCraftStore((s) => s.dispatchEnvelope);
+  const coreState = usePneumaCraftStore((s) => s.coreState);
+  const composition = usePneumaCraftStore((s) => s.composition);
+  const eventCount = useEventLog().length;
+
+  const currentTitleRef = useRef<string>("Untitled");
+  const [providerKey, setProviderKey] = useState(0);
+
+  // ── 1. Hydration: initial or external → rebuild craft store ─────────
+  //
+  // Self-origin events are our own autosave coming back through the
+  // FileChannel. The craft store already reflects them (we dispatched
+  // envelopes BEFORE calling writeProject below), so skip them here —
+  // rebuilding on self would replay the same envelopes against a store
+  // that already has them.
+  useEffect(() => {
+    if (!project) return;
+    if (status.lastOrigin === "self") return;
+
+    if (status.lastOrigin === "initial") {
+      // First hydration on mount. The provider remount machinery above
+      // (providerKey) is at its initial value, so the craft store is
+      // fresh and ready.
+      currentTitleRef.current = project.title;
+      for (const env of projectFileToCommands(project)) {
+        try {
+          dispatchEnvelope(env);
+        } catch (e) {
+          console.warn("[clipcraft] initial dispatch failed", e);
+        }
+      }
+      return;
+    }
+
+    if (status.lastOrigin === "external") {
+      // Agent (or another writer) edited project.json while we were
+      // watching. The craft store has live in-flight state that can't
+      // safely accept duplicate commands — bump providerKey to rebuild
+      // a fresh store, and the NEXT render will fall into the "initial"
+      // branch above (against the new store) to re-play the new project.
+      //
+      // Note: this still loses undo history and PlaybackEngine position.
+      // That's a known limitation — diff-and-dispatch is a separate
+      // future plan, not part of the source abstraction.
+      setProviderKey((k) => k + 1);
+    }
+  }, [project, status.lastOrigin, dispatchEnvelope]);
+
+  // ── 2. Autosave: debounced serialize + source.write ─────────────────
+  //
+  // No more ref-before-fetch dance. source.write() is atomic and the
+  // self event comes back through subscribe with origin === "self", at
+  // which point the hydration effect above sees it and skips — no loop.
+  useEffect(() => {
+    const timer = setTimeout(async () => {
+      const file = serializeProject(
+        coreState,
+        composition,
+        currentTitleRef.current,
+      );
+      try {
+        await writeProject(file);
+        // After await resolves, the provider guarantees:
+        //   - content is on disk
+        //   - status.lastOrigin === "self"
+        //   - all current subscribers have seen the self event
+        //   - `useSource`'s `value` reflects the new file
+        // You don't need any post-write bookkeeping.
+      } catch (err) {
+        console.error("[clipcraft] autosave failed", err);
+      }
+    }, 500);
+    return () => clearTimeout(timer);
+  }, [eventCount, coreState, composition, writeProject]);
+
+  // ── 3. Render with remount key ──────────────────────────────────────
+  return (
+    <PneumaCraftProvider key={providerKey}>
+      <ClipCraftCanvas />
+    </PneumaCraftProvider>
+  );
+}
+```
+
+Things to notice:
+
+- **The `write()` Promise is time-locked.** `await writeProject(file)` resolves only after the provider has (a) persisted via `FileChannel.write`, (b) updated `current()`, (c) delivered the `{ origin: "self" }` event to all subscribers. The P2 `BaseSource` contract guarantees this — tests at `core/sources/__tests__/base.test.ts` pin it.
+- **No optimistic state.** `useSource` gives you `value` straight from the latest subscription event. After `await writeProject(v)`, the next render reads `value === v` automatically. You never have to hold a local copy.
+- **No ref bookkeeping for echo detection.** The `status.lastOrigin === "self"` guard in the hydration effect is enough. There's no `lastAppliedRef`, no `hydratedDiskRef`, no `dirtyRef`, no load-bearing ordering.
+- **`providerKey` remount still exists** but its trigger is a clean origin check. The old null-reset-then-setProviderKey ordering is gone.
+
+### Step 3: Delete the dead files
+
+Once `ClipCraftPreview` consumes `useSource` directly, these files have no callers and no purpose:
+
+```bash
+rm modes/clipcraft/viewer/hooks/useProjectSync.ts
+rm modes/clipcraft/viewer/externalEdit.ts
+```
+
+If you have additional helpers under `modes/clipcraft/viewer/hooks/` that were only used by `useProjectSync`, delete those too. Grep to be sure:
+
+```bash
+grep -rn "useProjectSync\|lastAppliedRef\|hydratedDiskRef\|isExternalEdit" modes/clipcraft/
+```
+
+Expected: empty after the refactor.
+
+## Why this is correct
+
+Your four pieces of state, mapped to their new owners:
+
+| Piece | Old location | New location |
+|---|---|---|
+| `lastAppliedRef` | Parent component state, survived remount | Server-side `pendingSelfWrites: Map<path, { content, expiresAt }>` with a 5s TTL — tags chokidar echoes at the source, before they become WS events |
+| `hydratedDiskRef` | Hook instance, died on remount | React's `useSyncExternalStore` via `useSource` — StrictMode-safe by construction |
+| `providerKey: number` | **STAY** | **STAY** — this is ClipCraft's state-machine rebuild strategy, not an echo-detection artifact |
+| `currentTitleRef` | Hook instance | **STAY** — title side-channel until craft gains a title concept |
+
+The load-bearing ordering that was load-bearing — `lastAppliedRef.current = null; setProviderKey(k => k + 1)` — is gone because `lastAppliedRef` is gone. There's no longer a pair of mutations whose order can be wrong. The E2E regression Plan 3b shipped (silently wrong ordering → infinite remount under specific timing) is **structurally impossible** on the new shape.
+
+## What the source abstraction does NOT fix for you
+
+These are real limitations of the new shape that you'll want to know about before you rely on them:
+
+1. **Undo history and PlaybackEngine position are still lost on external edit.** Remount-on-external stays. Preserving in-memory craft state across agent edits requires diff-and-dispatch, which is a separate future plan — probably driven by Plan 4's playback needs. If an agent edit drops the user in the middle of a long timeline, they'll still see the playhead reset. This is not a regression from your current shape — your current shape already remounts on external edit; it just does so fragile-ly.
+
+2. **`currentTitleRef` as a side-channel.** The title lives outside `project.title` because there's no clean place for it in the craft store's command graph. Nothing in this migration changes that. The cleanest long-term fix is to make "title" a first-class craft concept, dispatched as a command like everything else, so `serializeProject` reads it from the store directly and `currentTitleRef` goes away. Out of scope for P7.
+
+3. **Serialize determinism.** If `formatProjectJson` emits different bytes for equivalent inputs (e.g., because it JSON.stringify's a `Map` which iterates in insertion order but the store mutates that order), the `pendingSelfWrites` content-equality check will miss the echo and `status.lastOrigin` will come back `"external"` for your own write. Symptom: writing anything immediately triggers a spurious remount. Fix: make serialization canonical (sort keys, sort arrays where order doesn't matter, etc.). Check this before you ship.
+
+4. **`Source.write()` rejects on disk failure.** If the server-side `/api/files` POST fails (disk full, permission denied, path outside workspace), `await writeProject(file)` rejects. The autosave effect above catches the rejection and logs. You may want a UI affordance for "save failed, retry?" — that's UX polish on top of the contract, not a gap in the contract.
+
+5. **There is no `aggregate-file` equivalent for ClipCraft.** Your domain IS one file (`project.json`), so `json-file` is the right provider. If you later add multi-file structure (e.g., separate timeline clips per file, or external asset manifests), consider switching to `aggregate-file` — the plan's slide / webcraft / illustrate migrations are working examples of that pattern. See `modes/slide/domain.ts` for a complete `loadDeck` / `saveDeck` reference implementation.
+
+## Verification
+
+After the refactor lands on your branch:
+
+```bash
+bun run tsc --noEmit 2>&1 | grep -E "modes/clipcraft"
+```
+Expected: empty (or only pre-existing errors unrelated to the migration — pre-existing seed template errors like `modes/clipcraft/seed/**` are fine).
+
+```bash
+bun test
+```
+Expected: existing test suite still passes. If you have E2E tests for ClipCraft (Plan 3b added at least one), they should keep passing — in fact, the one covering the load-bearing ordering bug should pass MORE robustly because the ordering no longer exists to get wrong.
+
+Manual smoke tests:
+
+1. **Fresh session.** Launch clipcraft against an empty workspace. Verify the scaffolded `project.json` loads and the canvas renders — this exercises `origin: "initial"`.
+2. **Local edit round-trip.** Make several rapid edits in the canvas. Verify:
+   - `project.json` on disk updates (tail -f the file to confirm)
+   - The craft store does NOT remount on your own saves (no flash, no cursor jumps)
+   - After each `await writeProject(...)` settles, `status.lastOrigin === "self"` at the next render
+3. **Agent edit while watching.** Start the agent on the same workspace. Ask it to modify the project. Verify:
+   - The viewer detects the change (`status.lastOrigin === "external"` at the next render)
+   - The craft store rebuilds via `providerKey++`
+   - The new project state renders correctly
+4. **Concurrent edit.** Type rapidly in the canvas AND have the agent issue edits in the same second. Verify no crash, no stuck remount loop, and that the user's in-flight local edits are either (a) preserved if the agent's external edit arrived after the local save's disk ack, or (b) replaced by the agent's version if the external edit arrived first. Either resolution is acceptable — what's NOT acceptable is a phantom infinite remount, which is the regression Plan 3b once shipped. If you see infinite remount, the most likely cause is `formatProjectJson` non-determinism (see limitation #3 above).
+
+## Commit boundaries
+
+The refactor breaks down into three clean commits on your branch:
+
+```bash
+# Commit 1 — declare the source
+git add modes/clipcraft/manifest.ts
+git commit -m "feat(clipcraft): declare sources.project as json-file
+
+Replaces the imperative useProjectSync scaffolding with a declarative
+source at the manifest layer. Viewer still reads from the legacy plumbing
+until commit 2."
+
+# Commit 2 — migrate the viewer
+git add modes/clipcraft/viewer/ClipCraftPreview.tsx
+git commit -m "refactor(clipcraft): migrate ClipCraftPreview to useSource(project)
+
+Deletes the three-ref dance (lastAppliedRef / hydratedDiskRef /
+ordering-dependent null-reset) and replaces it with a single
+useSource(sources.project). origin === \"external\" triggers the
+same providerKey remount the old onExternalEdit did, but without
+any of the state bookkeeping.
+
+autosave debounce is preserved; scheduleSave now calls source.write()
+directly and relies on the provider's time-locked write Promise.
+
+Load-bearing ordering that shipped broken in Plan 3b is structurally
+impossible on the new shape."
+
+# Commit 3 — delete the dead files
+git add modes/clipcraft/viewer/hooks/useProjectSync.ts \
+        modes/clipcraft/viewer/externalEdit.ts
+git commit -m "refactor(clipcraft): delete useProjectSync + externalEdit (dead code)
+
+Replaced by useSource(sources.project) + origin-tagged events in
+ClipCraftPreview. Both files have zero callers after the migration."
+```
+
+## Questions or pushback
+
+If something in this guide doesn't fit your branch's actual state — maybe your serialization layer is different, maybe `currentTitleRef` is actually deletable in your version, maybe you have a different parent-component shape than `ClipCraftPreview` — **adapt rather than fight the pattern**. The important thing is:
+
+1. Declare a `json-file` source with your `parse` and `serialize`
+2. Consume it via `useSource` in the viewer
+3. Replace autosave fetch with `source.write`
+4. Gate remount on `status.lastOrigin === "external"`
+5. Delete everything that was reverse-engineering origin from content
+
+Everything else is detail you own.
+
+If the abstraction can't express something you need — e.g., you want to observe `"self"` events for some reason, or you need per-path write serialization across multiple sources — flag it back to the `feat/source-abstraction` authors. The contract in `core/types/source.ts` is still fresh and can evolve.

--- a/modes/diagram/manifest.ts
+++ b/modes/diagram/manifest.ts
@@ -28,6 +28,13 @@ You are running inside **Pneuma**, a co-creation environment. The user sees a li
     serveDir: ".",
   },
 
+  sources: {
+    files: {
+      kind: "file-glob",
+      config: { patterns: ["**/*.drawio"] },
+    },
+  },
+
   viewerApi: {
     workspace: {
       type: "all",

--- a/modes/diagram/viewer/DiagramPreview.tsx
+++ b/modes/diagram/viewer/DiagramPreview.tsx
@@ -16,7 +16,10 @@ import { createPortal } from "react-dom";
 import type {
   ViewerPreviewProps,
   ViewerSelectionContext,
+  ViewerFileContent,
 } from "../../../core/types/viewer-contract.js";
+import type { Source } from "../../../core/types/source.js";
+import { useSource } from "../../../src/hooks/useSource.js";
 import { useStore } from "../../../src/store.js";
 import { setDiagramCaptureViewport } from "../pneuma-mode.js";
 import ScaffoldConfirm from "../../../src/components/ScaffoldConfirm.js";
@@ -44,7 +47,7 @@ function getApiBase(): string {
 
 /** Parse active .drawio file content */
 function parseDrawioFile(
-  files: ViewerPreviewProps["files"],
+  files: ViewerFileContent[],
   activeFile?: string | null,
 ): { content: string; filePath: string } | null {
   if (activeFile) {
@@ -69,7 +72,7 @@ function stripHtml(html: string): string {
 // ── Main Component ───────────────────────────────────────────────────────────
 
 export default function DiagramPreview({
-  files,
+  sources,
   selection,
   onSelect: rawOnSelect,
   mode: rawPreviewMode,
@@ -83,6 +86,10 @@ export default function DiagramPreview({
 }: ViewerPreviewProps) {
   const previewMode = readonly ? "view" : rawPreviewMode;
   const onSelect = readonly ? (() => {}) : rawOnSelect;
+
+  const filesSource = sources.files as Source<ViewerFileContent[]>;
+  const { value: filesValue } = useSource(filesSource);
+  const files: ViewerFileContent[] = filesValue ?? [];
 
   const setPreviewMode = useStore((s) => s.setPreviewMode);
   const pushUserAction = useStore((s) => s.pushUserAction);
@@ -135,8 +142,7 @@ export default function DiagramPreview({
   const [pan, setPan] = useState({ x: 0, y: 0 });
   const isDragging = useRef(false);
 
-  // Echo detection — track last rendered content
-  const lastFileContentRef = useRef<string>("");
+  // Tracks the active file path for callbacks (set when drawioData changes)
   const currentFilePathRef = useRef<string>("");
 
   // ── draw.io loading ─────────────────────────────────────────────────────
@@ -376,10 +382,7 @@ export default function DiagramPreview({
       return;
     }
 
-    const { content, filePath } = drawioData;
-
-    // Echo detection
-    if (content === lastFileContentRef.current && filePath === currentFilePathRef.current) return;
+    const { content } = drawioData;
 
     // Parse pages from the .drawio file
     const parsedPages = extractDiagramPages(content);
@@ -402,9 +405,6 @@ export default function DiagramPreview({
       const pageXml = parsedPages[0]?.xml;
       if (pageXml) mergeModelXml(pageXml);
     }
-
-    lastFileContentRef.current = content;
-    currentFilePathRef.current = filePath;
   }, [ready, drawioData, mergeModelXml, fitToCenter, resetGraph, activePageIdx]);
 
   // ── Real-time streaming from agent tool input ──────────────────────────

--- a/modes/doc/manifest.ts
+++ b/modes/doc/manifest.ts
@@ -37,6 +37,13 @@ For editing conventions, context format, and workspace constraints, consult the 
     serveDir: ".",
   },
 
+  sources: {
+    files: {
+      kind: "file-glob",
+      config: { patterns: ["**/*.md"] },
+    },
+  },
+
   viewerApi: {
     workspace: { type: "all", multiFile: true, ordered: false, hasActiveFile: false },
     locatorDescription: 'After creating or editing documents, embed locator cards so the user can jump to them. Navigate to file: `data=\'{"file":"notes.md"}\'`.',

--- a/modes/doc/viewer/DocPreview.tsx
+++ b/modes/doc/viewer/DocPreview.tsx
@@ -12,7 +12,9 @@ import { createPortal } from "react-dom";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeRaw from "rehype-raw";
-import type { ViewerPreviewProps, ViewerSelectionContext } from "../../../core/types/viewer-contract.js";
+import type { ViewerPreviewProps, ViewerSelectionContext, ViewerFileContent } from "../../../core/types/viewer-contract.js";
+import type { Source, FileChannel } from "../../../core/types/source.js";
+import { useSource } from "../../../src/hooks/useSource.js";
 
 // v1.0: DocPreview still references the store to control previewMode toggle.
 // This is a pragmatic coupling that can be decoupled via an onModeChange callback in the future.
@@ -209,23 +211,9 @@ function buildNearbyText(el: HTMLElement): string {
   return parts.join(" ");
 }
 
-/** Save file content to server */
-async function saveFile(path: string, content: string): Promise<boolean> {
-  try {
-    const baseUrl = import.meta.env.DEV ? `http://${location.hostname}:${import.meta.env.VITE_API_PORT || "17007"}` : "";
-    const res = await fetch(`${baseUrl}/api/files`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ path, content }),
-    });
-    return res.ok;
-  } catch {
-    return false;
-  }
-}
-
 export default function DocPreview({
-  files,
+  sources,
+  fileChannel,
   selection,
   onSelect: rawOnSelect,
   mode: rawPreviewMode,
@@ -240,6 +228,11 @@ export default function DocPreview({
   onNavigateComplete,
   readonly,
 }: ViewerPreviewProps) {
+  // Derive files from sources.files
+  const filesSource = sources.files as Source<ViewerFileContent[]>;
+  const { value: filesValue, status: filesStatus } = useSource(filesSource);
+  const files: ViewerFileContent[] = filesValue ?? [];
+
   // Readonly mode: force view, suppress selection
   const previewMode = readonly ? "view" : rawPreviewMode;
   const onSelect = readonly ? (() => {}) : rawOnSelect;
@@ -680,7 +673,13 @@ export default function DocPreview({
           }`}
         >
           {activeFiles.map((file) => (
-            <MarkdownEditor key={file.path} file={file} isDark={isDark} />
+            <MarkdownEditor
+              key={file.path}
+              file={file}
+              isDark={isDark}
+              fileChannel={fileChannel}
+              lastOrigin={filesStatus.lastOrigin}
+            />
           ))}
         </div>
       ) : (
@@ -737,29 +736,42 @@ export default function DocPreview({
 
 // ── Markdown Editor (Edit mode) ─────────────────────────────────────────────
 
-function MarkdownEditor({ file, isDark }: { file: { path: string; content: string }; isDark: boolean }) {
+function MarkdownEditor({
+  file,
+  isDark,
+  fileChannel,
+  lastOrigin,
+}: {
+  file: { path: string; content: string };
+  isDark: boolean;
+  fileChannel: FileChannel;
+  lastOrigin: "initial" | "self" | "external" | null;
+}) {
   const [saving, setSaving] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const lastExternalRef = useRef(file.content);
   const lastSavedForActionRef = useRef(file.content);
   const pushUserAction = useStore((s) => s.pushUserAction);
 
   useEffect(() => {
     const el = textareaRef.current;
-    if (el && file.content !== lastExternalRef.current) {
+    if (!el) return;
+    if (lastOrigin === "self") return;
+    if (el.value !== file.content) {
       el.value = file.content;
-      lastExternalRef.current = file.content;
       lastSavedForActionRef.current = file.content;
     }
-  }, [file.content]);
+  }, [file.content, lastOrigin]);
 
   const scheduleSave = useCallback((content: string) => {
     if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
     saveTimerRef.current = setTimeout(async () => {
       setSaving(true);
-      await saveFile(file.path, content);
-      lastExternalRef.current = content;
+      try {
+        await fileChannel.write(file.path, content);
+      } catch (err) {
+        console.error("[doc] save failed", err);
+      }
       setSaving(false);
 
       // Generate user action with line-level diff summary
@@ -790,16 +802,18 @@ function MarkdownEditor({ file, isDark }: { file: { path: string; content: strin
         });
       }
     }, 800);
-  }, [file.path, pushUserAction]);
+  }, [file.path, fileChannel, pushUserAction]);
 
   useEffect(() => {
     return () => {
       if (saveTimerRef.current && textareaRef.current) {
         clearTimeout(saveTimerRef.current);
-        saveFile(file.path, textareaRef.current.value);
+        fileChannel.write(file.path, textareaRef.current.value).catch((err) => {
+          console.error("[doc] save failed", err);
+        });
       }
     };
-  }, [file.path]);
+  }, [file.path, fileChannel]);
 
   const handleInput = () => {
     const el = textareaRef.current;

--- a/modes/draw/manifest.ts
+++ b/modes/draw/manifest.ts
@@ -38,6 +38,13 @@ For Excalidraw JSON format, element types, color palette, and diagram recipes, c
     serveDir: ".",
   },
 
+  sources: {
+    files: {
+      kind: "file-glob",
+      config: { patterns: ["**/*.excalidraw"] },
+    },
+  },
+
   viewerApi: {
     workspace: { type: "all", multiFile: true, ordered: false, hasActiveFile: true },
     locatorDescription: 'After creating drawings, embed locator cards so the user can switch to them. Navigate to file: `data=\'{"file":"architecture.excalidraw"}\'`.',

--- a/modes/draw/viewer/DrawPreview.tsx
+++ b/modes/draw/viewer/DrawPreview.tsx
@@ -16,7 +16,10 @@ import { createPortal } from "react-dom";
 import type {
   ViewerPreviewProps,
   ViewerSelectionContext,
+  ViewerFileContent,
 } from "../../../core/types/viewer-contract.js";
+import type { Source } from "../../../core/types/source.js";
+import { useSource } from "../../../src/hooks/useSource.js";
 import { useStore } from "../../../src/store.js";
 import { setDrawCaptureViewport } from "../pneuma-mode.js";
 import ScaffoldConfirm from "../../../src/components/ScaffoldConfirm.js";
@@ -44,7 +47,7 @@ function loadExcalidraw(): Promise<void> {
 
 /** Parse .excalidraw JSON from files array — prefer activeFile, fallback to first valid */
 function parseExcalidrawFile(
-  files: ViewerPreviewProps["files"],
+  files: ViewerFileContent[],
   activeFile?: string | null,
 ): { elements: any[]; appState: any; excalidrawFiles: any; filePath: string } | null {
   // If activeFile specified, try it first
@@ -91,20 +94,6 @@ function getApiBase(): string {
   return "";
 }
 
-/** Save file content to server */
-async function saveFile(path: string, content: string): Promise<boolean> {
-  try {
-    const res = await fetch(`${getApiBase()}/api/files`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ path, content }),
-    });
-    return res.ok;
-  } catch {
-    return false;
-  }
-}
-
 /** Serialize Excalidraw data to .excalidraw JSON string */
 function serializeToFile(elements: any[], appState: any, files: any): string {
   const exportState: Record<string, any> = {};
@@ -129,7 +118,8 @@ function serializeToFile(elements: any[], appState: any, files: any): string {
 // ── Main Component ───────────────────────────────────────────────────────────
 
 export default function DrawPreview({
-  files,
+  sources,
+  fileChannel,
   selection,
   onSelect: rawOnSelect,
   mode: rawPreviewMode,
@@ -142,6 +132,10 @@ export default function DrawPreview({
   onNavigateComplete,
   readonly,
 }: ViewerPreviewProps) {
+  // Derive files from sources.files
+  const filesSource = sources.files as Source<ViewerFileContent[]>;
+  const { value: filesValue, status } = useSource(filesSource);
+  const files: ViewerFileContent[] = filesValue ?? [];
   // Readonly mode: force view, suppress selection and editing
   const previewMode = readonly ? "view" : rawPreviewMode;
   const onSelect = readonly ? (() => {}) : rawOnSelect;
@@ -255,12 +249,8 @@ export default function DrawPreview({
   pushUserActionRef.current = pushUserAction;
   // Track element state for user action descriptions
   const prevElementSnapshotRef = useRef<Map<string, { type: string; text?: string }>>(new Map());
-  // Track what we last saved to avoid echo from file watcher
-  const lastSavedContentRef = useRef<string>("");
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const currentFilePathRef = useRef<string>("");
-  // Suppress onChange during Excalidraw remount initialization
-  const isUpdatingFromFileRef = useRef(false);
   // Key to force Excalidraw remount on external file changes.
   // updateScene() breaks text rendering — remount goes through proper font init.
   const [excalidrawKey, setExcalidrawKey] = useState(0);
@@ -313,15 +303,9 @@ export default function DrawPreview({
     };
   }, [excalidrawKey]);
 
-  // Record content on mount/remount so echo detection works
+  // Initialize element snapshot for user action tracking on mount/remount
   useEffect(() => {
     if (!excalidrawData) return;
-    lastSavedContentRef.current = serializeToFile(
-      excalidrawData.elements,
-      excalidrawData.appState,
-      excalidrawData.excalidrawFiles,
-    );
-    // Initialize element snapshot for user action tracking
     const snap = new Map<string, { type: string; text?: string }>();
     for (const el of excalidrawData.elements.filter((e: any) => !e.isDeleted)) {
       snap.set(el.id, { type: el.type, text: el.type === "text" ? el.text : undefined });
@@ -332,23 +316,15 @@ export default function DrawPreview({
   // Sync file changes from disk — force Excalidraw remount instead of updateScene.
   // updateScene() disrupts Excalidraw's internal font rendering, causing text to vanish.
   // Remounting goes through the proper initialData → font init pipeline.
+  // External changes rebuild the Excalidraw state from the incoming file.
+  // Self-origin echoes are our own save coming back — Excalidraw's in-memory
+  // state already reflects them, so we skip the remount and avoid the visual
+  // flash + cursor loss.
   useEffect(() => {
     if (!excalidrawData) return;
-    const newContent = serializeToFile(
-      excalidrawData.elements,
-      excalidrawData.appState,
-      excalidrawData.excalidrawFiles,
-    );
-    // Skip if content matches (our own save echoing back, or same as initial)
-    if (newContent === lastSavedContentRef.current) return;
-
-    // External file change: force Excalidraw remount with new initialData
-    isUpdatingFromFileRef.current = true;
+    if (status.lastOrigin === "self") return;
     setExcalidrawKey((k) => k + 1);
-    setTimeout(() => {
-      isUpdatingFromFileRef.current = false;
-    }, 500);
-  }, [excalidrawData]);
+  }, [excalidrawData, status.lastOrigin]);
 
   // Track current preview mode in a ref so handleChange can read it without re-creating
   const previewModeRef = useRef(previewMode);
@@ -359,16 +335,16 @@ export default function DrawPreview({
     (elements: any[], appState: any, files: any) => {
       // Skip saves in view mode
       if (previewModeRef.current === "view") return;
-      // Skip if we're updating from a file change (avoid echo)
-      if (isUpdatingFromFileRef.current) return;
-      if (!currentFilePathRef.current) return;
+      const path = currentFilePathRef.current;
+      if (!path) return;
 
       // Debounce saves
       if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
       saveTimerRef.current = setTimeout(() => {
         const content = serializeToFile(elements, appState, files);
-        lastSavedContentRef.current = content;
-        saveFile(currentFilePathRef.current, content);
+        fileChannel.write(path, content).catch((err) => {
+          console.error("[draw] save failed", err);
+        });
 
         // Track user action for canvas changes
         const active = elements.filter((el: any) => !el.isDeleted);
@@ -414,7 +390,7 @@ export default function DrawPreview({
         }
       }, 500);
     },
-    [],
+    [fileChannel],
   );
 
   // Export selected elements as a screenshot (base64 PNG)

--- a/modes/evolve/manifest.ts
+++ b/modes/evolve/manifest.ts
@@ -35,6 +35,8 @@ For the full evolution process, data access scripts, proposal format, and intera
     ignorePatterns: [],
   },
 
+  sources: {},
+
   viewerApi: {
     workspace: { type: "all", multiFile: true, ordered: false, hasActiveFile: false },
   },

--- a/modes/gridboard/manifest.ts
+++ b/modes/gridboard/manifest.ts
@@ -40,6 +40,21 @@ For tile component patterns, layout rules, and theming conventions, consult the 
 
   layout: "app",
   editing: { supported: true },
+
+  sources: {
+    files: {
+      kind: "file-glob",
+      config: {
+        patterns: [
+          "board.json",
+          "theme.css",
+          "tiles/**/*.tsx",
+          "tiles/**/*.ts",
+          "tiles/**/*.css",
+        ],
+      },
+    },
+  },
   window: { width: 1080, height: 800 },
 
   viewer: {

--- a/modes/gridboard/viewer/GridBoardPreview.tsx
+++ b/modes/gridboard/viewer/GridBoardPreview.tsx
@@ -9,8 +9,10 @@ import { useEffect, useState, useRef, useCallback, useMemo } from "react";
 import type {
   ViewerPreviewProps,
   ViewerSelectionContext,
+  ViewerFileContent,
 } from "../../../core/types/viewer-contract.js";
-import { getApiBase } from "../../../src/utils/api.js";
+import type { Source } from "../../../core/types/source.js";
+import { useSource } from "../../../src/hooks/useSource.js";
 import { useStore } from "../../../src/store.js";
 import { snapdom } from "@zumer/snapdom";
 import { useTileCompiler, type BoardConfig } from "./use-tile-compiler.js";
@@ -162,15 +164,6 @@ function findEmptyPosition(
   return null;
 }
 
-async function saveFile(path: string, content: string): Promise<void> {
-  const base = getApiBase();
-  await fetch(`${base}/api/files`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ path, content }),
-  });
-}
-
 // ── Default board fallback ──────────────────────────────────────────────────
 
 const DEFAULT_BOARD: BoardConfig = {
@@ -181,7 +174,8 @@ const DEFAULT_BOARD: BoardConfig = {
 // ── Main Component ──────────────────────────────────────────────────────────
 
 export default function GridBoardPreview({
-  files,
+  sources,
+  fileChannel,
   selection,
   onSelect: rawOnSelect,
   mode: previewMode,
@@ -197,6 +191,11 @@ export default function GridBoardPreview({
   readonly,
   editing,
 }: ViewerPreviewProps) {
+  // Derive files from sources.files
+  const filesSource = sources.files as Source<ViewerFileContent[]>;
+  const { value: filesValue } = useSource(filesSource);
+  const files: ViewerFileContent[] = filesValue ?? [];
+
   // Readonly mode: suppress interactions
   const isViewMode = !readonly && editing === false;
   const editingDisabled = readonly || isViewMode;
@@ -527,7 +526,7 @@ export default function GridBoardPreview({
           const updatedConfig = JSON.parse(JSON.stringify(boardConfig));
           updatedConfig.tiles[tileId].position = currentPos;
           setDragState(null);
-          await saveFile("board.json", JSON.stringify(updatedConfig, null, 2));
+          await fileChannel.write("board.json", JSON.stringify(updatedConfig, null, 2));
           return;
         }
       }
@@ -540,7 +539,7 @@ export default function GridBoardPreview({
       window.removeEventListener("mousemove", handleMouseMove);
       window.removeEventListener("mouseup", handleMouseUp);
     };
-  }, [dragState, boardConfig]);
+  }, [dragState, boardConfig, fileChannel]);
 
   // ── Drag Resize ───────────────────────────────────────────────────────
   const handleResizeStart = useCallback(
@@ -669,7 +668,7 @@ export default function GridBoardPreview({
 
           setResizeState(null);
 
-          await saveFile("board.json", JSON.stringify(updatedConfig, null, 2));
+          await fileChannel.write("board.json", JSON.stringify(updatedConfig, null, 2));
 
           // Check if the tile's render is optimized for the new pixel dimensions
           const compiled = compilation.tiles.get(tileId);
@@ -725,7 +724,7 @@ export default function GridBoardPreview({
       window.removeEventListener("mousemove", handleMouseMove);
       window.removeEventListener("mouseup", handleMouseUp);
     };
-  }, [resizeState, boardConfig, compilation.tiles, onNotifyAgent]);
+  }, [resizeState, boardConfig, compilation.tiles, onNotifyAgent, fileChannel]);
 
   // ── Action Handling ───────────────────────────────────────────────────
   useEffect(() => {
@@ -765,7 +764,7 @@ export default function GridBoardPreview({
           }
           const filename = `tile-${tileId}-${Date.now()}.png`;
           const path = `.pneuma/captures/${filename}`;
-          await saveFile(path, `data:${img.media_type};base64,${img.data}`);
+          await fileChannel.write(path, `data:${img.media_type};base64,${img.data}`);
           onActionResult?.(actionRequest.requestId, { success: true, message: path, data: { path } });
         });
         break;
@@ -783,7 +782,7 @@ export default function GridBoardPreview({
           }
           const filename = `board-${Date.now()}.png`;
           const path = `.pneuma/captures/${filename}`;
-          await saveFile(path, `data:${img.media_type};base64,${img.data}`);
+          await fileChannel.write(path, `data:${img.media_type};base64,${img.data}`);
           onActionResult?.(actionRequest.requestId, { success: true, message: path, data: { path } });
         });
         break;
@@ -818,7 +817,7 @@ export default function GridBoardPreview({
           message: `Unknown action: ${actionRequest.actionId}`,
         });
     }
-  }, [actionRequest]);
+  }, [actionRequest, fileChannel]);
 
   // ── Navigate Request (Locator Cards) ──────────────────────────────────
   useEffect(() => {
@@ -883,9 +882,9 @@ export default function GridBoardPreview({
       updatedConfig.tiles[tileId].status = "available";
       delete updatedConfig.tiles[tileId].position;
       delete updatedConfig.tiles[tileId].size;
-      await saveFile("board.json", JSON.stringify(updatedConfig, null, 2));
+      await fileChannel.write("board.json", JSON.stringify(updatedConfig, null, 2));
     },
-    [boardConfig, editingDisabled, selectedTileId, onSelect],
+    [boardConfig, editingDisabled, selectedTileId, onSelect, fileChannel],
   );
 
   // ── Gallery: non-active tiles ─────────────────────────────────────────
@@ -944,9 +943,9 @@ export default function GridBoardPreview({
         position: pos,
         size: { cols: minCols, rows: minRows },
       };
-      await saveFile("board.json", JSON.stringify(updatedConfig, null, 2));
+      await fileChannel.write("board.json", JSON.stringify(updatedConfig, null, 2));
     },
-    [boardConfig, compilation, editingDisabled, onNotifyAgent],
+    [boardConfig, compilation, editingDisabled, onNotifyAgent, fileChannel],
   );
 
   // ── Gallery: Create new tile via agent ────────────────────────────────

--- a/modes/illustrate/domain.ts
+++ b/modes/illustrate/domain.ts
@@ -1,0 +1,93 @@
+/**
+ * Illustrate domain types + aggregate-file load/save functions.
+ *
+ * A `Studio` is the full collection of every content set the user has in
+ * their workspace, each represented by its `manifest.json`. The viewer
+ * picks the active content set at render time based on the Zustand
+ * workspace slice's `activeContentSet`.
+ *
+ * `saveStudio` is currently a stub — the illustrate viewer is read-only
+ * from the UI side (the agent owns writes via the image generation
+ * scripts + Edit tool). When editing lands, swap the throw for a real
+ * decomposer that turns a Studio back into per-file writes.
+ */
+
+import type { ViewerFileContent } from "../../core/types/viewer-contract.js";
+
+// ── Types (must match the viewer's internal shape) ─────────────────────────
+
+export interface ManifestItem {
+  file: string;
+  title: string;
+  prompt: string;
+  aspectRatio?: string;
+  resolution?: string;
+  style?: string;
+  tags?: string[];
+  createdAt?: string;
+  status?: "generating" | "ready";
+}
+
+export interface ManifestRow {
+  id: string;
+  label: string;
+  items: ManifestItem[];
+}
+
+export interface IllustrateManifest {
+  title: string;
+  description?: string;
+  rows: ManifestRow[];
+}
+
+/**
+ * The whole illustrate workspace — every manifest.json found under any
+ * content set directory, keyed by the directory prefix. An empty-string
+ * key `""` represents a root-level `manifest.json` (workspace with no
+ * content-set subdirectory).
+ */
+export interface Studio {
+  byContentSet: Record<string, IllustrateManifest>;
+}
+
+// ── loadStudio ──────────────────────────────────────────────────────────────
+
+/**
+ * Build a Studio from the raw file snapshot. Matches every `manifest.json`
+ * found at any depth and parses each one into an IllustrateManifest keyed
+ * by the directory prefix (everything before `/manifest.json`). Returns
+ * null when no manifest.json exists yet — the source stays in "no initial"
+ * state and a later file change can produce a valid Studio.
+ *
+ * Parse errors throw; the aggregate-file provider catches the throw and
+ * emits an error event while keeping the source alive.
+ */
+export function loadStudio(
+  files: ReadonlyArray<ViewerFileContent>,
+): Studio | null {
+  const manifests = files.filter(
+    (f) => f.path === "manifest.json" || f.path.endsWith("/manifest.json"),
+  );
+  if (manifests.length === 0) return null;
+
+  const byContentSet: Record<string, IllustrateManifest> = {};
+  for (const mf of manifests) {
+    const prefix =
+      mf.path === "manifest.json"
+        ? ""
+        : mf.path.slice(0, -"/manifest.json".length);
+    // Let JSON.parse throw — aggregate-file catches and emits an error.
+    byContentSet[prefix] = JSON.parse(mf.content) as IllustrateManifest;
+  }
+
+  return { byContentSet };
+}
+
+// ── saveStudio ──────────────────────────────────────────────────────────────
+
+export function saveStudio(
+  _next: Studio,
+  _current: ReadonlyArray<ViewerFileContent>,
+): { writes: Array<{ path: string; content: string }>; deletes: string[] } {
+  throw new Error("illustrate viewer is read-only; editing not yet supported");
+}

--- a/modes/illustrate/manifest.ts
+++ b/modes/illustrate/manifest.ts
@@ -4,6 +4,7 @@
  */
 
 import type { ModeManifest } from "../../core/types/mode-manifest.js";
+import { loadStudio, saveStudio } from "./domain.js";
 
 const illustrateManifest: ModeManifest = {
   name: "illustrate",
@@ -57,6 +58,17 @@ For prompt crafting, style management, generation & editing workflows, consult t
     ],
     ignorePatterns: [],
     serveDir: ".",
+  },
+
+  sources: {
+    studio: {
+      kind: "aggregate-file",
+      config: {
+        patterns: ["**/manifest.json", "**/images/**/*"],
+        load: loadStudio,
+        save: saveStudio,
+      },
+    },
   },
 
   viewerApi: {

--- a/modes/illustrate/viewer/IllustratePreview.tsx
+++ b/modes/illustrate/viewer/IllustratePreview.tsx
@@ -34,34 +34,23 @@ import type {
   ViewerPreviewProps,
   ViewerSelectionContext,
 } from "../../../core/types/viewer-contract.js";
-import { useResilientParse } from "../../../core/hooks/use-resilient-parse.js";
+import type { Source } from "../../../core/types/source.js";
+import { useSource } from "../../../src/hooks/useSource.js";
 import { useStore } from "../../../src/store.js";
+import type {
+  ManifestItem as DomainManifestItem,
+  ManifestRow as DomainManifestRow,
+  IllustrateManifest as DomainIllustrateManifest,
+  Studio,
+} from "../domain.js";
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
-interface ManifestItem {
-  file: string;
-  title: string;
-  prompt: string;
-  aspectRatio?: string;
-  resolution?: string;
-  style?: string;
-  tags?: string[];
-  createdAt?: string;
-  status?: "generating" | "ready";
-}
-
-interface ManifestRow {
-  id: string;
-  label: string;
-  items: ManifestItem[];
-}
-
-interface IllustrateManifest {
-  title: string;
-  description?: string;
-  rows: ManifestRow[];
-}
+// Domain types live in ../domain.ts and are consumed via a Source<Studio>.
+// Local aliases keep the rest of the viewer readable.
+type ManifestItem = DomainManifestItem;
+type ManifestRow = DomainManifestRow;
+type IllustrateManifest = DomainIllustrateManifest;
 
 interface ImageNodeData {
   item: ManifestItem;
@@ -138,17 +127,6 @@ const COLORS = {
 };
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
-
-function parseManifest(
-  files: { path: string; content: string }[],
-): { data: IllustrateManifest | null; file?: string } {
-  const mf = files.find(
-    (f) => f.path === "manifest.json" || f.path.endsWith("/manifest.json"),
-  );
-  if (!mf) return { data: null };
-  // Let JSON.parse throw — useResilientParse catches it
-  return { data: JSON.parse(mf.content) as IllustrateManifest, file: mf.path };
-}
 
 function aspectToRatio(aspect?: string): number {
   if (!aspect) return 1;
@@ -1150,7 +1128,7 @@ function EmptyCanvas() {
 
 function CanvasInner(props: ViewerPreviewProps) {
   const {
-    files, selection, onSelect: rawOnSelect, mode: rawPreviewMode, imageVersion,
+    sources, selection, onSelect: rawOnSelect, mode: rawPreviewMode, imageVersion,
     actionRequest, onActionResult, onActiveFileChange, onNotifyAgent: rawOnNotifyAgent,
     navigateRequest, onNavigateComplete, readonly,
   } = props;
@@ -1173,8 +1151,21 @@ function CanvasInner(props: ViewerPreviewProps) {
   const [cmdHeld, setCmdHeld] = useState(false);
   const [selectedFiles, setSelectedFiles] = useState<Set<string>>(new Set());
 
-  // Parse manifest with fallback — keeps last valid state if agent breaks the JSON
-  const manifest = useResilientParse(files, parseManifest, onNotifyAgent);
+  // Domain source: the full Studio (every content set's manifest.json),
+  // keyed by content-set prefix. We pick the active one at render time.
+  const studioSource = sources.studio as Source<Studio>;
+  const { value: studio } = useSource(studioSource);
+  const manifest = useMemo<IllustrateManifest | null>(() => {
+    if (!studio) return null;
+    const key = activeContentSet ?? "";
+    const byCS = studio.byContentSet;
+    if (byCS[key]) return byCS[key];
+    // Fallback: if no matching content set (e.g. activeContentSet not yet
+    // set), take the first manifest we have. Mirrors the old
+    // files.find(...) behavior that just picked the first match.
+    const firstKey = Object.keys(byCS)[0];
+    return firstKey !== undefined ? byCS[firstKey] : null;
+  }, [studio, activeContentSet]);
 
   const annotatedFiles = useMemo(() => {
     const set = new Set<string>();

--- a/modes/mode-maker/manifest.ts
+++ b/modes/mode-maker/manifest.ts
@@ -54,6 +54,22 @@ For ModeManifest reference, ViewerContract patterns, publishing workflow, and mo
     ],
   },
 
+  sources: {
+    files: {
+      kind: "file-glob",
+      config: {
+        patterns: [
+          "manifest.ts", "manifest.js",
+          "pneuma-mode.ts", "pneuma-mode.js",
+          "viewer/**/*.tsx", "viewer/**/*.ts", "viewer/**/*.js",
+          "skill/**/*.md", "skill/**/*",
+          "seed/**/*",
+        ],
+        ignore: [".build/**"],
+      },
+    },
+  },
+
   viewerApi: {
     workspace: { type: "all", multiFile: true, ordered: false, hasActiveFile: true },
   },

--- a/modes/mode-maker/viewer/ModeMakerPreview.tsx
+++ b/modes/mode-maker/viewer/ModeMakerPreview.tsx
@@ -19,9 +19,24 @@ import { json } from "@codemirror/lang-json";
 import { css } from "@codemirror/lang-css";
 import { html } from "@codemirror/lang-html";
 import { markdown as mdLang } from "@codemirror/lang-markdown";
-import type { ViewerPreviewProps } from "../../../core/types/viewer-contract.js";
+import type { ViewerPreviewProps, ViewerFileContent } from "../../../core/types/viewer-contract.js";
+import type { FileChannel, Source } from "../../../core/types/source.js";
+import { useSource } from "../../../src/hooks/useSource.js";
 import { parseManifestTs, type ParsedManifest } from "./utils/manifest-parser.js";
 import { classifyFile, detectLanguage, type FileCategory } from "./utils/file-classifier.js";
+
+/**
+ * No-op FileChannel passed to the dynamically loaded preview viewer in
+ * Mode Maker's Preview tab. The preview is read-only mock data, so
+ * writes/subscriptions are unreachable in practice. Providing a stub
+ * satisfies ViewerPreviewProps' required fileChannel prop added in P3.
+ */
+const STUB_FILE_CHANNEL: FileChannel = {
+  snapshot: () => [],
+  subscribe: () => () => { },
+  write: async () => { },
+  delete: async () => { },
+};
 
 function getApiBase(): string {
   if (import.meta.env.DEV) {
@@ -66,7 +81,7 @@ interface CheckItem {
   detail?: string;
 }
 
-function getChecklist(files: ViewerPreviewProps["files"]): CheckItem[] {
+function getChecklist(files: ViewerFileContent[]): CheckItem[] {
   const paths = files.map((f) => f.path);
   const categories = paths.map((p) => classifyFile(p));
 
@@ -114,7 +129,7 @@ function getManifestSummary(parsed: ParsedManifest): string {
   return parts.join(" — ");
 }
 
-function getModeDefSummary(files: ViewerPreviewProps["files"]): string {
+function getModeDefSummary(files: ViewerFileContent[]): string {
   const modeDef = files.find((f) => f.path === "pneuma-mode.ts" || f.path === "pneuma-mode.js");
   if (!modeDef) return "Manifest + viewer binding";
   const match = modeDef.content.match(/import\s+(\w+)\s+from\s+["']\.\/(viewer\/[^"']+)["']/);
@@ -122,7 +137,7 @@ function getModeDefSummary(files: ViewerPreviewProps["files"]): string {
   return `Binds ${match[1]} from ${match[2].replace(/\.[jt]sx?$/, "").replace(/\.js$/, "")}`;
 }
 
-function getViewerSummary(files: ViewerPreviewProps["files"]): string {
+function getViewerSummary(files: ViewerFileContent[]): string {
   const viewerFiles = files.filter((f) => classifyFile(f.path) === "viewer");
   if (viewerFiles.length === 0) return "Preview component";
   const totalLines = viewerFiles.reduce((sum, f) => sum + f.content.split("\n").length, 0);
@@ -133,7 +148,7 @@ function getViewerSummary(files: ViewerPreviewProps["files"]): string {
   return `${viewerFiles.length} files, ${totalLines} lines`;
 }
 
-function getSkillSummary(files: ViewerPreviewProps["files"]): string {
+function getSkillSummary(files: ViewerFileContent[]): string {
   const skill = files.find((f) => f.path === "skill/SKILL.md");
   if (!skill) return "Domain knowledge prompt";
   const headings = skill.content.split("\n")
@@ -148,7 +163,7 @@ function getSkillSummary(files: ViewerPreviewProps["files"]): string {
   return `${headings.length} sections: ${shown}${more}`;
 }
 
-function getSeedSummary(files: ViewerPreviewProps["files"]): string {
+function getSeedSummary(files: ViewerFileContent[]): string {
   const seedFiles = files.filter((f) => classifyFile(f.path) === "seed");
   if (seedFiles.length === 0) return "Initial workspace files";
   const names = seedFiles.map((f) => f.path.replace(/^seed\//, "").split("/").pop() || f.path);
@@ -187,7 +202,7 @@ function ManifestDetail({ parsed }: { parsed: ParsedManifest }) {
   );
 }
 
-function ModeDefDetail({ files }: { files: ViewerPreviewProps["files"] }) {
+function ModeDefDetail({ files }: { files: ViewerFileContent[] }) {
   const modeDef = files.find((f) => f.path === "pneuma-mode.ts" || f.path === "pneuma-mode.js");
   if (!modeDef) return <div className="text-xs text-cc-muted">File not found</div>;
 
@@ -219,7 +234,7 @@ function ModeDefDetail({ files }: { files: ViewerPreviewProps["files"] }) {
   );
 }
 
-function SkillOutline({ files }: { files: ViewerPreviewProps["files"] }) {
+function SkillOutline({ files }: { files: ViewerFileContent[] }) {
   const skill = files.find((f) => f.path === "skill/SKILL.md");
   if (!skill) return <div className="text-xs text-cc-muted">File not found</div>;
 
@@ -381,7 +396,7 @@ interface PublishResult {
 // ── Overview Tab ─────────────────────────────────────────────────────────────
 
 function OverviewTab({ files, parsed, onSelectFile, onTabChange }: {
-  files: ViewerPreviewProps["files"];
+  files: ViewerFileContent[];
   parsed: ParsedManifest;
   onSelectFile: (path: string) => void;
   onTabChange: (tab: TabId) => void;
@@ -994,7 +1009,7 @@ class ViewerErrorBoundary extends Component<
 // ── Preview Tab (dynamic viewer) ──────────────────────────────────────────────
 
 /** Parse pneuma-mode.ts to find the viewer component file path. */
-function findViewerEntryFile(files: ViewerPreviewProps["files"]): string | null {
+function findViewerEntryFile(files: ViewerFileContent[]): string | null {
   const modeDef = files.find((f) => f.path === "pneuma-mode.ts" || f.path === "pneuma-mode.js");
   if (!modeDef) return null;
 
@@ -1014,7 +1029,7 @@ function findViewerEntryFile(files: ViewerPreviewProps["files"]): string | null 
   return null;
 }
 
-function PreviewTab({ files }: { files: ViewerPreviewProps["files"] }) {
+function PreviewTab({ files }: { files: ViewerFileContent[] }) {
   const [dynViewer, setDynViewer] = useState<{ C: ComponentType<ViewerPreviewProps> } | null>(null);
   const [loadError, setLoadError] = useState("");
   const [importVersion, setImportVersion] = useState(0);
@@ -1092,17 +1107,6 @@ function PreviewTab({ files }: { files: ViewerPreviewProps["files"] }) {
       });
   }, [isDev, workspacePath, viewerEntry, importVersion]);
 
-  // Prepare seed files as mock workspace data (strip seed/ prefix)
-  const mockFiles = useMemo(() => {
-    const seeds = files
-      .filter((f) => classifyFile(f.path) === "seed")
-      .map((f) => ({ path: f.path.replace(/^seed\//, ""), content: f.content }));
-    // Provide a default file if no seeds exist
-    return seeds.length > 0
-      ? seeds
-      : [{ path: "example.md", content: "# Hello\n\nThis is a preview. Add files to `seed/` to customize." }];
-  }, [files]);
-
   // No viewer component in workspace
   if (!viewerEntry) {
     const hasViewerFiles = files.some((f) => classifyFile(f.path) === "viewer");
@@ -1164,7 +1168,8 @@ function PreviewTab({ files }: { files: ViewerPreviewProps["files"] }) {
   return (
     <ViewerErrorBoundary key={importVersion}>
       <DynComponent
-        files={mockFiles}
+        sources={{}}
+        fileChannel={STUB_FILE_CHANNEL}
         selection={null}
         onSelect={() => { }}
         mode="view"
@@ -1176,7 +1181,7 @@ function PreviewTab({ files }: { files: ViewerPreviewProps["files"] }) {
 
 // ── Skill Tab ────────────────────────────────────────────────────────────────
 
-function SkillTab({ files }: { files: ViewerPreviewProps["files"] }) {
+function SkillTab({ files }: { files: ViewerFileContent[] }) {
   const skillFile = files.find((f) => f.path === "skill/SKILL.md");
 
   if (!skillFile) {
@@ -1207,7 +1212,7 @@ interface FileGroup {
   files: { path: string; name: string }[];
 }
 
-function groupFiles(files: ViewerPreviewProps["files"]): FileGroup[] {
+function groupFiles(files: ViewerFileContent[]): FileGroup[] {
   const groups = new Map<string, { path: string; name: string }[]>();
 
   for (const f of files) {
@@ -1224,7 +1229,7 @@ function groupFiles(files: ViewerPreviewProps["files"]): FileGroup[] {
 }
 
 function FilesTab({ files, onSelectFile }: {
-  files: ViewerPreviewProps["files"];
+  files: ViewerFileContent[];
   onSelectFile: (path: string) => void;
 }) {
   const [selectedFile, setSelectedFile] = useState<string>("");
@@ -1298,10 +1303,14 @@ function FilesTab({ files, onSelectFile }: {
 // ── Main Component ───────────────────────────────────────────────────────────
 
 export default function ModeMakerPreview({
-  files,
+  sources,
   onSelect,
   onActiveFileChange,
 }: ViewerPreviewProps) {
+  const filesSource = sources.files as Source<ViewerFileContent[]>;
+  const { value: filesValue } = useSource(filesSource);
+  const files: ViewerFileContent[] = filesValue ?? [];
+
   const [activeTab, setActiveTab] = useState<TabId>("overview");
 
   // Parse manifest for Overview tab

--- a/modes/remotion/manifest.ts
+++ b/modes/remotion/manifest.ts
@@ -82,6 +82,18 @@ The live preview compiles your code in-browser with core Remotion APIs. For feat
     serveDir: ".",
   },
 
+  sources: {
+    files: {
+      kind: "file-glob",
+      config: {
+        patterns: [
+          "src/**/*.tsx", "src/**/*.ts", "src/**/*.css", "public/**",
+          "*/src/**/*.tsx", "*/src/**/*.ts", "*/src/**/*.css", "*/public/**",
+        ],
+      },
+    },
+  },
+
   viewerApi: {
     workspace: {
       type: "all",

--- a/modes/remotion/viewer/RemotionPreview.tsx
+++ b/modes/remotion/viewer/RemotionPreview.tsx
@@ -12,7 +12,10 @@ import type {
   ViewerActionRequest,
   ViewerActionResult,
   ViewerNotification,
+  ViewerFileContent,
 } from "../../../core/types/viewer-contract.js";
+import type { Source } from "../../../core/types/source.js";
+import { useSource } from "../../../src/hooks/useSource.js";
 import { useRemotionCompiler } from "./use-remotion-compiler.js";
 import { getApiBase } from "../../../src/utils/api.js";
 import RemotionControls from "./RemotionControls.js";
@@ -138,7 +141,7 @@ function PlayerCanvas({
 // ── Main Component ──────────────────────────────────────────────────────────
 
 export default function RemotionPreview({
-  files,
+  sources,
   activeFile,
   onActiveFileChange,
   onViewportChange,
@@ -149,6 +152,10 @@ export default function RemotionPreview({
   onNavigateComplete,
   readonly,
 }: ViewerPreviewProps) {
+  const filesSource = sources.files as Source<ViewerFileContent[]>;
+  const { value: filesValue } = useSource(filesSource);
+  const files: ViewerFileContent[] = filesValue ?? [];
+
   // Readonly mode: suppress agent notifications (replay / view-only)
   const effectiveOnNotifyAgent = readonly ? undefined : onNotifyAgent;
 

--- a/modes/slide/domain.ts
+++ b/modes/slide/domain.ts
@@ -1,0 +1,166 @@
+/**
+ * Slide domain types + aggregate-file load/save.
+ *
+ * A `Deck` is the entire slide workspace: every `manifest.json` found
+ * under any content set directory (keyed by the directory prefix, where
+ * an empty-string key `""` means a root-level manifest). Mirrors the
+ * illustrate `Studio` pattern — the viewer picks the active content
+ * set at render time via the Zustand workspace slice's
+ * `activeContentSet`.
+ *
+ * The viewer drives three write paths (reorder, delete, debounced
+ * text edit). All three collapse into `writeDeck(nextDeck)`; the
+ * `saveDeck` decomposer diffs against the current file snapshot and
+ * emits the minimal {writes, deletes} that the aggregate-file provider
+ * applies to disk.
+ */
+
+import type { ViewerFileContent } from "../../core/types/viewer-contract.js";
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+/** One slide entry as stored in manifest.json and rendered by the viewer. */
+export interface SlideEntry {
+  file: string; // relative path within the content set, e.g. "slides/slide-01.html"
+  title: string;
+}
+
+/** The manifest for a single content set. */
+export interface DeckManifest {
+  title: string;
+  slides: SlideEntry[];
+}
+
+/**
+ * The whole slide workspace — every `manifest.json` found under any
+ * content set, keyed by directory prefix (everything before
+ * `/manifest.json`). A root-level manifest uses key `""`.
+ */
+export interface Deck {
+  byContentSet: Record<string, DeckManifest>;
+}
+
+// ── loadDeck ────────────────────────────────────────────────────────────────
+
+/**
+ * Build a Deck from the raw file snapshot. Every `manifest.json` at
+ * any depth is parsed into a DeckManifest keyed by its prefix. Returns
+ * null when no manifest exists yet — the source stays in "no initial"
+ * state and a later file change can produce a valid Deck.
+ *
+ * JSON parse errors throw; the aggregate-file provider catches and
+ * emits an error event while keeping the source alive.
+ */
+export function loadDeck(
+  files: ReadonlyArray<ViewerFileContent>,
+): Deck | null {
+  const manifests = files.filter(
+    (f) => f.path === "manifest.json" || f.path.endsWith("/manifest.json"),
+  );
+  if (manifests.length === 0) return null;
+
+  const byContentSet: Record<string, DeckManifest> = {};
+  for (const mf of manifests) {
+    const prefix =
+      mf.path === "manifest.json"
+        ? ""
+        : mf.path.slice(0, -"/manifest.json".length);
+    const parsed = JSON.parse(mf.content) as Partial<DeckManifest>;
+    byContentSet[prefix] = {
+      title: typeof parsed.title === "string" ? parsed.title : "Untitled",
+      slides: Array.isArray(parsed.slides)
+        ? parsed.slides.map((s) => ({
+            file: String(s.file ?? ""),
+            title: String(s.title ?? ""),
+          }))
+        : [],
+    };
+  }
+
+  return { byContentSet };
+}
+
+// ── saveDeck ────────────────────────────────────────────────────────────────
+
+/**
+ * Decompose a next-state Deck into the minimum file operations that
+ * make disk match. Handles all three slide write paths:
+ *
+ *  - **Reorder**: manifest.slides order changed → one manifest.json write.
+ *  - **Delete**:  a slide entry removed → manifest.json write + the
+ *                 orphaned `slides/*.html` file is queued for delete
+ *                 (only if it's no longer referenced by any content set
+ *                 under the same prefix).
+ *  - **Text edit**: a virtual `__edits` map on a DeckManifest contributes
+ *                 per-file HTML writes (see `writeDeckEdits` helper).
+ *
+ * For a minimum viable decomposer we compare against `current` — any
+ * content-set prefix whose manifest bytes differ from the freshly
+ * serialized next state gets a manifest write. Per-slide HTML writes
+ * are carried on an optional `__edits: Record<path, html>` field that
+ * the viewer sets on the next Deck before calling `write`. That field
+ * is stripped before serializing the manifest.
+ */
+export function saveDeck(
+  next: Deck,
+  current: ReadonlyArray<ViewerFileContent>,
+): { writes: Array<{ path: string; content: string }>; deletes: string[] } {
+  const writes: Array<{ path: string; content: string }> = [];
+  const deletes: string[] = [];
+
+  // Collect all per-slide HTML edits carried on the next Deck (if any)
+  // and strip them from the serialized manifest.
+  for (const [prefix, manifest] of Object.entries(next.byContentSet)) {
+    const edits = (manifest as DeckManifest & {
+      __edits?: Record<string, string>;
+    }).__edits;
+    if (edits) {
+      for (const [relPath, html] of Object.entries(edits)) {
+        const fullPath = prefix === "" ? relPath : `${prefix}/${relPath}`;
+        writes.push({ path: fullPath, content: html + "\n" });
+      }
+    }
+
+    // Serialize manifest (without __edits)
+    const clean: DeckManifest = {
+      title: manifest.title,
+      slides: manifest.slides.map((s) => ({ file: s.file, title: s.title })),
+    };
+    const serialized = JSON.stringify(clean, null, 2) + "\n";
+    const manifestPath = prefix === "" ? "manifest.json" : `${prefix}/manifest.json`;
+    const existing = current.find((f) => f.path === manifestPath);
+    if (existing?.content !== serialized) {
+      writes.push({ path: manifestPath, content: serialized });
+    }
+  }
+
+  // Delete orphaned slide HTML files: a slides/*.html file that was
+  // referenced by the old manifest but no longer appears in the new
+  // manifest for the same prefix.
+  for (const [prefix, manifest] of Object.entries(next.byContentSet)) {
+    const manifestPath = prefix === "" ? "manifest.json" : `${prefix}/manifest.json`;
+    const oldManifestFile = current.find((f) => f.path === manifestPath);
+    if (!oldManifestFile) continue;
+    let oldManifest: DeckManifest;
+    try {
+      oldManifest = JSON.parse(oldManifestFile.content) as DeckManifest;
+    } catch {
+      continue;
+    }
+    const nextFiles = new Set(manifest.slides.map((s) => s.file));
+    const oldFiles = Array.isArray(oldManifest.slides)
+      ? oldManifest.slides.map((s) => s.file)
+      : [];
+    for (const f of oldFiles) {
+      if (!nextFiles.has(f)) {
+        const fullPath = prefix === "" ? f : `${prefix}/${f}`;
+        // Only delete if the file actually exists in the snapshot.
+        if (current.some((cf) => cf.path === fullPath)) {
+          deletes.push(fullPath);
+        }
+      }
+    }
+  }
+
+  return { writes, deletes };
+}

--- a/modes/slide/hooks/useSlideThumbnails.ts
+++ b/modes/slide/hooks/useSlideThumbnails.ts
@@ -12,7 +12,7 @@
 
 import { useState, useEffect, useRef } from "react";
 import { snapdom } from "@zumer/snapdom";
-import type { ViewerPreviewProps } from "../../../core/types/viewer-contract.js";
+import type { ViewerFileContent } from "../../../core/types/viewer-contract.js";
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -267,7 +267,7 @@ export async function captureSlideToSvg(
  */
 export function useSlideThumbnails(
   slides: { file: string; title: string }[],
-  files: ViewerPreviewProps["files"],
+  files: ViewerFileContent[],
   themeCSS: string,
   virtualWidth: number,
   virtualHeight: number,
@@ -286,10 +286,17 @@ export function useSlideThumbnails(
     // Determine which slides need re-capture
     const toCapture: { file: string; html: string; hash: number }[] = [];
 
+    // Prefer the content-set-scoped full path to avoid picking a slide from
+    // the wrong content set when multiple sets share the same relative
+    // `slides/slide-01.html` name. `contentBase` is `${activeContentSet}/`
+    // when a content set is active, empty string otherwise.
     for (const slide of slides) {
-      const fileEntry = files.find(
-        (f) => f.path === slide.file || f.path.endsWith(`/${slide.file}`),
-      );
+      const fullPath = contentBase + slide.file;
+      const fileEntry =
+        files.find((f) => f.path === fullPath) ??
+        files.find(
+          (f) => f.path === slide.file || f.path.endsWith(`/${slide.file}`),
+        );
       const html = fileEntry?.content || "";
       const hash = djb2(html + themeCSS);
       const prevHash = hashesRef.current.get(slide.file);

--- a/modes/slide/manifest.ts
+++ b/modes/slide/manifest.ts
@@ -4,6 +4,7 @@
  */
 
 import type { ModeManifest } from "../../core/types/mode-manifest.js";
+import { loadDeck, saveDeck } from "./domain.js";
 
 const slideManifest: ModeManifest = {
   name: "slide",
@@ -58,6 +59,40 @@ For design workflow, height calculation rules, layout patterns, and quality chec
     ],
     ignorePatterns: [],
     serveDir: ".",
+  },
+
+  sources: {
+    deck: {
+      kind: "aggregate-file",
+      config: {
+        patterns: [
+          "**/slides/*.html",
+          "**/manifest.json",
+          "**/theme.css",
+        ],
+        load: loadDeck,
+        save: saveDeck,
+      },
+    },
+    assets: {
+      kind: "file-glob",
+      config: { patterns: ["**/assets/**/*"] },
+    },
+    // Companion file-glob for raw content reads. The `deck` aggregate-file
+    // source exposes structural metadata (titles, ordering); this source
+    // exposes the raw file contents used by the iframe srcdoc path,
+    // theme.css lookup, and slide HTML rendering.
+    files: {
+      kind: "file-glob",
+      config: {
+        patterns: [
+          "**/slides/*.html",
+          "**/manifest.json",
+          "**/theme.css",
+          "**/assets/**/*",
+        ],
+      },
+    },
   },
 
   agent: {

--- a/modes/slide/viewer/SlideIframePool.tsx
+++ b/modes/slide/viewer/SlideIframePool.tsx
@@ -18,7 +18,7 @@ import {
   useMemo,
 } from "react";
 import type {
-  ViewerPreviewProps,
+  ViewerFileContent,
   ViewerSelectionContext,
 } from "../../../core/types/viewer-contract.js";
 
@@ -30,7 +30,7 @@ const MAX_POOL_SIZE = 20;
 
 interface SlideIframePoolProps {
   slides: { file: string; title: string }[];
-  files: ViewerPreviewProps["files"];
+  files: ViewerFileContent[];
   themeCSS: string;
   activeIndex: number;
   isSelectMode: boolean;
@@ -40,11 +40,15 @@ interface SlideIframePoolProps {
   onTextEdit?: (slideFile: string, html: string, changes?: { tag: string; before: string; after: string }[]) => void;
   /** Build the full srcdoc for a slide's HTML + theme */
   buildSrcdoc: (slideHtml: string, themeCSS: string) => string;
-  /** Find a slide's HTML content by file path */
+  /** Find a slide's HTML content by file path (content-set aware) */
   findSlideContent: (
-    files: ViewerPreviewProps["files"],
+    files: ViewerFileContent[],
     slidePath: string,
+    contentSet?: string | null,
   ) => string;
+  /** Active content set (used to disambiguate slide lookup when multiple
+   *  content sets share the same `slides/slide-01.html` relative path). */
+  activeContentSet: string | null;
   /** CSS selector to highlight in the active iframe (for navigating to historical selections) */
   highlightSelector?: string | null;
   /** CSS selectors for annotation highlights on the active slide */
@@ -69,6 +73,7 @@ export default function SlideIframePool({
   onTextEdit,
   buildSrcdoc,
   findSlideContent,
+  activeContentSet,
   highlightSelector,
   annotationSelectors,
   onEscapeKey,
@@ -249,12 +254,12 @@ export default function SlideIframePool({
     const versionTag = `<meta name="image-version" content="${imageVersion}">`;
     for (const slide of slides) {
       if (pool.has(slide.file)) {
-        const html = findSlideContent(files, slide.file);
+        const html = findSlideContent(files, slide.file, activeContentSet);
         map.set(slide.file, buildSrcdoc(html, themeCSS).replace("</head>", `${versionTag}</head>`));
       }
     }
     return map;
-  }, [slides, pool, files, themeCSS, buildSrcdoc, findSlideContent, imageVersion]);
+  }, [slides, pool, files, themeCSS, buildSrcdoc, findSlideContent, activeContentSet, imageVersion]);
 
   // Check for srcdoc changes and update iframes that need it
   useEffect(() => {

--- a/modes/slide/viewer/SlidePreview.tsx
+++ b/modes/slide/viewer/SlidePreview.tsx
@@ -26,10 +26,14 @@ import { CSS } from "@dnd-kit/utilities";
 import type {
   ViewerPreviewProps,
   ViewerSelectionContext,
+  ViewerFileContent,
 } from "../../../core/types/viewer-contract.js";
 import { useResilientParse } from "../../../core/hooks/use-resilient-parse.js";
 import { buildSelectionScript } from "../../../core/iframe-selection/index.js";
 import { useStore } from "../../../src/store.js";
+import { useSource } from "../../../src/hooks/useSource.js";
+import type { Source } from "../../../core/types/source.js";
+import type { Deck, DeckManifest } from "../domain.js";
 import { useSlideThumbnails, sanitizeHtmlQuotes } from "../hooks/useSlideThumbnails.js";
 import SlideIframePool from "./SlideIframePool.js";
 import HighlighterCanvas from "./HighlighterCanvas.js";
@@ -52,7 +56,7 @@ type NavigatorPosition = "left" | "bottom" | "hidden";
 
 /** Parse manifest.json from the files array */
 function parseManifest(
-  files: ViewerPreviewProps["files"],
+  files: ViewerFileContent[],
 ) {
   const mf = files.find(
     (f) => f.path === "manifest.json" || f.path.endsWith("/manifest.json"),
@@ -62,19 +66,53 @@ function parseManifest(
   return { data: JSON.parse(mf.content) as SlideManifest, file: mf.path };
 }
 
-/** Find theme.css content from files array */
-function findThemeCSS(files: ViewerPreviewProps["files"]): string {
+/**
+ * Find theme.css content from files array, preferring the active
+ * content set's theme. Without a content-set-aware lookup the
+ * multi-content-set case would pick the first content set's theme.css
+ * regardless of which content set the user is viewing.
+ */
+function findThemeCSS(
+  files: ViewerFileContent[],
+  contentSet?: string | null,
+): string {
+  if (contentSet) {
+    const fullPath = `${contentSet}/theme.css`;
+    const exact = files.find((f) => f.path === fullPath);
+    if (exact) return exact.content;
+  }
   const themeFile = files.find(
     (f) => f.path === "theme.css" || f.path.endsWith("/theme.css"),
   );
   return themeFile?.content || "";
 }
 
-/** Find a slide's HTML content by its file path */
+/**
+ * Find a slide's HTML content by its file path.
+ *
+ * `slidePath` is the manifest-relative path (e.g. "slides/slide-01.html"),
+ * unprefixed. When multiple content sets are present (e.g. `en-dark/` and
+ * `zh-light/`) the raw `files` array from `sources.files` contains slides
+ * from ALL content sets simultaneously. A naive `endsWith('/' + slidePath)`
+ * match would pick whichever content set happens to come first in the
+ * array, which can silently deliver the wrong language's slide content
+ * under the active content-set header.
+ *
+ * The fix: take an optional `contentSet` parameter and prefer an exact
+ * match against `${contentSet}/${slidePath}`. Fall back to the legacy
+ * `endsWith` behavior only when no content set is active (single-content
+ * workspaces).
+ */
 function findSlideContent(
-  files: ViewerPreviewProps["files"],
+  files: ViewerFileContent[],
   slidePath: string,
+  contentSet?: string | null,
 ): string {
+  if (contentSet) {
+    const fullPath = `${contentSet}/${slidePath}`;
+    const file = files.find((f) => f.path === fullPath);
+    if (file) return file.content;
+  }
   const file = files.find(
     (f) => f.path === slidePath || f.path.endsWith(`/${slidePath}`),
   );
@@ -458,7 +496,7 @@ function AnnotationPopover({
 // ── Main Component ───────────────────────────────────────────────────────────
 
 export default function SlidePreview({
-  files,
+  sources,
   selection,
   onSelect: rawOnSelect,
   mode: rawPreviewMode,
@@ -530,10 +568,37 @@ export default function SlidePreview({
   const [showHighlighter, setShowHighlighter] = useState(false);
 
   const [highlightSelector, setHighlightSelector] = useState<string | null>(null);
-  const manifest = useResilientParse(files, parseManifest, onNotifyAgent);
+  // Domain source: full Deck (every content set's manifest.json), keyed by
+  // directory prefix. We pick the entry matching activeContentSet (or "" for
+  // root) and present it to the rest of the component as `manifest`.
+  const deckSource = sources.deck as Source<Deck>;
+  const { value: deck, write: writeDeck } = useSource(deckSource);
+  // Companion file-glob: raw file contents used by iframe srcdoc, theme.css
+  // lookup, and per-slide HTML rendering. The deck source covers structural
+  // metadata; this source covers the raw body that the renderer splices.
+  const filesSource = sources.files as Source<ViewerFileContent[]>;
+  const { value: filesValue } = useSource(filesSource);
+  const files: ViewerFileContent[] = filesValue ?? [];
   const activeContentSet = useStore((s) => s.activeContentSet);
   const contentBase = activeContentSet ? activeContentSet + "/" : "";
-  const themeCSS = useMemo(() => findThemeCSS(files), [files]);
+  const deckPrefix = activeContentSet ?? "";
+  const manifest = useMemo<DeckManifest | null>(() => {
+    if (!deck) return null;
+    const direct = deck.byContentSet[deckPrefix];
+    if (direct) return direct;
+    // Fallback: pick the first available content set (e.g. activeContentSet
+    // not yet hydrated, or root-only workspace).
+    const first = Object.values(deck.byContentSet)[0];
+    return first ?? null;
+  }, [deck, deckPrefix]);
+  // Silence unused-variable lint for the legacy resilient parser (kept
+  // around for other modes; no longer used here).
+  void useResilientParse;
+  void parseManifest;
+  const themeCSS = useMemo(
+    () => findThemeCSS(files, activeContentSet),
+    [files, activeContentSet],
+  );
   const boundBuildSrcdoc = useCallback(
     (html: string, css: string) => buildSrcdoc(html, css, contentBase),
     [contentBase],
@@ -633,17 +698,16 @@ export default function SlidePreview({
         setActiveSlideIndex(activeSlideIndex + 1);
       }
 
-      // Persist to file in background
-      const newManifest = { ...manifest, slides: newSlides };
-      const baseUrl = import.meta.env.DEV ? `http://${location.hostname}:${import.meta.env.VITE_API_PORT || "17007"}` : "";
-      fetch(`${baseUrl}/api/files`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          path: "manifest.json",
-          content: JSON.stringify(newManifest, null, 2) + "\n",
-        }),
-      }).catch(() => {});
+      // Persist via domain source — writeDeck merges back into the full Deck.
+      if (deck) {
+        const nextDeck: Deck = {
+          byContentSet: {
+            ...deck.byContentSet,
+            [deckPrefix]: { ...manifest, slides: newSlides },
+          },
+        };
+        writeDeck(nextDeck).catch(() => {});
+      }
 
       pushUserAction({
         timestamp: Date.now(),
@@ -651,7 +715,7 @@ export default function SlidePreview({
         description: `Moved slide "${moved.title || moved.file}" from position ${fromIndex + 1} to ${toIndex + 1}`,
       });
     },
-    [manifest, slides, activeSlideIndex, pushUserAction],
+    [manifest, slides, activeSlideIndex, pushUserAction, deck, deckPrefix, writeDeck],
   );
 
   // Delete slide — remove from manifest (confirmation handled by UI component)
@@ -669,16 +733,17 @@ export default function SlidePreview({
         setActiveSlideIndex(activeSlideIndex - 1);
       }
 
-      const newManifest = { ...manifest, slides: newSlides };
-      const baseUrl = import.meta.env.DEV ? `http://${location.hostname}:${import.meta.env.VITE_API_PORT || "17007"}` : "";
-      fetch(`${baseUrl}/api/files`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          path: "manifest.json",
-          content: JSON.stringify(newManifest, null, 2) + "\n",
-        }),
-      }).catch(() => {});
+      // Persist via domain source — saveDeck diffs old vs new manifest
+      // and queues the orphaned slide HTML file for delete.
+      if (deck) {
+        const nextDeck: Deck = {
+          byContentSet: {
+            ...deck.byContentSet,
+            [deckPrefix]: { ...manifest, slides: newSlides },
+          },
+        };
+        writeDeck(nextDeck).catch(() => {});
+      }
 
       pushUserAction({
         timestamp: Date.now(),
@@ -686,25 +751,38 @@ export default function SlidePreview({
         description: `Deleted slide ${index + 1}: "${slide.title || slide.file}"`,
       });
     },
-    [manifest, slides, activeSlideIndex, pushUserAction],
+    [manifest, slides, activeSlideIndex, pushUserAction, deck, deckPrefix, writeDeck],
   );
 
   // Handle text edit from iframe (edit mode)
   const editTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   const pendingChangesRef = useRef<{ tag: string; before: string; after: string }[]>([]);
+  const pendingEditsRef = useRef<Record<string, string>>({});
   const handleTextEdit = useCallback(
     (slideFile: string, html: string, changes?: { tag: string; before: string; after: string }[]) => {
       if (changes?.length) {
         pendingChangesRef.current.push(...changes);
       }
+      pendingEditsRef.current[slideFile] = html;
       clearTimeout(editTimerRef.current);
       editTimerRef.current = setTimeout(() => {
-        const baseUrl = import.meta.env.DEV ? `http://${location.hostname}:${import.meta.env.VITE_API_PORT || "17007"}` : "";
-        fetch(`${baseUrl}/api/files`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ path: slideFile, content: html + "\n" }),
-        }).catch(() => {});
+        // Flush pending per-slide HTML edits through the domain source
+        // via the __edits carrier (consumed by saveDeck).
+        const edits = pendingEditsRef.current;
+        pendingEditsRef.current = {};
+        if (deck && manifest) {
+          const nextManifest: DeckManifest & { __edits?: Record<string, string> } = {
+            ...manifest,
+            __edits: edits,
+          };
+          const nextDeck: Deck = {
+            byContentSet: {
+              ...deck.byContentSet,
+              [deckPrefix]: nextManifest,
+            },
+          };
+          writeDeck(nextDeck).catch(() => {});
+        }
 
         const slide = slides.find((s) => s.file === slideFile);
         const label = slide?.title || slideFile;
@@ -722,7 +800,7 @@ export default function SlidePreview({
         });
       }, 800);
     },
-    [slides, pushUserAction],
+    [slides, pushUserAction, deck, manifest, deckPrefix, writeDeck],
   );
 
   // Clamp active index when slides change
@@ -1247,7 +1325,7 @@ export default function SlidePreview({
       const currentSlide = slides[activeSlideIndex];
       if (!currentSlide) return;
 
-      const slideHtml = findSlideContent(files, currentSlide.file);
+      const slideHtml = findSlideContent(files, currentSlide.file, activeContentSet);
       if (!slideHtml) return;
 
       // Keep strokes visible
@@ -1432,6 +1510,7 @@ export default function SlidePreview({
             onTextEdit={handleTextEdit}
             buildSrcdoc={boundBuildSrcdoc}
             findSlideContent={findSlideContent}
+            activeContentSet={activeContentSet}
             highlightSelector={highlightSelector}
             annotationSelectors={annotationSelectors}
             onEscapeKey={() => {
@@ -1529,7 +1608,7 @@ export default function SlidePreview({
       <div ref={fullscreenRef} className="flex flex-col h-full bg-black">
         <div className="flex-1 flex items-center justify-center">
           <iframe
-            srcDoc={boundBuildSrcdoc(currentSlide ? findSlideContent(files, currentSlide.file) : "", themeCSS)}
+            srcDoc={boundBuildSrcdoc(currentSlide ? findSlideContent(files, currentSlide.file, activeContentSet) : "", themeCSS)}
             title={currentSlide?.title || "Slide"}
             className="w-full h-full border-0"
             sandbox="allow-scripts"

--- a/modes/webcraft/domain.ts
+++ b/modes/webcraft/domain.ts
@@ -1,0 +1,162 @@
+/**
+ * Webcraft domain types + aggregate-file load/save functions.
+ *
+ * A `Site` is the full collection of every content set in the workspace,
+ * each represented by its `manifest.json` (or, as a fallback, by the
+ * .html files found at the content-set root). The viewer picks the
+ * active content set at render time via the Zustand workspace slice's
+ * `activeContentSet`.
+ *
+ * Content-set prefix convention (matches illustrate/slide):
+ *   ""          → root-level manifest.json / root-level html files
+ *   "pneuma"    → pneuma/manifest.json   / pneuma/*.html
+ *
+ * `saveSite` is a stub. Webcraft HTML edits flow through
+ * `fileChannel.write()` directly (the UI never restructures manifests),
+ * so the Site-level write path has nothing to emit. Future UI-level
+ * page add/remove/reorder would extend this to rewrite manifest.json.
+ */
+
+import type { ViewerFileContent } from "../../core/types/viewer-contract.js";
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+export interface PageEntry {
+  /** Path relative to the content-set prefix (e.g. "index.html"). */
+  file: string;
+  title: string;
+}
+
+export interface SiteManifest {
+  pages: PageEntry[];
+}
+
+/**
+ * The whole webcraft workspace — every site's page list keyed by
+ * content-set prefix. `""` represents a root-level site.
+ */
+export interface Site {
+  byContentSet: Record<string, SiteManifest>;
+}
+
+// ── loadSite ────────────────────────────────────────────────────────────────
+
+/**
+ * Build a Site from the raw file snapshot.
+ *
+ * First pass: match every `manifest.json` at any depth and parse each one
+ * into a SiteManifest keyed by the directory prefix (everything before
+ * `/manifest.json`). Accepts both `{ pages: [...] }` and the legacy
+ * `{ files: [...] }` format. Parse errors throw; the aggregate-file
+ * provider catches and emits an error event while keeping the source
+ * alive.
+ *
+ * Second pass (fallback): for content-set prefixes that have .html files
+ * at their root but no manifest.json, synthesize a minimal manifest
+ * listing those .html files in alphabetical order. Preserves the old
+ * "auto-discover pages from html glob" behavior the viewer relied on.
+ *
+ * Returns null when the snapshot is empty — the source stays in
+ * "no initial" state and a later file change can produce a valid Site.
+ */
+export function loadSite(
+  files: ReadonlyArray<ViewerFileContent>,
+): Site | null {
+  if (files.length === 0) return null;
+
+  const byContentSet: Record<string, SiteManifest> = {};
+
+  // ── First pass: parse every manifest.json ────────────────────────────────
+  for (const file of files) {
+    const isRootManifest = file.path === "manifest.json";
+    const isNestedManifest = file.path.endsWith("/manifest.json");
+    if (!isRootManifest && !isNestedManifest) continue;
+
+    const prefix = isRootManifest
+      ? ""
+      : file.path.slice(0, -"/manifest.json".length);
+
+    // Let JSON.parse throw — aggregate-file catches and emits an error.
+    const parsed = JSON.parse(file.content);
+    const entries: unknown = parsed.pages ?? parsed.files;
+    if (!Array.isArray(entries) || entries.length === 0) continue;
+
+    const pages: PageEntry[] = entries
+      .map((p: { file?: string; path?: string; title?: string }) => {
+        const f = p.file || p.path || "";
+        return {
+          file: f,
+          title:
+            p.title ||
+            f.replace(/\.html$/i, "").replace(/^.*\//, ""),
+        };
+      })
+      .filter((p) => p.file.length > 0);
+
+    if (pages.length > 0) {
+      byContentSet[prefix] = { pages };
+    }
+  }
+
+  // ── Second pass: html-glob fallback for prefixes without a manifest ──────
+  // Content sets are top-level directories in webcraft. Group html files by
+  // their immediate parent directory (first path component). Nested html
+  // files deeper inside a content set are ignored by the fallback — the
+  // manifest.json is the only way to register non-root pages.
+  const htmlByPrefix = new Map<string, ViewerFileContent[]>();
+  for (const file of files) {
+    if (!/\.html$/i.test(file.path)) continue;
+    const firstSlash = file.path.indexOf("/");
+    let prefix: string;
+    if (firstSlash < 0) {
+      // Root-level html (e.g. "index.html").
+      prefix = "";
+    } else {
+      // First directory component is the content-set prefix.
+      // Only count html files that live DIRECTLY under that directory —
+      // deeper paths (e.g. "pneuma/sub/page.html") don't belong to the
+      // simple page list.
+      const rest = file.path.slice(firstSlash + 1);
+      if (rest.includes("/")) continue;
+      prefix = file.path.slice(0, firstSlash);
+    }
+    const bucket = htmlByPrefix.get(prefix);
+    if (bucket) bucket.push(file);
+    else htmlByPrefix.set(prefix, [file]);
+  }
+
+  for (const [prefix, htmlFiles] of htmlByPrefix) {
+    if (byContentSet[prefix]) continue; // manifest already covers this prefix
+    const sorted = [...htmlFiles].sort((a, b) =>
+      a.path.localeCompare(b.path),
+    );
+    byContentSet[prefix] = {
+      pages: sorted.map((f) => {
+        const rel = prefix === "" ? f.path : f.path.slice(prefix.length + 1);
+        return {
+          file: rel,
+          title: rel.replace(/\.html$/i, "").replace(/^.*\//, ""),
+        };
+      }),
+    };
+  }
+
+  if (Object.keys(byContentSet).length === 0) return null;
+  return { byContentSet };
+}
+
+// ── saveSite ────────────────────────────────────────────────────────────────
+
+/**
+ * Stub: webcraft's viewer does not currently restructure the Site from
+ * the UI. All content edits (HTML text-edit events) route through
+ * `fileChannel.write()` directly. When UI-level page add/remove/reorder
+ * lands, this function should diff `next.byContentSet` against `current`
+ * and emit manifest.json rewrites + any orphaned-file deletes.
+ */
+export function saveSite(
+  _next: Site,
+  _current: ReadonlyArray<ViewerFileContent>,
+): { writes: Array<{ path: string; content: string }>; deletes: string[] } {
+  return { writes: [], deletes: [] };
+}

--- a/modes/webcraft/manifest.ts
+++ b/modes/webcraft/manifest.ts
@@ -4,6 +4,7 @@
  */
 
 import type { ModeManifest } from "../../core/types/mode-manifest.js";
+import { loadSite, saveSite } from "./domain.js";
 
 const webcraftManifest: ModeManifest = {
   name: "webcraft",
@@ -60,6 +61,68 @@ When the user provides original content (uploaded files, pasted HTML, or a URL t
     ],
     ignorePatterns: [],
     serveDir: ".",
+  },
+
+  sources: {
+    // Structural site metadata: manifest.json files + html page list.
+    // Aggregate-file so the viewer can consume a typed `Site` via useSource.
+    site: {
+      kind: "aggregate-file",
+      config: {
+        patterns: ["**/*.html", "**/manifest.json"],
+        load: loadSite,
+        save: saveSite,
+      },
+    },
+    // Static assets + source files still flow through a file-glob; they
+    // back the high-frequency iframe srcdoc construction path that keeps
+    // reading from the legacy `files` prop through P5.11.
+    assets: {
+      kind: "file-glob",
+      config: {
+        patterns: [
+          "**/*.css",
+          "**/*.js",
+          "**/*.jsx",
+          "**/*.ts",
+          "**/*.tsx",
+          "**/*.svg",
+          "**/*.png",
+          "**/*.jpg",
+          "**/*.jpeg",
+          "**/*.gif",
+          "**/*.webp",
+          "**/*.woff",
+          "**/*.woff2",
+        ],
+      },
+    },
+    // Companion file-glob for raw HTML content reads. The iframe srcdoc
+    // path and handleTextEdit need the full original document content to
+    // splice <body> edits back in, which is beyond what the structural
+    // `site` aggregate-file exposes.
+    files: {
+      kind: "file-glob",
+      config: {
+        patterns: [
+          "**/*.html",
+          "**/*.css",
+          "**/*.js",
+          "**/*.jsx",
+          "**/*.ts",
+          "**/*.tsx",
+          "**/*.json",
+          "**/*.svg",
+          "**/*.png",
+          "**/*.jpg",
+          "**/*.jpeg",
+          "**/*.gif",
+          "**/*.webp",
+          "**/*.woff",
+          "**/*.woff2",
+        ],
+      },
+    },
   },
 
   viewerApi: {

--- a/modes/webcraft/viewer/WebPreview.tsx
+++ b/modes/webcraft/viewer/WebPreview.tsx
@@ -13,10 +13,13 @@ import { useState, useEffect, useRef, useCallback, useMemo, type CSSProperties }
 import type {
   ViewerPreviewProps,
   ViewerSelectionContext,
+  ViewerFileContent,
 } from "../../../core/types/viewer-contract.js";
-import { useResilientParse } from "../../../core/hooks/use-resilient-parse.js";
+import type { Source } from "../../../core/types/source.js";
+import { useSource } from "../../../src/hooks/useSource.js";
 import { buildSelectionScript } from "../../../core/iframe-selection/index.js";
 import { useStore } from "../../../src/store.js";
+import type { Site } from "../domain.js";
 
 // ── Edit Mode Extension ─────────────────────────────────────────────────────
 
@@ -805,7 +808,8 @@ function AnnotationPopover({
 // ── Main Component ───────────────────────────────────────────────────────────
 
 export default function WebPreview({
-  files,
+  sources,
+  fileChannel,
   selection,
   onSelect: rawOnSelect,
   mode: rawPreviewMode,
@@ -849,36 +853,26 @@ export default function WebPreview({
     rect: { left: number; top: number; right: number; bottom: number; width: number; height: number };
   } | null>(null);
 
-  // Parse manifest.json for page list with resilient fallback
-  const manifestPages = useResilientParse<PageEntry[]>(files, (files) => {
-    const mf = files.find(
-      (f) => f.path === "manifest.json" || f.path.endsWith("/manifest.json"),
-    );
-    if (!mf) return { data: null };
-    // Let JSON.parse throw — useResilientParse catches it
-    const parsed = JSON.parse(mf.content);
-    // Accept both { pages: [...] } and { files: [...] } formats
-    const entries: any[] | undefined = parsed.pages || parsed.files;
-    if (!Array.isArray(entries) || entries.length === 0) return { data: null };
-    return {
-      data: entries.map((p: { file?: string; path?: string; title?: string }) => ({
-        file: p.file || p.path || "",
-        title: p.title || (p.file || p.path || "").replace(/\.html$/i, "").replace(/^.*\//, ""),
-      })),
-      file: mf.path,
-    };
-  }, onNotifyAgent);
-
-  // Fallback to raw HTML files when no manifest exists
+  // Domain source: the full Site (every content set's page list), keyed
+  // by content-set prefix. Pick the active bucket at render time; fall
+  // back to the first one if activeContentSet hasn't been set yet.
+  const siteSource = sources.site as Source<Site>;
+  const { value: site } = useSource(siteSource);
+  // Companion file-glob: raw HTML/CSS/JS content used by iframe srcdoc
+  // construction and handleTextEdit (splicing <body> edits back into the
+  // full original document).
+  const filesSource = sources.files as Source<ViewerFileContent[]>;
+  const { value: filesValue } = useSource(filesSource);
+  const files: ViewerFileContent[] = filesValue ?? [];
   const pageEntries = useMemo<PageEntry[]>(() => {
-    if (manifestPages) return manifestPages;
-    return files
-      .filter((f) => /\.html$/i.test(f.path))
-      .map((f) => ({
-        file: f.path,
-        title: f.path.replace(/\.html$/i, "").replace(/^.*\//, ""),
-      }));
-  }, [manifestPages, files]);
+    if (!site) return [];
+    const key = activeContentSet ?? "";
+    const bucket = site.byContentSet[key];
+    if (bucket) return bucket.pages;
+    const firstKey = Object.keys(site.byContentSet)[0];
+    if (firstKey === undefined) return [];
+    return site.byContentSet[firstKey].pages;
+  }, [site, activeContentSet]);
 
   const htmlFiles = useMemo(
     () => pageEntries.map((p) => p.file),
@@ -903,13 +897,22 @@ export default function WebPreview({
     return `${apiBase}/content/`;
   }, [activeContentSet]);
 
-  // Build srcdoc for the current file
+  // Build srcdoc for the current file.
+  //
+  // Note on path resolution: `currentFile` is the manifest-relative path
+  // like "index.html" (unprefixed). After P5.11 removed the useViewerProps
+  // content-set remap, the raw files from `sources.files` carry the
+  // content-set prefix like "gazette/index.html". We reconstruct the
+  // fully-qualified path before lookup.
   const srcdoc = useMemo(() => {
     if (!currentFile) return "";
-    const fileContent = files.find((f) => f.path === currentFile);
+    const fullPath = activeContentSet
+      ? `${activeContentSet}/${currentFile}`
+      : currentFile;
+    const fileContent = files.find((f) => f.path === fullPath);
     if (!fileContent) return "";
     return buildSrcdoc(fileContent.content, baseHref);
-  }, [currentFile, files, baseHref]);
+  }, [currentFile, files, baseHref, activeContentSet]);
 
   // Stable srcdoc: only update when the actual file content changes (not on
   // every `files` array reference change).  This prevents the iframe from
@@ -981,12 +984,14 @@ export default function WebPreview({
     if (changes?.length) pendingChangesRef.current.push(...changes);
     clearTimeout(editTimerRef.current);
     editTimerRef.current = setTimeout(() => {
-      const apiBase = import.meta.env.DEV
-        ? `http://${location.hostname}:${import.meta.env.VITE_API_PORT || "17007"}`
-        : "";
-
-      // Reconstruct the full HTML document by replacing the body content
-      const fileContent = files.find((f) => f.path === file);
+      // Reconstruct the full HTML document by replacing the body content.
+      // `file` is the manifest-relative path (e.g. "index.html"); the raw
+      // `files` array from sources.files carries the content-set prefix
+      // (e.g. "gazette/index.html"), so we fully qualify before looking up.
+      const fullPath = activeContentSet
+        ? `${activeContentSet}/${file}`
+        : file;
+      const fileContent = files.find((f) => f.path === fullPath);
       if (!fileContent) return;
       const original = fileContent.content;
       let updated: string;
@@ -999,13 +1004,11 @@ export default function WebPreview({
         updated = html;
       }
 
-      // Persist via API
+      // Persist via the source-aware file channel (origin-tagged "self").
       const savePath = activeContentSet ? `${activeContentSet}/${file}` : file;
-      fetch(`${apiBase}/api/files`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ path: savePath, content: updated }),
-      }).catch(() => {});
+      fileChannel.write(savePath, updated).catch((err) => {
+        console.error("[webcraft] save failed", err);
+      });
 
       // Record user action
       const batch = pendingChangesRef.current.splice(0);
@@ -1019,7 +1022,7 @@ export default function WebPreview({
         description: desc,
       });
     }, 800);
-  }, [files, activeContentSet]);
+  }, [files, activeContentSet, fileChannel]);
 
   // Listen for selection and text edit messages from iframe
   useEffect(() => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pneuma-skills",
-  "version": "2.28.0",
+  "version": "2.29.0",
   "type": "module",
   "description": "Co-creation infrastructure for humans and code agents — visual environment, skills, continuous learning, and distribution.",
   "license": "MIT",

--- a/server/file-watcher.ts
+++ b/server/file-watcher.ts
@@ -70,6 +70,93 @@ const DEFAULT_IGNORE = [
 export interface FileUpdate {
   path: string;
   content: string;
+  /**
+   * Origin tag added by the file watcher. "self" if this change matches
+   * a pending registerSelfWrite/Delete entry (i.e. it's the echo of a
+   * viewer write routed through /api/files); "external" otherwise.
+   * Always present on updates emitted after P3.
+   */
+  origin: "self" | "external";
+  /**
+   * True for unlink events (file deleted on disk). `content` is empty
+   * string in that case. Consumers that care about delete vs empty-write
+   * should check this flag.
+   */
+  deleted?: boolean;
+}
+
+/**
+ * pendingSelfWrites is the ONLY place in the system where viewer-origin
+ * writes are identified. When the /api/files POST handler receives a
+ * write, it calls `registerSelfWrite(path, content)` here. When chokidar
+ * subsequently fires for that path, we look up the entry and tag the
+ * outgoing FileUpdate with origin: "self" if the content matches. Entries
+ * auto-expire after PENDING_SELF_WRITE_TTL_MS to guarantee an unmatched
+ * registration doesn't poison a later legitimate external edit.
+ *
+ * pendingSelfDeletes works the same way for DELETE /api/files, but since
+ * a delete has no content to match on, the map stores only the expiry
+ * timestamp. The next chokidar `unlink` event for that path consumes the
+ * entry regardless of timing (within the TTL).
+ */
+const PENDING_SELF_WRITE_TTL_MS = 5000;
+
+interface PendingSelfWrite {
+  content: string;
+  expiresAt: number;
+}
+
+const pendingSelfWrites = new Map<string, PendingSelfWrite[]>();
+const pendingSelfDeletes = new Map<string, number /* expiresAt */>();
+
+export function registerSelfWrite(relPath: string, content: string): void {
+  const entry: PendingSelfWrite = {
+    content,
+    expiresAt: Date.now() + PENDING_SELF_WRITE_TTL_MS,
+  };
+  const existing = pendingSelfWrites.get(relPath) ?? [];
+  existing.push(entry);
+  pendingSelfWrites.set(relPath, existing);
+}
+
+export function registerSelfDelete(relPath: string): void {
+  pendingSelfDeletes.set(relPath, Date.now() + PENDING_SELF_WRITE_TTL_MS);
+}
+
+/**
+ * Consume a pending self-write entry matching this content.
+ * Content equality is the matching strategy. Expired entries are dropped
+ * silently without matching so a stale registration cannot mis-tag a
+ * later legitimate external edit.
+ */
+function consumeSelfWrite(relPath: string, content: string): boolean {
+  const queue = pendingSelfWrites.get(relPath);
+  if (!queue || queue.length === 0) return false;
+  const now = Date.now();
+  // Drop expired entries from the head.
+  while (queue.length > 0 && queue[0].expiresAt < now) {
+    queue.shift();
+  }
+  if (queue.length === 0) {
+    pendingSelfWrites.delete(relPath);
+    return false;
+  }
+  const idx = queue.findIndex((e) => e.content === content);
+  if (idx < 0) return false;
+  queue.splice(idx, 1);
+  if (queue.length === 0) pendingSelfWrites.delete(relPath);
+  return true;
+}
+
+function consumeSelfDelete(relPath: string): boolean {
+  const exp = pendingSelfDeletes.get(relPath);
+  if (!exp) return false;
+  if (exp < Date.now()) {
+    pendingSelfDeletes.delete(relPath);
+    return false;
+  }
+  pendingSelfDeletes.delete(relPath);
+  return true;
 }
 
 /**
@@ -144,7 +231,10 @@ export function startFileWatcher(
       if (existsSync(absPath)) {
         try {
           const content = readFileSync(absPath, "utf-8");
-          files.push({ path: relPath, content });
+          const origin: "self" | "external" = consumeSelfWrite(relPath, content)
+            ? "self"
+            : "external";
+          files.push({ path: relPath, content, origin });
         } catch {
           // skip unreadable files
         }
@@ -166,7 +256,9 @@ export function startFileWatcher(
     // Image changes: notify browser to bust cache (don't read content)
     const ext = relPath.slice(relPath.lastIndexOf(".")).toLowerCase();
     if (IMAGE_EXTS.has(ext)) {
-      onUpdate([{ path: relPath, content: "" }]);
+      // Images are never self-writes from a viewer (data URLs bypass the
+      // registerSelfWrite path per the plan), so hard-code "external".
+      onUpdate([{ path: relPath, content: "", origin: "external" }]);
       return;
     }
 
@@ -180,8 +272,27 @@ export function startFileWatcher(
     debounceTimer = setTimeout(flush, DEBOUNCE_MS);
   };
 
+  const handleUnlink = (absPath: string) => {
+    // Normalize to forward slashes for cross-platform consistency.
+    const relPath = relative(workspace, absPath).replaceAll("\\", "/");
+
+    // Apply the same watch-pattern + image filter as add/change, so deletes
+    // of ignored file types don't leak out. Images fall through the pattern
+    // filter (their extensions aren't in watchExtensions) but we still want
+    // to emit delete events for them, so check IMAGE_EXTS first.
+    const ext = relPath.slice(relPath.lastIndexOf(".")).toLowerCase();
+    const isImage = IMAGE_EXTS.has(ext);
+    if (!isImage && !matchesWatchPatterns(relPath, watchExtensions)) return;
+
+    const origin: "self" | "external" = consumeSelfDelete(relPath) ? "self" : "external";
+    // Emit immediately — the file is gone, so we can't route through the
+    // readFileSync-backed debounce flush. This mirrors the image branch.
+    onUpdate([{ path: relPath, content: "", origin, deleted: true }]);
+  };
+
   watcher.on("change", scheduleFlush);
   watcher.on("add", scheduleFlush);
+  watcher.on("unlink", handleUnlink);
   watcher.on("error", (err) => {
     // Permission errors (EACCES/EPERM) during directory traversal — log and continue
     console.warn(`[file-watcher] ${err}`);

--- a/server/index.ts
+++ b/server/index.ts
@@ -28,7 +28,7 @@ import { SettingsManager } from "../core/settings-manager.js";
 import { HookBus } from "../core/hook-bus.js";
 import { createProxyMiddleware, mergeProxyConfig, type ProxyConfigRef } from "./proxy-middleware.js";
 import type { ProxyRoute } from "../core/types/mode-manifest.js";
-import { startProxyWatcher } from "./file-watcher.js";
+import { startProxyWatcher, registerSelfWrite, registerSelfDelete } from "./file-watcher.js";
 import { mountNativeRoutes } from "./native-bridge.js";
 
 const DEFAULT_PORT = 17007;
@@ -1729,11 +1729,40 @@ export async function startServer(options: ServerOptions) {
       if (dataUrlMatch) {
         writeFileSync(absPath, Buffer.from(dataUrlMatch[1], "base64"));
       } else {
+        // Register this write as self-originated so the chokidar echo is
+        // tagged origin: "self" when it arrives. Registration happens BEFORE
+        // the disk write so there's no window where the echo could arrive
+        // ahead of the registration. Binary writes (data URLs) take the
+        // image-cache-bust path in the watcher and don't need origin tracking.
+        registerSelfWrite(relPath, body.content);
         writeFileSync(absPath, body.content, "utf-8");
       }
       return c.json({ ok: true });
     } catch (err) {
       return c.json({ error: "Failed to write file" }, 500);
+    }
+  });
+
+  // ── Delete file ────────────────────────────────────────────────────
+  app.delete("/api/files", async (c) => {
+    const relPath = c.req.query("path");
+    if (!relPath || typeof relPath !== "string") {
+      return c.json({ error: "Missing path query parameter" }, 400);
+    }
+    const absPath = join(workspace, relPath);
+    if (!pathStartsWith(absPath, workspace)) {
+      return c.json({ error: "Forbidden" }, 403);
+    }
+    try {
+      // Register the self-delete BEFORE unlinking so the chokidar unlink
+      // event is tagged origin: "self" when it arrives.
+      registerSelfDelete(relPath);
+      if (existsSync(absPath)) {
+        unlinkSync(absPath);
+      }
+      return c.json({ ok: true });
+    } catch (err) {
+      return c.json({ error: "Failed to delete file" }, 500);
     }
   });
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useMemo, useRef, lazy, Suspense } from "react";
+import { useEffect, useState, useRef, lazy, Suspense } from "react";
 import { getApiBase } from "./utils/api.js";
 import { Panel, Group, Separator } from "react-resizable-panels";
 import TopBar from "./components/TopBar.js";
@@ -17,6 +17,10 @@ import { useSystemPreferences } from "./hooks/useSystemPreferences.js";
 import { selectBestContentSet } from "../core/utils/content-set-matcher.js";
 import { ReplayPlayer } from "./components/ReplayPlayer";
 import type { ViewerPreviewProps } from "../core/types/viewer-contract.js";
+import type { Source, FileChannel } from "../core/types/source.js";
+import { SourceRegistry } from "../core/source-registry.js";
+import { BUILT_IN_PROVIDERS } from "../core/sources/index.js";
+import { BrowserFileChannel } from "./runtime/file-channel.js";
 import { useThumbnailCapture } from "./hooks/useThumbnailCapture.js";
 import { normalizeViewerState } from "./utils/viewer-state.js";
 
@@ -66,10 +70,65 @@ function RightPanel() {
   );
 }
 
+/**
+ * Instantiate sources AND the FileChannel for the current mode. Returns
+ * both as a single object so useViewerProps can pass each through to the
+ * viewer as separate props. Rebuilds (destroying the old set) whenever
+ * the active mode changes.
+ *
+ * This is the lifecycle boundary for sources. When a user switches modes
+ * in the launcher, the old mode's sources are destroyed here and the new
+ * mode's sources are created against a fresh FileChannel + SourceRegistry.
+ * Sources and the FileChannel never outlive their mode.
+ */
+function useSourceInstances(): {
+  sources: Record<string, Source<unknown>>;
+  channel: FileChannel;
+} {
+  const manifest = useStore((s) => s.modeManifest);
+  const [state, setState] = useState<{
+    sources: Record<string, Source<unknown>>;
+    channel: FileChannel;
+  }>(() => ({ sources: {}, channel: new BrowserFileChannel() }));
+
+  useEffect(() => {
+    if (!manifest) {
+      setState({ sources: {}, channel: new BrowserFileChannel() });
+      return;
+    }
+    const channel = new BrowserFileChannel();
+    const registry = new SourceRegistry();
+    for (const provider of BUILT_IN_PROVIDERS) registry.register(provider);
+    // Plugin-contributed providers live server-side (see PluginRegistry.collectSourceProviders).
+    // They are not currently wired into the browser-side SourceRegistry because plugin
+    // providers contain .create() functions that can't be serialized over WS. When the
+    // first browser-capable plugin provider exists, it will need either (a) a bridge
+    // that proxies provider.create() calls over WS, or (b) a browser-loaded plugin
+    // runtime. Until then, only built-in providers are available in the browser.
+    const ctx = {
+      workspace: "", // workspace is known to the server; providers
+                     // that need it get it via FileChannel instead
+      log: (msg: string) => {
+        console.debug("[source]", msg);
+      },
+      signal: new AbortController().signal,
+      files: channel,
+    };
+    const effective = SourceRegistry.effectiveSources(manifest);
+    const built = registry.instantiateAll(effective, ctx);
+    setState({ sources: built, channel });
+    return () => {
+      registry.destroyAll(built);
+      (channel as BrowserFileChannel).destroy();
+    };
+  }, [manifest]);
+
+  return state;
+}
+
 /** Build the ViewerPreviewProps from store state. */
 function useViewerProps(): ViewerPreviewProps {
-  const rawFiles = useStore((s) => s.files);
-  const activeContentSet = useStore((s) => s.activeContentSet);
+  const { sources, channel: fileChannel } = useSourceInstances();
   const selection = useStore((s) => s.selection);
   const setSelection = useStore((s) => s.setSelection);
   const previewMode = useStore((s) => s.previewMode);
@@ -86,17 +145,9 @@ function useViewerProps(): ViewerPreviewProps {
   const contentSets = useStore((s) => s.contentSets);
   const replayMode = useStore((s) => s.replayMode);
 
-  // Filter and remap files based on active content set
-  const files = useMemo(() => {
-    if (!activeContentSet) return rawFiles.map((f) => ({ path: f.path, content: f.content }));
-    const pfx = activeContentSet + "/";
-    return rawFiles
-      .filter((f) => f.path.startsWith(pfx))
-      .map((f) => ({ path: f.path.slice(pfx.length), content: f.content }));
-  }, [rawFiles, activeContentSet]);
-
   return {
-    files,
+    sources,
+    fileChannel,
     activeFile,
     selection: selection
       ? {
@@ -118,8 +169,9 @@ function useViewerProps(): ViewerPreviewProps {
         setSelection(null);
         return;
       }
-      // Use file from the viewer component (e.g. current slide), fallback to first file
-      const file = sel.file || files[0]?.path || "";
+      // Use file from the viewer component (e.g. current slide).
+      // Viewers that care about file attribution always populate sel.file.
+      const file = sel.file || "";
       setSelection({
         type: sel.type as SelectionType,
         content: sel.content,
@@ -201,6 +253,7 @@ export default function App() {
 
       const def = await loadMode(modeName);
       useStore.getState().setModeViewer(def.viewer);
+      useStore.getState().setModeManifest(def.manifest);
       useStore.getState().setModeDisplayName(def.manifest.displayName);
       useStore.getState().setModeCommands(def.manifest.viewerApi?.commands ?? []);
     };

--- a/src/hooks/useSource.ts
+++ b/src/hooks/useSource.ts
@@ -1,0 +1,115 @@
+import { useMemo, useSyncExternalStore, useRef } from "react";
+import type { Source, SourceEvent } from "../../core/types/source.js";
+
+export interface SourceStatus {
+  /** Origin of the most recently delivered value event, or null. */
+  lastOrigin: "initial" | "self" | "external" | null;
+  /** Most recent error event, or null. Cleared on the next successful value. */
+  lastError: { code: string; message: string } | null;
+}
+
+export interface UseSourceResult<T> {
+  /** Latest value, or null before the initial event. */
+  value: T | null;
+  /** Bound write method — identical semantics to source.write(). */
+  write: (value: T) => Promise<void>;
+  /** Observability state. */
+  status: SourceStatus;
+}
+
+/**
+ * React binding for Source<T>.
+ *
+ * Uses useSyncExternalStore so React's concurrent rendering and
+ * StrictMode double-invocation behave correctly — the subscription
+ * is re-attached cleanly on remount without causing the source to
+ * re-emit.
+ *
+ * The returned { value, write, status } is a stable shape. `value`
+ * changes when new events arrive; `write` is a bound reference that
+ * does not change identity across renders (so downstream effects
+ * depending on [write] don't re-run gratuitously).
+ *
+ * ## Handling undefined source
+ *
+ * Accepts `Source<T> | null | undefined` because `useSourceInstances`
+ * in App.tsx populates the source map asynchronously (first render
+ * returns an empty `sources: {}` while the useEffect runs). During
+ * that one-render window, `sources.myKey` is undefined, and every
+ * migrated viewer would otherwise crash on `source.current()`.
+ *
+ * When source is null/undefined, this hook:
+ *   - returns `value: null` (viewer's existing "no initial value yet"
+ *     fallback handles it — e.g. `if (!deck) return <EmptyState />`)
+ *   - returns a no-op `write` that resolves without doing anything
+ *   - leaves `status` at its default {lastOrigin: null, lastError: null}
+ *
+ * Once the source map populates (second render), the hook re-subscribes
+ * cleanly — useSyncExternalStore's subscribe function dep-array picks
+ * up the source reference change.
+ */
+export function useSource<T>(
+  source: Source<T> | null | undefined,
+): UseSourceResult<T> {
+  // A mutable status ref so status updates don't cause a re-render
+  // on their own — status is a secondary observation surface, the
+  // primary re-render driver is `value`.
+  const statusRef = useRef<SourceStatus>({
+    lastOrigin: null,
+    lastError: null,
+  });
+
+  // useSyncExternalStore needs a stable subscribe function per source.
+  // When source is missing, subscribe is a no-op that returns a no-op
+  // unsubscribe.
+  const subscribe = useMemo(() => {
+    if (!source) {
+      return (_notify: () => void) => () => {};
+    }
+    return (notify: () => void) => {
+      const off = source.subscribe((event: SourceEvent<T>) => {
+        if (event.kind === "value") {
+          statusRef.current = {
+            lastOrigin: event.origin,
+            lastError: null,
+          };
+        } else if (event.kind === "error") {
+          statusRef.current = {
+            ...statusRef.current,
+            lastError: { code: event.code, message: event.message },
+          };
+        }
+        notify();
+      });
+      return off;
+    };
+  }, [source]);
+
+  // getSnapshot must be stable per source. When source is missing,
+  // always return null so useSyncExternalStore sees a stable value.
+  const getSnapshot = useMemo(() => {
+    if (!source) return () => null;
+    return () => source.current();
+  }, [source]);
+
+  const value = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+
+  // write() binds to the real source, or is a silent no-op when
+  // source is missing. The no-op resolves rather than rejects so
+  // viewer code that `await`s write doesn't need a try/catch just
+  // for the initial-render gap.
+  const write = useMemo<(value: T) => Promise<void>>(() => {
+    if (!source) {
+      return async () => {
+        // no-op during the first-render source-population gap
+      };
+    }
+    return source.write.bind(source);
+  }, [source]);
+
+  return {
+    value,
+    write,
+    status: statusRef.current,
+  };
+}

--- a/src/runtime/file-channel.ts
+++ b/src/runtime/file-channel.ts
@@ -1,0 +1,93 @@
+import type {
+  FileChannel,
+  FileChangeEvent,
+} from "../../core/types/source.js";
+import type { ViewerFileContent } from "../../core/types/viewer-contract.js";
+import { fileEventBus } from "./file-event-bus.js";
+import { useStore } from "../store/index.js";
+
+/**
+ * Get the API base URL (dev proxy vs prod same-origin). Mirrors the
+ * helper used inline in several mode viewers — centralized here so
+ * every source gets the same resolution.
+ */
+function getApiBase(): string {
+  if (import.meta.env.DEV) {
+    return `http://${location.hostname}:${import.meta.env.VITE_API_PORT || "17007"}`;
+  }
+  return "";
+}
+
+/**
+ * Browser-side FileChannel implementation. Backed by:
+ *   - snapshot: the workspace slice `files` array
+ *   - subscribe: fileEventBus (populated by workspace-slice.updateFiles)
+ *   - write: POST /api/files
+ *   - delete: DELETE /api/files?path=...
+ *
+ * One instance per active mode. The runtime creates it in
+ * useSourceInstances (Task 3.7) and destroys it on mode switch. The
+ * BrowserFileChannel owns the subscription relationship with
+ * fileEventBus — its own subscribe/unsubscribe tracks handlers from
+ * Source instances (file-glob / json-file / aggregate-file providers).
+ */
+export class BrowserFileChannel implements FileChannel {
+  private unsubBus: (() => void) | null = null;
+  private handlers = new Set<(batch: FileChangeEvent[]) => void>();
+
+  constructor() {
+    this.unsubBus = fileEventBus.subscribe((batch) => this.dispatch(batch));
+  }
+
+  snapshot(): ReadonlyArray<ViewerFileContent> {
+    // Read directly from the store — synchronous, same source of truth
+    // that useViewerProps uses to build props.files.
+    const files = useStore.getState().files;
+    return files.map((f) => ({ path: f.path, content: f.content }));
+  }
+
+  subscribe(handler: (batch: FileChangeEvent[]) => void): () => void {
+    this.handlers.add(handler);
+    return () => {
+      this.handlers.delete(handler);
+    };
+  }
+
+  async write(path: string, content: string): Promise<void> {
+    const res = await fetch(`${getApiBase()}/api/files`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ path, content }),
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      throw new Error(`POST /api/files failed: ${res.status} ${text}`);
+    }
+  }
+
+  async delete(path: string): Promise<void> {
+    const url = `${getApiBase()}/api/files?path=${encodeURIComponent(path)}`;
+    const res = await fetch(url, { method: "DELETE" });
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      throw new Error(`DELETE /api/files failed: ${res.status} ${text}`);
+    }
+  }
+
+  private dispatch(batch: FileChangeEvent[]): void {
+    for (const handler of Array.from(this.handlers)) {
+      try {
+        handler(batch);
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error("[file-channel] handler threw", err);
+      }
+    }
+  }
+
+  destroy(): void {
+    this.unsubBus?.();
+    this.unsubBus = null;
+    this.handlers.clear();
+  }
+}

--- a/src/runtime/file-event-bus.ts
+++ b/src/runtime/file-event-bus.ts
@@ -1,0 +1,36 @@
+import type { FileChangeEvent } from "../../core/types/source.js";
+
+/**
+ * Browser-side singleton pub/sub for file change events. The workspace
+ * slice's updateFiles() publishes to this bus; the FileChannel
+ * implementation (src/runtime/file-channel.ts) subscribes and re-emits
+ * to its own subscribers (which are Source instances).
+ *
+ * We use a module-level singleton because there is only ever one
+ * workspace per browser tab in Pneuma. A multi-workspace future would
+ * need to scope this to a session id.
+ */
+class FileEventBus {
+  private handlers = new Set<(batch: FileChangeEvent[]) => void>();
+
+  subscribe(handler: (batch: FileChangeEvent[]) => void): () => void {
+    this.handlers.add(handler);
+    return () => {
+      this.handlers.delete(handler);
+    };
+  }
+
+  publish(batch: FileChangeEvent[]): void {
+    // Snapshot to allow handlers to subscribe/unsubscribe during delivery.
+    for (const handler of Array.from(this.handlers)) {
+      try {
+        handler(batch);
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error("[file-event-bus] handler threw", err);
+      }
+    }
+  }
+}
+
+export const fileEventBus = new FileEventBus();

--- a/src/store/mode-slice.ts
+++ b/src/store/mode-slice.ts
@@ -1,10 +1,12 @@
 import type { StateCreator } from "zustand";
 import type { ViewerContract, ViewerCommandDescriptor } from "../../core/types/viewer-contract.js";
+import type { ModeManifest } from "../../core/types/mode-manifest.js";
 import type { AppState } from "./types.js";
 import { filterAndRemapFiles } from "./helpers.js";
 
 export interface ModeSlice {
   modeViewer: ViewerContract | null;
+  modeManifest: ModeManifest | null;
   modeDisplayName: string;
   modeCommands: ViewerCommandDescriptor[];
   initParams: Record<string, number | string>;
@@ -13,6 +15,7 @@ export interface ModeSlice {
   editingSupported: boolean;
 
   setModeViewer: (viewer: ViewerContract) => void;
+  setModeManifest: (manifest: ModeManifest | null) => void;
   setModeDisplayName: (name: string) => void;
   setModeCommands: (commands: ViewerCommandDescriptor[]) => void;
   setInitParams: (params: Record<string, number | string>) => void;
@@ -23,6 +26,7 @@ export interface ModeSlice {
 
 export const createModeSlice: StateCreator<AppState, [], [], ModeSlice> = (set) => ({
   modeViewer: null,
+  modeManifest: null,
   modeDisplayName: "",
   modeCommands: [],
   initParams: {},
@@ -49,6 +53,7 @@ export const createModeSlice: StateCreator<AppState, [], [], ModeSlice> = (set) 
         workspaceItems: resolveItems ? resolveItems(filtered) : s.workspaceItems,
       };
     }),
+  setModeManifest: (modeManifest) => set({ modeManifest }),
   setModeDisplayName: (modeDisplayName) => set({ modeDisplayName }),
   setModeCommands: (modeCommands) => set({ modeCommands }),
   setInitParams: (initParams) => set({ initParams }),

--- a/src/store/workspace-slice.ts
+++ b/src/store/workspace-slice.ts
@@ -3,6 +3,7 @@ import type { FileContent } from "../types.js";
 import type { WorkspaceItem, ContentSet } from "../../core/types/viewer-contract.js";
 import type { AppState } from "./types.js";
 import { filterAndRemapFiles } from "./helpers.js";
+import { fileEventBus } from "../runtime/file-event-bus.js";
 
 export interface WorkspaceSlice {
   files: FileContent[];
@@ -12,7 +13,7 @@ export interface WorkspaceSlice {
   workspaceItems: WorkspaceItem[];
 
   setFiles: (files: FileContent[]) => void;
-  updateFiles: (updates: FileContent[]) => void;
+  updateFiles: (updates: Array<FileContent & { origin?: "self" | "external" }>) => void;
   setActiveContentSet: (prefix: string | null) => void;
 }
 
@@ -23,7 +24,7 @@ export const createWorkspaceSlice: StateCreator<AppState, [], [], WorkspaceSlice
   contentSetUnread: new Set(),
   workspaceItems: [],
 
-  setFiles: (files) =>
+  setFiles: (files) => {
     set((s) => {
       const ws = s.modeViewer?.workspace;
       const contentSets = ws?.resolveContentSets ? ws.resolveContentSets(files) : [];
@@ -53,9 +54,22 @@ export const createWorkspaceSlice: StateCreator<AppState, [], [], WorkspaceSlice
         workspaceItems: newItems,
         activeFile,
       };
-    }),
+    });
+    // After state has been updated, notify source providers. setFiles is
+    // used both on initial mode load (fetch /api/files → setFiles) and
+    // on replay-checkpoint boundaries — both cases need the source layer
+    // to see the new file list. We tag origin: "external" because the
+    // batch is not the echo of any specific in-viewer write.
+    fileEventBus.publish(
+      files.map((f) => ({
+        path: f.path,
+        content: f.content,
+        origin: "external" as const,
+      })),
+    );
+  },
 
-  updateFiles: (updates) =>
+  updateFiles: (updates) => {
     set((s) => {
       const fileMap = new Map(s.files.map((f) => [f.path, f]));
       for (const u of updates) {
@@ -110,7 +124,16 @@ export const createWorkspaceSlice: StateCreator<AppState, [], [], WorkspaceSlice
         workspaceItems: newItems,
         activeFile,
       };
-    }),
+    });
+    // After state has been updated, notify source providers.
+    fileEventBus.publish(
+      updates.map((u) => ({
+        path: u.path,
+        content: u.content,
+        origin: u.origin ?? "external",
+      })),
+    );
+  },
 
   setActiveContentSet: (activeContentSet) =>
     set((s) => {

--- a/src/ws.ts
+++ b/src/ws.ts
@@ -631,8 +631,11 @@ function handleParsedMessage(data: BrowserIncomingMessage) {
       // During replay mode, ignore file watcher updates — files come from checkpoints
       if (store.replayMode) break;
       const IMAGE_RE = /\.(png|jpe?g|gif|webp|svg)$/i;
-      const contentFiles = data.files.filter((f: { path: string; content: string }) => !IMAGE_RE.test(f.path));
-      const hasImageChange = data.files.some((f: { path: string; content: string }) => IMAGE_RE.test(f.path));
+      type Incoming = { path: string; content: string; origin?: "self" | "external" };
+      const contentFiles = (data.files as Incoming[])
+        .filter((f) => !IMAGE_RE.test(f.path))
+        .map((f) => ({ ...f, origin: f.origin ?? "external" }));
+      const hasImageChange = (data.files as Incoming[]).some((f) => IMAGE_RE.test(f.path));
       if (contentFiles.length > 0) store.updateFiles(contentFiles);
       if (hasImageChange) store.bumpImageTick();
       break;


### PR DESCRIPTION
## Summary

Introduces `Source<T>`, a typed + origin-aware + subscription-shaped data-channel contract between the runtime and mode viewers. Files on disk remain the coding agent's native habitat — what changes is that viewers now consume domain-typed aggregates (`Deck`, `Site`, `Studio`) via `useSource` instead of grepping through a raw `files` array and hand-rolling echo detection. Realizes the "viewer is the whole app UI" vision from `docs/design/pneuma-3.0-design.md` at the contract layer.

**8 commits, 7 phases, zero interactive browser smoke yet** — per pair agreement, you review locally and run the viewers by hand before merge.

- `90429bc` **docs(source)** — viewer-as-player framing pass across README / CLAUDE.md / viewer-agent-protocol.md / pneuma-3.0-design.md / ADR-007 / superseded mode-sync-transport header
- `cd1efab` **docs(source)** — 5768-line implementation plan at `docs/superpowers/plans/2026-04-13-source-abstraction.md`
- `f3c0bb1` **feat(source) P1** — `core/types/source.ts` contract (Source / SourceEvent / SourceProvider / SourceContext / FileChannel / SourceDescriptor) + compile-time contract test
- `ccddf47` **feat(source) P2** — `BaseSource` abstract class enforcing four invariants (single writer via Promise queue, change-read-via-subscription, time-locked write Promise, origin-tagged events) + four built-in providers (memory / file-glob / json-file / aggregate-file) + 46 bun:test cases
- `d3ff50b` **feat(source) P3** — server-side `pendingSelfWrites` + `pendingSelfDeletes` TTL maps, `FileUpdate.origin`, `DELETE /api/files` route, browser `fileEventBus` + `BrowserFileChannel`, `SourceRegistry` with synthesis fallback, `useSource` React hook via `useSyncExternalStore`, `useSourceInstances` lifecycle hook in App.tsx, `modeManifest` store field
- `f4d9420` **feat(source) P4** — plugin extension point (`PluginManifest.sources`, `PluginRegistry.collectSourceProviders`) — browser-side plugin provider bridge deferred with code comment
- `ba4928b` **refactor(source) P5** — all 10 viewer modes migrated, `files` prop deleted from `ViewerPreviewProps`, synthesis fallback removed; Pattern C modes (slide / webcraft / illustrate) define `modes/<mode>/domain.ts` with typed aggregates + pure load/save functions
- `54b3a19` **docs(source) P7** — `clipcraft-source-migration.md` guide for the ClipCraft mode author (ClipCraft branch itself is not touched)

## What the new shape looks like in a viewer

**Pattern C (domain-typed, e.g. slide):**
```tsx
export default function SlidePreview({ sources }: ViewerPreviewProps) {
  const deckSource = sources.deck as Source<Deck>;
  const { value: deck, write: writeDeck, status } = useSource(deckSource);
  if (!deck) return <EmptyState />;

  // Three old write paths collapse into one:
  const handleReorder = (from: number, to: number) => {
    writeDeck({ ...deck, byContentSet: { /* reordered */ } });
  };
}
```
No `files.find()`, no `JSON.stringify(manifest)`, no `POST /api/files`, no echo refs.

**Pattern D (file-shaped domain, e.g. doc):**
```tsx
export default function DocPreview({ sources, fileChannel }: ViewerPreviewProps) {
  const { value: files, status } = useSource(sources.files as Source<ViewerFileContent[]>);
  // save via fileChannel.write(activePath, content) — origin tagged server-side
  // textarea sync gated on status.lastOrigin !== "self"
}
```

## What got deleted

- `lastExternalRef` (doc), `lastSavedContentRef` + `isUpdatingFromFileRef` + load-bearing ref-before-fetch ordering (draw), `lastFileContentRef` + `currentFilePathRef` skip-guard (diagram)
- 6 inline `saveFile` helpers + ~8 inline `fetch('/api/files')` call sites across doc / draw / slide / webcraft / gridboard
- `useResilientParse(files, parser)` usage in slide / webcraft / illustrate — replaced by provider-layer `load()` pure functions in `modes/<mode>/domain.ts`
- The `files: ViewerFileContent[]` deprecated prop from `ViewerPreviewProps`
- The content-set-scoping memo in `useViewerProps` — now handled internally by Pattern C modes via `byContentSet` bucketing

## Architectural commitments locked in

1. **Layer 1 — files on disk** is the coding agent's native habitat. Not abstracted, not mediated. Claude Code / Codex use Read/Edit/Write tools unchanged.
2. **Layer 2 — runtime transport** (chokidar → `pendingSelfWrites` origin tagging → WS → `fileEventBus`) is infrastructure, not viewer-facing.
3. **Layer 3 — `Source<T>`** is the viewer's domain-typed contract with the runtime. `T` is a domain type (`Deck`, `Site`, `Studio`, `ProjectFile` for future ClipCraft), not a file shape.
4. **Agent writes and viewer writes are two independent paths sharing one disk**, reconciled at the source via the server-side `pendingSelfWrites` content-hash match. The viewer NEVER reverse-engineers origin.

Full contract reference + design principle 7 "Files 归 agent, Domain 归 viewer" in `docs/reference/viewer-agent-protocol.md` (pushed in commit `90429bc`).

## Test plan

- [x] `bun run tsc --noEmit` — **151 errors, unchanged from main baseline** (all pre-existing in unrelated files). Every new/modified file is tsc-clean.
- [x] `bun test` — **610 pass / 0 fail / 1495 expect calls / 50 test files**. Up from 562 on main (+48 new Source tests across `source-types` / `base` / `memory` / `file-glob` / `json-file` / `aggregate-file` / `source-registry` + 2 `plugin-registry` tests).
- [ ] **Interactive browser smoke for each of 9 viewer modes** (deferred to reviewer per agreement). Things most likely to surface:
  - [ ] Content-set scoping for slide / webcraft / illustrate — Pattern C domains bucket by prefix via `byContentSet`, viewer picks the active bucket. Edge cases around empty content sets or mid-edit switches are the most likely regression surface.
  - [ ] Slide / webcraft iframe rendering — both now read raw HTML via a companion `sources.files` file-glob instead of the legacy `props.files`. Should be byte-identical but the plumbing changed.
  - [ ] Draw `setExcalidrawKey` remount — now gated on `status.lastOrigin !== "self"`, should NOT remount on self-saves (unlike the old 500ms busy flag which still flashed). Expected UX improvement.
  - [ ] Doc textarea cursor persistence — origin-aware effect skips reassignment on self-origin echoes. Rapid-typing test.
  - [ ] Gridboard drag/resize/lock — 6 saveFile call sites replaced with `fileChannel.write`, no echo guards existed before or after.
- [ ] **Serialize determinism audit** — the `pendingSelfWrites` content-equality match assumes every `serialize` function is byte-deterministic. The existing tests pass but a subtle determinism bug could surface as "phantom external event after my own save". Flagged as limitation in the ClipCraft guide too.

## Deferred (explicitly out-of-scope)

- **ClipCraft branch refactor.** P7 ships a guide document only. The ClipCraft author rebases onto this branch and follows the guide on their own timeline. `modes/clipcraft/` is not touched by this PR.
- **Browser-side plugin provider runtime.** P4 landed the types + collection API but `useSourceInstances` only registers built-ins because `.create()` functions can't serialize over WS. First browser-capable plugin provider will need either a WS bridge or a browser-loaded plugin runtime — separate plan.
- **Diff-and-dispatch for in-place craft store updates.** Pattern C modes still remount on `origin: "external"` (same as pre-P5 behavior for slide/webcraft/illustrate). Preserving in-memory state across agent edits is a future plan.

## Review guide

The plan at `docs/superpowers/plans/2026-04-13-source-abstraction.md` (5768 lines) is the full spec. If you want the short version, read in commit order:

1. `90429bc` — the framing pass establishes the vocabulary everything else uses (viewer-agent-protocol.md Sources section is worth proofreading)
2. `f3c0bb1` — `core/types/source.ts` is the most important file on the branch; the JSDoc on `Source<T>` invariants is load-bearing
3. `ccddf47` — `core/sources/base.ts` enforces the four invariants; `core/sources/aggregate-file.ts` is the architecturally interesting provider
4. `d3ff50b` — `server/file-watcher.ts` origin pipeline + `src/App.tsx` `useSourceInstances` are the integration-risk files
5. `ba4928b` — 29-file migration diff; per-mode review recommended, especially slide and webcraft (largest viewers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)