### PR TITLE
Add project layer metadata and session sandboxes

### DIFF
--- a/bin/__tests__/pneuma-cli-helpers.test.ts
+++ b/bin/__tests__/pneuma-cli-helpers.test.ts
@@ -12,6 +12,8 @@ describe("pneuma CLI helpers", () => {
 
     expect(parsed.mode).toBe("doc");
     expect(parsed.workspace).toBe("/tmp/workspace");
+    expect(parsed.projectRoot).toBe("");
+    expect(parsed.role).toBe("");
     expect(parsed.backendType).toBe("claude-code");
   });
 
@@ -45,6 +47,26 @@ describe("pneuma CLI helpers", () => {
     expect(parsed.skipSkill).toBe(true);
     expect(parsed.debug).toBe(true);
     expect(parsed.forceDev).toBe(true);
+  });
+
+  test("parseCliArgs parses project and role flags", () => {
+    const parsed = parseCliArgs(
+      [
+        "bun",
+        "bin/pneuma.ts",
+        "webcraft",
+        "--project",
+        "./site",
+        "--role",
+        "Build the home page",
+      ],
+      "/tmp/base",
+    );
+
+    expect(parsed.mode).toBe("webcraft");
+    expect(parsed.projectRoot).toBe("/tmp/base/site");
+    expect(parsed.role).toBe("Build the home page");
+    expect(parsed.workspace).toBe("/tmp/base");
   });
 
   test("parseCliArgs recognizes top-level help and version flags", () => {

--- a/bin/pneuma-cli-helpers.ts
+++ b/bin/pneuma-cli-helpers.ts
@@ -25,6 +25,8 @@ export interface SessionRecord {
 export interface ParsedCliArgs {
   mode: string;
   workspace: string;
+  projectRoot: string;
+  role: string;
   port: number;
   backendType: AgentBackendType;
   showHelp: boolean;
@@ -63,6 +65,8 @@ export function parseCliArgs(argv: string[], cwd = process.cwd()): ParsedCliArgs
   const args = argv.slice(2);
   let mode = "";
   let workspace = cwd;
+  let projectRoot = "";
+  let role = "";
   let port = 0;
   let backendType: AgentBackendType = getDefaultBackendType();
   let showHelp = false;
@@ -81,6 +85,10 @@ export function parseCliArgs(argv: string[], cwd = process.cwd()): ParsedCliArgs
     const arg = args[i];
     if (arg === "--workspace" && i + 1 < args.length) {
       workspace = args[++i];
+    } else if (arg === "--project" && i + 1 < args.length) {
+      projectRoot = resolve(cwd, args[++i]);
+    } else if (arg === "--role" && i + 1 < args.length) {
+      role = args[++i];
     } else if (arg === "--port" && i + 1 < args.length) {
       port = Number(args[++i]);
     } else if (arg === "--backend" && i + 1 < args.length) {
@@ -115,6 +123,8 @@ export function parseCliArgs(argv: string[], cwd = process.cwd()): ParsedCliArgs
   return {
     mode,
     workspace: resolve(cwd, workspace),
+    projectRoot,
+    role,
     port,
     backendType,
     showHelp,

--- a/bin/pneuma.ts
+++ b/bin/pneuma.ts
@@ -732,6 +732,8 @@ Modes:
 
 Options:
   --workspace <path>           Target workspace directory (default: cwd)
+  --project <path>             Launch inside an explicit Pneuma project root
+  --role <text>                Describe this session's role within the project
   --port <number>              Preferred server port
   --backend <type>             Agent backend to launch (default: claude-code)
   --no-open                    Don't auto-open the browser
@@ -1093,7 +1095,7 @@ Options:
     return;
   }
 
-  const { mode, port, backendType, noOpen, debug, forceDev, noPrompt, skipSkill, replaySource, sessionName, viewing } = parsedArgs;
+  const { mode, port, backendType, noOpen, debug, forceDev, noPrompt, skipSkill, replaySource, sessionName, viewing, projectRoot, role } = parsedArgs;
   let { workspace, replayPackage } = parsedArgs;
 
   // Launcher mode — no mode arg → start marketplace UI
@@ -1250,6 +1252,25 @@ Options:
       );
       process.exit(1);
     }
+  }
+
+  let activeProjectRoot = "";
+  let projectSessionId = "";
+
+  if (projectRoot) {
+    const { resolveProjectRuntime } = await import("../core/project.js");
+    const runtime = resolveProjectRuntime({
+      projectRoot,
+      mode: modeName,
+      displayName: manifest.displayName,
+      backendType,
+      role,
+    });
+    activeProjectRoot = runtime.projectRoot;
+    projectSessionId = runtime.session.sessionId;
+    workspace = runtime.workspace;
+    p.log.info(`Project: ${runtime.project.name} (${activeProjectRoot})`);
+    p.log.info(`Project session: ${projectSessionId}`);
   }
 
   if (!existsSync(workspace)) {

--- a/core/__tests__/project.test.ts
+++ b/core/__tests__/project.test.ts
@@ -1,0 +1,196 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  createProject,
+  createProjectSession,
+  listProjectSessions,
+  loadProject,
+  loadRecentProjects,
+  projectManifestPath,
+  projectPneumaDir,
+  projectSessionDir,
+  projectSessionWorkspace,
+  recentProjectsRegistryPath,
+  recordRecentProject,
+  resolveProjectRuntime,
+} from "../project.js";
+
+describe("project manifest", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = join(tmpdir(), `pneuma-project-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(root, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test("createProject writes project.json and project-preferences.md", () => {
+    const project = createProject(root, {
+      name: "Launch Site",
+      description: "Marketing site for Pneuma",
+      now: () => "2026-04-28T00:00:00.000Z",
+      idFactory: () => "project_123",
+    });
+
+    expect(project.projectId).toBe("project_123");
+    expect(project.name).toBe("Launch Site");
+    expect(project.root).toBe(root);
+    expect(existsSync(projectManifestPath(root))).toBe(true);
+    expect(existsSync(join(projectPneumaDir(root), "project-preferences.md"))).toBe(true);
+
+    const loaded = loadProject(root);
+    expect(loaded?.description).toBe("Marketing site for Pneuma");
+  });
+
+  test("createProject derives a readable name from the directory when name is omitted", () => {
+    const project = createProject(root, {
+      now: () => "2026-04-28T00:00:00.000Z",
+      idFactory: () => "project_derived",
+    });
+
+    expect(project.name).toBe(root.split("/").pop());
+  });
+
+  test("loadProject returns null when project.json is absent", () => {
+    expect(loadProject(root)).toBeNull();
+  });
+});
+
+describe("project sessions", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = join(tmpdir(), `pneuma-project-session-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(root, { recursive: true });
+    createProject(root, {
+      name: "Session Project",
+      now: () => "2026-04-28T00:00:00.000Z",
+      idFactory: () => "project_sessions",
+    });
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test("createProjectSession creates session.json, workspace, and scratch", () => {
+    const session = createProjectSession(root, {
+      mode: "webcraft",
+      displayName: "Webcraft",
+      backendType: "claude-code",
+      role: "Build the landing page",
+      now: () => "2026-04-28T01:00:00.000Z",
+      idFactory: () => "webcraft-abc",
+    });
+
+    expect(session.sessionId).toBe("webcraft-abc");
+    expect(session.projectId).toBe("project_sessions");
+    expect(session.sessionWorkspace).toBe(projectSessionWorkspace(root, "webcraft-abc"));
+    expect(existsSync(join(projectSessionDir(root, "webcraft-abc"), "session.json"))).toBe(true);
+    expect(existsSync(projectSessionWorkspace(root, "webcraft-abc"))).toBe(true);
+    expect(existsSync(join(projectSessionDir(root, "webcraft-abc"), "scratch"))).toBe(true);
+  });
+
+  test("listProjectSessions returns sessions sorted by lastAccessed descending", () => {
+    createProjectSession(root, {
+      mode: "doc",
+      displayName: "Doc",
+      backendType: "claude-code",
+      now: () => "2026-04-28T01:00:00.000Z",
+      idFactory: () => "doc-old",
+    });
+    createProjectSession(root, {
+      mode: "webcraft",
+      displayName: "Webcraft",
+      backendType: "codex",
+      now: () => "2026-04-28T02:00:00.000Z",
+      idFactory: () => "web-new",
+    });
+
+    expect(listProjectSessions(root).map((s) => s.sessionId)).toEqual(["web-new", "doc-old"]);
+  });
+});
+
+describe("recent project registry", () => {
+  let home: string;
+  let root: string;
+
+  beforeEach(() => {
+    home = join(tmpdir(), `pneuma-project-home-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    root = join(tmpdir(), `pneuma-project-registry-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(home, { recursive: true });
+    mkdirSync(root, { recursive: true });
+    createProject(root, {
+      name: "Registry Project",
+      now: () => "2026-04-28T00:00:00.000Z",
+      idFactory: () => "project_registry",
+    });
+  });
+
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test("recordRecentProject writes ~/.pneuma/projects.json style records", () => {
+    recordRecentProject(root, {
+      homeDir: home,
+      now: () => "2026-04-28T03:00:00.000Z",
+    });
+
+    expect(existsSync(recentProjectsRegistryPath(home))).toBe(true);
+    const records = loadRecentProjects(home);
+    expect(records).toHaveLength(1);
+    expect(records[0]).toMatchObject({
+      projectId: "project_registry",
+      name: "Registry Project",
+      root,
+      lastAccessed: "2026-04-28T03:00:00.000Z",
+    });
+  });
+
+  test("recordRecentProject de-duplicates by projectId and keeps newest first", () => {
+    recordRecentProject(root, { homeDir: home, now: () => "2026-04-28T03:00:00.000Z" });
+    recordRecentProject(root, { homeDir: home, now: () => "2026-04-28T04:00:00.000Z" });
+
+    const records = loadRecentProjects(home);
+    expect(records).toHaveLength(1);
+    expect(records[0].lastAccessed).toBe("2026-04-28T04:00:00.000Z");
+  });
+});
+
+describe("project runtime", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = join(tmpdir(), `pneuma-project-runtime-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(root, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test("resolveProjectRuntime creates a project session workspace", () => {
+    const runtime = resolveProjectRuntime({
+      projectRoot: root,
+      mode: "webcraft",
+      displayName: "Webcraft",
+      backendType: "claude-code",
+      role: "Build the hero section",
+      now: () => "2026-04-28T05:00:00.000Z",
+      projectIdFactory: () => "project_runtime",
+      sessionIdFactory: () => "web-runtime",
+    });
+
+    expect(runtime.project.projectId).toBe("project_runtime");
+    expect(runtime.session.sessionId).toBe("web-runtime");
+    expect(runtime.workspace).toBe(join(root, ".pneuma", "sessions", "web-runtime", "workspace"));
+    expect(runtime.projectRoot).toBe(root);
+  });
+});

--- a/core/project.ts
+++ b/core/project.ts
@@ -1,0 +1,293 @@
+import { existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import { basename, join, resolve } from "node:path";
+import { homedir } from "node:os";
+
+export type ProjectBackendType = "claude-code" | "codex";
+
+export interface ProjectManifest {
+  schemaVersion: 1;
+  projectId: string;
+  name: string;
+  description?: string;
+  createdAt: string;
+  updatedAt: string;
+  root: string;
+  deliverablePaths?: string[];
+  defaultBackendType?: ProjectBackendType;
+}
+
+export interface CreateProjectOptions {
+  name?: string;
+  description?: string;
+  now?: () => string;
+  idFactory?: () => string;
+}
+
+export interface ProjectSessionManifest {
+  schemaVersion: 1;
+  sessionId: string;
+  projectId: string;
+  mode: string;
+  role?: string;
+  displayName: string;
+  backendType: ProjectBackendType;
+  status: "active" | "idle" | "archived";
+  createdAt: string;
+  lastAccessed: string;
+  sessionWorkspace: string;
+  deliverablePaths?: string[];
+  sourceQuickSessionId?: string;
+}
+
+export interface CreateProjectSessionOptions {
+  mode: string;
+  displayName: string;
+  backendType: ProjectBackendType;
+  role?: string;
+  now?: () => string;
+  idFactory?: () => string;
+}
+
+export interface RecentProjectRecord {
+  projectId: string;
+  name: string;
+  description?: string;
+  root: string;
+  lastAccessed: string;
+}
+
+export interface RecordRecentProjectOptions {
+  homeDir?: string;
+  now?: () => string;
+  limit?: number;
+}
+
+export interface ResolveProjectRuntimeOptions {
+  projectRoot: string;
+  mode: string;
+  displayName: string;
+  backendType: ProjectBackendType;
+  role?: string;
+  now?: () => string;
+  projectIdFactory?: () => string;
+  sessionIdFactory?: () => string;
+}
+
+export interface ProjectRuntime {
+  projectRoot: string;
+  workspace: string;
+  project: ProjectManifest;
+  session: ProjectSessionManifest;
+}
+
+export type ProjectTimelineEvent =
+  | { type: "project.created"; at: string; projectId: string; name: string }
+  | { type: "project.updated"; at: string; changes: Record<string, unknown> }
+  | { type: "session.created"; at: string; sessionId: string; mode: string; role?: string }
+  | { type: "session.resumed"; at: string; sessionId: string }
+  | { type: "deliverable.published"; at: string; sessionId: string; paths: string[] };
+
+export function projectPneumaDir(projectRoot: string): string {
+  return join(resolve(projectRoot), ".pneuma");
+}
+
+export function projectManifestPath(projectRoot: string): string {
+  return join(projectPneumaDir(projectRoot), "project.json");
+}
+
+export function projectPreferencesPath(projectRoot: string): string {
+  return join(projectPneumaDir(projectRoot), "project-preferences.md");
+}
+
+export function projectTimelinePath(projectRoot: string): string {
+  return join(projectPneumaDir(projectRoot), "timeline.jsonl");
+}
+
+export function projectSessionsDir(projectRoot: string): string {
+  return join(projectPneumaDir(projectRoot), "sessions");
+}
+
+export function projectSessionDir(projectRoot: string, sessionId: string): string {
+  return join(projectSessionsDir(projectRoot), sessionId);
+}
+
+export function projectSessionWorkspace(projectRoot: string, sessionId: string): string {
+  return join(projectSessionDir(projectRoot, sessionId), "workspace");
+}
+
+export function recentProjectsRegistryPath(homeDir = homedir()): string {
+  return join(homeDir, ".pneuma", "projects.json");
+}
+
+function defaultNow(): string {
+  return new Date().toISOString();
+}
+
+function defaultProjectId(): string {
+  return `project_${crypto.randomUUID()}`;
+}
+
+function defaultSessionId(mode: string): string {
+  const stamp = new Date().toISOString().replace(/[-:]/g, "").replace(/\.\d{3}Z$/, "Z");
+  return `${mode}-${stamp}-${crypto.randomUUID().slice(0, 8)}`;
+}
+
+export function loadProject(projectRoot: string): ProjectManifest | null {
+  const filePath = projectManifestPath(projectRoot);
+  if (!existsSync(filePath)) return null;
+
+  const parsed = JSON.parse(readFileSync(filePath, "utf-8")) as ProjectManifest;
+  if (parsed.schemaVersion !== 1 || !parsed.projectId || !parsed.name) {
+    throw new Error(`Invalid Pneuma project manifest: ${filePath}`);
+  }
+
+  return { ...parsed, root: resolve(projectRoot) };
+}
+
+export function appendProjectTimelineEvent(projectRoot: string, event: ProjectTimelineEvent): void {
+  mkdirSync(projectPneumaDir(projectRoot), { recursive: true });
+  writeFileSync(projectTimelinePath(projectRoot), `${JSON.stringify(event)}\n`, { flag: "a" });
+}
+
+export function createProject(projectRoot: string, options: CreateProjectOptions = {}): ProjectManifest {
+  const root = resolve(projectRoot);
+  const existing = loadProject(root);
+  if (existing) return existing;
+
+  const now = options.now?.() ?? defaultNow();
+  const manifest: ProjectManifest = {
+    schemaVersion: 1,
+    projectId: options.idFactory?.() ?? defaultProjectId(),
+    name: options.name?.trim() || basename(root),
+    ...(options.description?.trim() ? { description: options.description.trim() } : {}),
+    createdAt: now,
+    updatedAt: now,
+    root,
+  };
+
+  mkdirSync(projectPneumaDir(root), { recursive: true });
+  mkdirSync(projectSessionsDir(root), { recursive: true });
+  writeFileSync(projectManifestPath(root), JSON.stringify(manifest, null, 2));
+  if (!existsSync(projectPreferencesPath(root))) {
+    writeFileSync(projectPreferencesPath(root), "# Project Preferences\n\n");
+  }
+  appendProjectTimelineEvent(root, {
+    type: "project.created",
+    at: now,
+    projectId: manifest.projectId,
+    name: manifest.name,
+  });
+  return manifest;
+}
+
+export function createProjectSession(
+  projectRoot: string,
+  options: CreateProjectSessionOptions,
+): ProjectSessionManifest {
+  const project = createProject(projectRoot);
+  const now = options.now?.() ?? defaultNow();
+  const sessionId = options.idFactory?.() ?? defaultSessionId(options.mode);
+  const dir = projectSessionDir(projectRoot, sessionId);
+  const workspace = projectSessionWorkspace(projectRoot, sessionId);
+
+  mkdirSync(workspace, { recursive: true });
+  mkdirSync(join(dir, "scratch"), { recursive: true });
+
+  const session: ProjectSessionManifest = {
+    schemaVersion: 1,
+    sessionId,
+    projectId: project.projectId,
+    mode: options.mode,
+    ...(options.role?.trim() ? { role: options.role.trim() } : {}),
+    displayName: options.displayName,
+    backendType: options.backendType,
+    status: "active",
+    createdAt: now,
+    lastAccessed: now,
+    sessionWorkspace: workspace,
+  };
+
+  writeFileSync(join(dir, "session.json"), JSON.stringify(session, null, 2));
+  appendProjectTimelineEvent(projectRoot, {
+    type: "session.created",
+    at: now,
+    sessionId,
+    mode: options.mode,
+    ...(options.role?.trim() ? { role: options.role.trim() } : {}),
+  });
+  return session;
+}
+
+export function listProjectSessions(projectRoot: string): ProjectSessionManifest[] {
+  const dir = projectSessionsDir(projectRoot);
+  if (!existsSync(dir)) return [];
+
+  const sessions: ProjectSessionManifest[] = [];
+  for (const entry of readdirSync(dir)) {
+    const entryDir = join(dir, entry);
+    const filePath = join(entryDir, "session.json");
+    try {
+      if (!statSync(entryDir).isDirectory() || !existsSync(filePath)) continue;
+      sessions.push(JSON.parse(readFileSync(filePath, "utf-8")) as ProjectSessionManifest);
+    } catch {
+      continue;
+    }
+  }
+
+  return sessions.sort((a, b) => b.lastAccessed.localeCompare(a.lastAccessed));
+}
+
+export function loadRecentProjects(homeDir = homedir()): RecentProjectRecord[] {
+  try {
+    const records = JSON.parse(readFileSync(recentProjectsRegistryPath(homeDir), "utf-8")) as RecentProjectRecord[];
+    return records.filter((record) => existsSync(record.root));
+  } catch {
+    return [];
+  }
+}
+
+export function saveRecentProjects(records: RecentProjectRecord[], homeDir = homedir()): void {
+  mkdirSync(join(homeDir, ".pneuma"), { recursive: true });
+  writeFileSync(recentProjectsRegistryPath(homeDir), JSON.stringify(records, null, 2));
+}
+
+export function recordRecentProject(projectRoot: string, options: RecordRecentProjectOptions = {}): RecentProjectRecord {
+  const project = createProject(projectRoot);
+  const home = options.homeDir ?? homedir();
+  const record: RecentProjectRecord = {
+    projectId: project.projectId,
+    name: project.name,
+    ...(project.description ? { description: project.description } : {}),
+    root: resolve(projectRoot),
+    lastAccessed: options.now?.() ?? defaultNow(),
+  };
+  const next = [
+    record,
+    ...loadRecentProjects(home).filter((existing) => existing.projectId !== record.projectId),
+  ].slice(0, options.limit ?? 50);
+
+  saveRecentProjects(next, home);
+  return record;
+}
+
+export function resolveProjectRuntime(options: ResolveProjectRuntimeOptions): ProjectRuntime {
+  const project = createProject(options.projectRoot, {
+    now: options.now,
+    idFactory: options.projectIdFactory,
+  });
+  const session = createProjectSession(options.projectRoot, {
+    mode: options.mode,
+    displayName: options.displayName,
+    backendType: options.backendType,
+    role: options.role,
+    now: options.now,
+    idFactory: options.sessionIdFactory,
+  });
+  recordRecentProject(options.projectRoot, { now: options.now });
+  return {
+    projectRoot: resolve(options.projectRoot),
+    workspace: session.sessionWorkspace,
+    project,
+    session,
+  };
+}

--- a/docs/superpowers/plans/2026-04-28-project-layer-foundation.md
+++ b/docs/superpowers/plans/2026-04-28-project-layer-foundation.md
@@ -1,0 +1,1121 @@
+# Project Layer Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the foundation for optional Pneuma projects: project metadata, recent-project registry, project session sandboxes, and CLI/launcher launch plumbing while preserving quick-session behavior.
+
+**Architecture:** Add a focused `core/project.ts` module that owns project manifests, session manifests, timeline events, and recent-project registry files. CLI launch code resolves a project session into a normal `workspace` pointing at `.pneuma/sessions/<session-id>/workspace`, while keeping `projectRoot` as explicit runtime metadata for later context injection and UI work.
+
+**Tech Stack:** Bun, TypeScript, Hono launcher routes, existing `bin/pneuma.ts` CLI flow, existing Bun test suite.
+
+---
+
+## Scope
+
+This plan implements the foundation needed before Launcher overview, editable cross-mode handoffs, project preference injection, quick-session upgrade UI, and project-level evolve. Those features are represented as follow-up board cards because they are independently testable subsystems.
+
+This foundation must ship with one observable guarantee: `pneuma <mode>` still behaves as a quick session, while `pneuma <mode> --project <root> --role <role>` creates or uses a project and stores session state under the project session sandbox.
+
+## File Map
+
+- Create: `core/project.ts`
+  - Project manifest types and read/write helpers.
+  - Project session manifest helpers.
+  - Timeline append helper.
+  - Recent-project registry helpers.
+  - Runtime session path resolver.
+
+- Create: `core/__tests__/project.test.ts`
+  - Unit tests for project creation, project loading, session sandbox resolution, timeline append, registry behavior, and corrupt manifest handling.
+
+- Modify: `bin/pneuma-cli-helpers.ts`
+  - Add `--project` and `--role` parsing.
+  - Extend `ParsedCliArgs`.
+
+- Modify: `bin/__tests__/pneuma-cli-helpers.test.ts`
+  - Assert project and role flags parse without changing quick-session defaults.
+
+- Modify: `bin/pneuma.ts`
+  - Resolve project session runtime before workspace existence checks.
+  - Use the session sandbox as `workspace` for skill install, config, history, watcher, server, and backend cwd.
+  - Record recent project and project session metadata.
+
+- Modify: `server/index.ts`
+  - Add Launcher-mode project APIs.
+  - Accept project launch fields in `/api/launch`.
+  - Spawn child processes with `--project` and `--role` when requested.
+
+- Create: `server/__tests__/project-routes.test.ts`
+  - Route tests for listing projects, creating projects, project path validation, and project launch argument behavior where observable without spawning a real agent.
+
+## Task 1: Project Domain Module
+
+**Files:**
+- Create: `core/project.ts`
+- Create: `core/__tests__/project.test.ts`
+
+- [ ] **Step 1: Write failing tests for project manifest creation**
+
+Create `core/__tests__/project.test.ts` with this first test group:
+
+```ts
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  createProject,
+  loadProject,
+  projectManifestPath,
+  projectPneumaDir,
+} from "../project.js";
+
+describe("project manifest", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = join(tmpdir(), `pneuma-project-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(root, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test("createProject writes project.json and project-preferences.md", () => {
+    const project = createProject(root, {
+      name: "Launch Site",
+      description: "Marketing site for Pneuma",
+      now: () => "2026-04-28T00:00:00.000Z",
+      idFactory: () => "project_123",
+    });
+
+    expect(project.projectId).toBe("project_123");
+    expect(project.name).toBe("Launch Site");
+    expect(project.root).toBe(root);
+    expect(existsSync(projectManifestPath(root))).toBe(true);
+    expect(existsSync(join(projectPneumaDir(root), "project-preferences.md"))).toBe(true);
+
+    const loaded = loadProject(root);
+    expect(loaded?.description).toBe("Marketing site for Pneuma");
+  });
+
+  test("createProject derives a readable name from the directory when name is omitted", () => {
+    const project = createProject(root, {
+      now: () => "2026-04-28T00:00:00.000Z",
+      idFactory: () => "project_derived",
+    });
+
+    expect(project.name).toBe(root.split("/").pop());
+  });
+
+  test("loadProject returns null when project.json is absent", () => {
+    expect(loadProject(root)).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run the focused test and confirm it fails**
+
+Run:
+
+```bash
+bun test core/__tests__/project.test.ts
+```
+
+Expected: FAIL because `core/project.ts` does not exist.
+
+- [ ] **Step 3: Implement project manifest helpers**
+
+Create `core/project.ts` with these exports:
+
+```ts
+import { existsSync, mkdirSync, readFileSync, writeFileSync, readdirSync, statSync } from "node:fs";
+import { basename, join, resolve } from "node:path";
+import { homedir } from "node:os";
+
+export interface ProjectManifest {
+  schemaVersion: 1;
+  projectId: string;
+  name: string;
+  description?: string;
+  createdAt: string;
+  updatedAt: string;
+  root: string;
+  deliverablePaths?: string[];
+  defaultBackendType?: "claude-code" | "codex";
+}
+
+export interface CreateProjectOptions {
+  name?: string;
+  description?: string;
+  now?: () => string;
+  idFactory?: () => string;
+}
+
+export function projectPneumaDir(projectRoot: string): string {
+  return join(resolve(projectRoot), ".pneuma");
+}
+
+export function projectManifestPath(projectRoot: string): string {
+  return join(projectPneumaDir(projectRoot), "project.json");
+}
+
+export function projectPreferencesPath(projectRoot: string): string {
+  return join(projectPneumaDir(projectRoot), "project-preferences.md");
+}
+
+export function projectTimelinePath(projectRoot: string): string {
+  return join(projectPneumaDir(projectRoot), "timeline.jsonl");
+}
+
+export function projectSessionsDir(projectRoot: string): string {
+  return join(projectPneumaDir(projectRoot), "sessions");
+}
+
+function defaultNow(): string {
+  return new Date().toISOString();
+}
+
+function defaultProjectId(): string {
+  return `project_${crypto.randomUUID()}`;
+}
+
+export function loadProject(projectRoot: string): ProjectManifest | null {
+  const filePath = projectManifestPath(projectRoot);
+  if (!existsSync(filePath)) return null;
+  const parsed = JSON.parse(readFileSync(filePath, "utf-8")) as ProjectManifest;
+  if (parsed.schemaVersion !== 1 || !parsed.projectId || !parsed.name) {
+    throw new Error(`Invalid Pneuma project manifest: ${filePath}`);
+  }
+  return { ...parsed, root: resolve(projectRoot) };
+}
+
+export function createProject(projectRoot: string, options: CreateProjectOptions = {}): ProjectManifest {
+  const root = resolve(projectRoot);
+  const existing = loadProject(root);
+  if (existing) return existing;
+
+  const now = options.now?.() ?? defaultNow();
+  const manifest: ProjectManifest = {
+    schemaVersion: 1,
+    projectId: options.idFactory?.() ?? defaultProjectId(),
+    name: options.name?.trim() || basename(root),
+    ...(options.description?.trim() ? { description: options.description.trim() } : {}),
+    createdAt: now,
+    updatedAt: now,
+    root,
+  };
+
+  mkdirSync(projectPneumaDir(root), { recursive: true });
+  mkdirSync(projectSessionsDir(root), { recursive: true });
+  writeFileSync(projectManifestPath(root), JSON.stringify(manifest, null, 2));
+  if (!existsSync(projectPreferencesPath(root))) {
+    writeFileSync(projectPreferencesPath(root), "# Project Preferences\n\n");
+  }
+  appendProjectTimelineEvent(root, {
+    type: "project.created",
+    at: now,
+    projectId: manifest.projectId,
+    name: manifest.name,
+  });
+  return manifest;
+}
+```
+
+Add the timeline helper at the bottom of the same file:
+
+```ts
+export type ProjectTimelineEvent =
+  | { type: "project.created"; at: string; projectId: string; name: string }
+  | { type: "project.updated"; at: string; changes: Record<string, unknown> }
+  | { type: "session.created"; at: string; sessionId: string; mode: string; role?: string }
+  | { type: "session.resumed"; at: string; sessionId: string }
+  | { type: "deliverable.published"; at: string; sessionId: string; paths: string[] };
+
+export function appendProjectTimelineEvent(projectRoot: string, event: ProjectTimelineEvent): void {
+  mkdirSync(projectPneumaDir(projectRoot), { recursive: true });
+  const line = `${JSON.stringify(event)}\n`;
+  const path = projectTimelinePath(projectRoot);
+  writeFileSync(path, line, { flag: "a" });
+}
+```
+
+- [ ] **Step 4: Run the focused test and confirm it passes**
+
+Run:
+
+```bash
+bun test core/__tests__/project.test.ts
+```
+
+Expected: PASS for the manifest test group.
+
+## Task 2: Project Session Sandboxes
+
+**Files:**
+- Modify: `core/project.ts`
+- Modify: `core/__tests__/project.test.ts`
+
+- [ ] **Step 1: Add failing tests for session sandbox creation**
+
+Append these tests to `core/__tests__/project.test.ts`:
+
+```ts
+import {
+  createProjectSession,
+  listProjectSessions,
+  projectSessionDir,
+  projectSessionWorkspace,
+} from "../project.js";
+
+describe("project sessions", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = join(tmpdir(), `pneuma-project-session-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(root, { recursive: true });
+    createProject(root, {
+      name: "Session Project",
+      now: () => "2026-04-28T00:00:00.000Z",
+      idFactory: () => "project_sessions",
+    });
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test("createProjectSession creates session.json, workspace, and scratch", () => {
+    const session = createProjectSession(root, {
+      mode: "webcraft",
+      displayName: "Webcraft",
+      backendType: "claude-code",
+      role: "Build the landing page",
+      now: () => "2026-04-28T01:00:00.000Z",
+      idFactory: () => "webcraft-abc",
+    });
+
+    expect(session.sessionId).toBe("webcraft-abc");
+    expect(session.projectId).toBe("project_sessions");
+    expect(session.sessionWorkspace).toBe(projectSessionWorkspace(root, "webcraft-abc"));
+    expect(existsSync(join(projectSessionDir(root, "webcraft-abc"), "session.json"))).toBe(true);
+    expect(existsSync(projectSessionWorkspace(root, "webcraft-abc"))).toBe(true);
+    expect(existsSync(join(projectSessionDir(root, "webcraft-abc"), "scratch"))).toBe(true);
+  });
+
+  test("listProjectSessions returns sessions sorted by lastAccessed descending", () => {
+    createProjectSession(root, {
+      mode: "doc",
+      displayName: "Doc",
+      backendType: "claude-code",
+      now: () => "2026-04-28T01:00:00.000Z",
+      idFactory: () => "doc-old",
+    });
+    createProjectSession(root, {
+      mode: "webcraft",
+      displayName: "Webcraft",
+      backendType: "codex",
+      now: () => "2026-04-28T02:00:00.000Z",
+      idFactory: () => "web-new",
+    });
+
+    expect(listProjectSessions(root).map((s) => s.sessionId)).toEqual(["web-new", "doc-old"]);
+  });
+});
+```
+
+- [ ] **Step 2: Run the focused test and confirm it fails**
+
+Run:
+
+```bash
+bun test core/__tests__/project.test.ts
+```
+
+Expected: FAIL because session helper exports do not exist.
+
+- [ ] **Step 3: Implement session helpers**
+
+Add these exports to `core/project.ts`:
+
+```ts
+export interface ProjectSessionManifest {
+  schemaVersion: 1;
+  sessionId: string;
+  projectId: string;
+  mode: string;
+  role?: string;
+  displayName: string;
+  backendType: "claude-code" | "codex";
+  status: "active" | "idle" | "archived";
+  createdAt: string;
+  lastAccessed: string;
+  sessionWorkspace: string;
+  deliverablePaths?: string[];
+  sourceQuickSessionId?: string;
+}
+
+export interface CreateProjectSessionOptions {
+  mode: string;
+  displayName: string;
+  backendType: "claude-code" | "codex";
+  role?: string;
+  now?: () => string;
+  idFactory?: () => string;
+}
+
+export function projectSessionDir(projectRoot: string, sessionId: string): string {
+  return join(projectSessionsDir(projectRoot), sessionId);
+}
+
+export function projectSessionWorkspace(projectRoot: string, sessionId: string): string {
+  return join(projectSessionDir(projectRoot, sessionId), "workspace");
+}
+
+function defaultSessionId(mode: string): string {
+  const stamp = new Date().toISOString().replace(/[-:]/g, "").replace(/\.\d{3}Z$/, "Z");
+  return `${mode}-${stamp}-${crypto.randomUUID().slice(0, 8)}`;
+}
+
+export function createProjectSession(
+  projectRoot: string,
+  options: CreateProjectSessionOptions,
+): ProjectSessionManifest {
+  const project = createProject(projectRoot);
+  const now = options.now?.() ?? defaultNow();
+  const sessionId = options.idFactory?.() ?? defaultSessionId(options.mode);
+  const dir = projectSessionDir(projectRoot, sessionId);
+  const workspace = projectSessionWorkspace(projectRoot, sessionId);
+  mkdirSync(workspace, { recursive: true });
+  mkdirSync(join(dir, "scratch"), { recursive: true });
+
+  const session: ProjectSessionManifest = {
+    schemaVersion: 1,
+    sessionId,
+    projectId: project.projectId,
+    mode: options.mode,
+    ...(options.role?.trim() ? { role: options.role.trim() } : {}),
+    displayName: options.displayName,
+    backendType: options.backendType,
+    status: "active",
+    createdAt: now,
+    lastAccessed: now,
+    sessionWorkspace: workspace,
+  };
+
+  writeFileSync(join(dir, "session.json"), JSON.stringify(session, null, 2));
+  appendProjectTimelineEvent(projectRoot, {
+    type: "session.created",
+    at: now,
+    sessionId,
+    mode: options.mode,
+    ...(options.role?.trim() ? { role: options.role.trim() } : {}),
+  });
+  return session;
+}
+
+export function listProjectSessions(projectRoot: string): ProjectSessionManifest[] {
+  const dir = projectSessionsDir(projectRoot);
+  if (!existsSync(dir)) return [];
+  const sessions: ProjectSessionManifest[] = [];
+  for (const entry of readdirSync(dir)) {
+    const filePath = join(dir, entry, "session.json");
+    try {
+      if (!statSync(join(dir, entry)).isDirectory() || !existsSync(filePath)) continue;
+      sessions.push(JSON.parse(readFileSync(filePath, "utf-8")) as ProjectSessionManifest);
+    } catch {
+      continue;
+    }
+  }
+  return sessions.sort((a, b) => b.lastAccessed.localeCompare(a.lastAccessed));
+}
+```
+
+- [ ] **Step 4: Run the focused test and confirm it passes**
+
+Run:
+
+```bash
+bun test core/__tests__/project.test.ts
+```
+
+Expected: PASS for manifest and session helper tests.
+
+## Task 3: Recent Project Registry
+
+**Files:**
+- Modify: `core/project.ts`
+- Modify: `core/__tests__/project.test.ts`
+
+- [ ] **Step 1: Add failing tests for recent-project registry behavior**
+
+Append this test group:
+
+```ts
+import {
+  loadRecentProjects,
+  recordRecentProject,
+  recentProjectsRegistryPath,
+} from "../project.js";
+
+describe("recent project registry", () => {
+  let home: string;
+  let root: string;
+
+  beforeEach(() => {
+    home = join(tmpdir(), `pneuma-project-home-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    root = join(tmpdir(), `pneuma-project-registry-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(home, { recursive: true });
+    mkdirSync(root, { recursive: true });
+    createProject(root, {
+      name: "Registry Project",
+      now: () => "2026-04-28T00:00:00.000Z",
+      idFactory: () => "project_registry",
+    });
+  });
+
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test("recordRecentProject writes ~/.pneuma/projects.json style records", () => {
+    recordRecentProject(root, {
+      homeDir: home,
+      now: () => "2026-04-28T03:00:00.000Z",
+    });
+
+    expect(existsSync(recentProjectsRegistryPath(home))).toBe(true);
+    const records = loadRecentProjects(home);
+    expect(records).toHaveLength(1);
+    expect(records[0]).toMatchObject({
+      projectId: "project_registry",
+      name: "Registry Project",
+      root,
+      lastAccessed: "2026-04-28T03:00:00.000Z",
+    });
+  });
+
+  test("recordRecentProject de-duplicates by projectId and keeps newest first", () => {
+    recordRecentProject(root, { homeDir: home, now: () => "2026-04-28T03:00:00.000Z" });
+    recordRecentProject(root, { homeDir: home, now: () => "2026-04-28T04:00:00.000Z" });
+
+    const records = loadRecentProjects(home);
+    expect(records).toHaveLength(1);
+    expect(records[0].lastAccessed).toBe("2026-04-28T04:00:00.000Z");
+  });
+});
+```
+
+- [ ] **Step 2: Run the focused test and confirm it fails**
+
+Run:
+
+```bash
+bun test core/__tests__/project.test.ts
+```
+
+Expected: FAIL because registry helper exports do not exist.
+
+- [ ] **Step 3: Implement recent-project registry helpers**
+
+Add these exports to `core/project.ts`:
+
+```ts
+export interface RecentProjectRecord {
+  projectId: string;
+  name: string;
+  description?: string;
+  root: string;
+  lastAccessed: string;
+}
+
+export interface RecordRecentProjectOptions {
+  homeDir?: string;
+  now?: () => string;
+  limit?: number;
+}
+
+export function recentProjectsRegistryPath(homeDir = homedir()): string {
+  return join(homeDir, ".pneuma", "projects.json");
+}
+
+export function loadRecentProjects(homeDir = homedir()): RecentProjectRecord[] {
+  const path = recentProjectsRegistryPath(homeDir);
+  try {
+    const records = JSON.parse(readFileSync(path, "utf-8")) as RecentProjectRecord[];
+    return records.filter((record) => existsSync(record.root));
+  } catch {
+    return [];
+  }
+}
+
+export function saveRecentProjects(records: RecentProjectRecord[], homeDir = homedir()): void {
+  const path = recentProjectsRegistryPath(homeDir);
+  mkdirSync(join(homeDir, ".pneuma"), { recursive: true });
+  writeFileSync(path, JSON.stringify(records, null, 2));
+}
+
+export function recordRecentProject(projectRoot: string, options: RecordRecentProjectOptions = {}): RecentProjectRecord {
+  const project = createProject(projectRoot);
+  const home = options.homeDir ?? homedir();
+  const record: RecentProjectRecord = {
+    projectId: project.projectId,
+    name: project.name,
+    ...(project.description ? { description: project.description } : {}),
+    root: resolve(projectRoot),
+    lastAccessed: options.now?.() ?? defaultNow(),
+  };
+  const limit = options.limit ?? 50;
+  const next = [
+    record,
+    ...loadRecentProjects(home).filter((existing) => existing.projectId !== record.projectId),
+  ].slice(0, limit);
+  saveRecentProjects(next, home);
+  return record;
+}
+```
+
+- [ ] **Step 4: Run the focused test and confirm it passes**
+
+Run:
+
+```bash
+bun test core/__tests__/project.test.ts
+```
+
+Expected: PASS.
+
+## Task 4: CLI Argument Parsing
+
+**Files:**
+- Modify: `bin/pneuma-cli-helpers.ts`
+- Modify: `bin/__tests__/pneuma-cli-helpers.test.ts`
+
+- [ ] **Step 1: Add failing parser tests**
+
+Add these tests to `bin/__tests__/pneuma-cli-helpers.test.ts`:
+
+```ts
+test("parseCliArgs parses project and role flags", () => {
+  const parsed = parseCliArgs(
+    [
+      "bun",
+      "bin/pneuma.ts",
+      "webcraft",
+      "--project",
+      "./site",
+      "--role",
+      "Build the home page",
+    ],
+    "/tmp/base",
+  );
+
+  expect(parsed.mode).toBe("webcraft");
+  expect(parsed.projectRoot).toBe("/tmp/base/site");
+  expect(parsed.role).toBe("Build the home page");
+  expect(parsed.workspace).toBe("/tmp/base");
+});
+
+test("parseCliArgs preserves quick-session defaults when project is absent", () => {
+  const parsed = parseCliArgs(["bun", "bin/pneuma.ts", "doc"], "/tmp/workspace");
+
+  expect(parsed.projectRoot).toBe("");
+  expect(parsed.role).toBe("");
+  expect(parsed.workspace).toBe("/tmp/workspace");
+});
+```
+
+- [ ] **Step 2: Run the focused parser test and confirm it fails**
+
+Run:
+
+```bash
+bun test bin/__tests__/pneuma-cli-helpers.test.ts
+```
+
+Expected: FAIL because `projectRoot` and `role` are not on `ParsedCliArgs`.
+
+- [ ] **Step 3: Extend parser types and logic**
+
+Modify `bin/pneuma-cli-helpers.ts`:
+
+```ts
+export interface ParsedCliArgs {
+  mode: string;
+  workspace: string;
+  projectRoot: string;
+  role: string;
+  port: number;
+  backendType: AgentBackendType;
+  showHelp: boolean;
+  showVersion: boolean;
+  noOpen: boolean;
+  debug: boolean;
+  forceDev: boolean;
+  noPrompt: boolean;
+  skipSkill: boolean;
+  replayPackage: string;
+  replaySource: string;
+  sessionName: string;
+  viewing: boolean;
+}
+```
+
+Inside `parseCliArgs` initialize:
+
+```ts
+let projectRoot = "";
+let role = "";
+```
+
+Add flag handling:
+
+```ts
+} else if (arg === "--project" && i + 1 < args.length) {
+  projectRoot = resolve(cwd, args[++i]);
+} else if (arg === "--role" && i + 1 < args.length) {
+  role = args[++i];
+```
+
+Return the new fields:
+
+```ts
+return {
+  mode,
+  workspace: resolve(cwd, workspace),
+  projectRoot,
+  role,
+  port,
+  backendType,
+  showHelp,
+  showVersion,
+  noOpen,
+  debug,
+  forceDev,
+  noPrompt,
+  skipSkill,
+  replayPackage,
+  replaySource,
+  sessionName,
+  viewing,
+};
+```
+
+- [ ] **Step 4: Run parser tests**
+
+Run:
+
+```bash
+bun test bin/__tests__/pneuma-cli-helpers.test.ts
+```
+
+Expected: PASS.
+
+## Task 5: Project Runtime Resolution in CLI
+
+**Files:**
+- Modify: `bin/pneuma.ts`
+- Modify: `core/project.ts`
+- Modify: `core/__tests__/project.test.ts`
+
+- [ ] **Step 1: Add a runtime resolver test**
+
+Append this test to `core/__tests__/project.test.ts`:
+
+```ts
+import { resolveProjectRuntime } from "../project.js";
+
+describe("project runtime", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = join(tmpdir(), `pneuma-project-runtime-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(root, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test("resolveProjectRuntime creates a project session workspace", () => {
+    const runtime = resolveProjectRuntime({
+      projectRoot: root,
+      mode: "webcraft",
+      displayName: "Webcraft",
+      backendType: "claude-code",
+      role: "Build the hero section",
+      now: () => "2026-04-28T05:00:00.000Z",
+      projectIdFactory: () => "project_runtime",
+      sessionIdFactory: () => "web-runtime",
+    });
+
+    expect(runtime.project.projectId).toBe("project_runtime");
+    expect(runtime.session.sessionId).toBe("web-runtime");
+    expect(runtime.workspace).toBe(join(root, ".pneuma", "sessions", "web-runtime", "workspace"));
+    expect(runtime.projectRoot).toBe(root);
+  });
+});
+```
+
+- [ ] **Step 2: Run the focused test and confirm it fails**
+
+Run:
+
+```bash
+bun test core/__tests__/project.test.ts
+```
+
+Expected: FAIL because `resolveProjectRuntime` does not exist.
+
+- [ ] **Step 3: Implement the runtime resolver**
+
+Add this to `core/project.ts`:
+
+```ts
+export interface ResolveProjectRuntimeOptions {
+  projectRoot: string;
+  mode: string;
+  displayName: string;
+  backendType: "claude-code" | "codex";
+  role?: string;
+  now?: () => string;
+  projectIdFactory?: () => string;
+  sessionIdFactory?: () => string;
+}
+
+export interface ProjectRuntime {
+  projectRoot: string;
+  workspace: string;
+  project: ProjectManifest;
+  session: ProjectSessionManifest;
+}
+
+export function resolveProjectRuntime(options: ResolveProjectRuntimeOptions): ProjectRuntime {
+  const project = createProject(options.projectRoot, {
+    now: options.now,
+    idFactory: options.projectIdFactory,
+  });
+  const session = createProjectSession(options.projectRoot, {
+    mode: options.mode,
+    displayName: options.displayName,
+    backendType: options.backendType,
+    role: options.role,
+    now: options.now,
+    idFactory: options.sessionIdFactory,
+  });
+  recordRecentProject(options.projectRoot, { now: options.now });
+  return {
+    projectRoot: resolve(options.projectRoot),
+    workspace: session.sessionWorkspace,
+    project,
+    session,
+  };
+}
+```
+
+- [ ] **Step 4: Wire runtime resolution into `bin/pneuma.ts`**
+
+In `bin/pneuma.ts`, extend parsed args:
+
+```ts
+const { mode, port, backendType, noOpen, debug, forceDev, noPrompt, skipSkill, replaySource, sessionName, viewing, projectRoot, role } = parsedArgs;
+let { workspace, replayPackage } = parsedArgs;
+```
+
+After mode manifest loading and before workspace existence checks, add:
+
+```ts
+let activeProjectRoot = "";
+let projectSessionId = "";
+
+if (projectRoot) {
+  const { resolveProjectRuntime } = await import("../core/project.js");
+  const runtime = resolveProjectRuntime({
+    projectRoot,
+    mode: modeName,
+    displayName: manifest.displayName,
+    backendType,
+    role,
+  });
+  activeProjectRoot = runtime.projectRoot;
+  projectSessionId = runtime.session.sessionId;
+  workspace = runtime.workspace;
+  p.log.info(`Project: ${runtime.project.name} (${activeProjectRoot})`);
+  p.log.info(`Project session: ${projectSessionId}`);
+}
+```
+
+Do not change existing quick-session behavior. All existing call sites for `loadSession(workspace)`, `saveSession(workspace)`, `installSkill`, `startServer({ workspace })`, backend `cwd: workspace`, and `startFileWatcher` should continue using the resolved `workspace` variable.
+
+- [ ] **Step 5: Add help text for project flags**
+
+In the CLI usage block in `bin/pneuma.ts`, add:
+
+```text
+  --project <path>             Launch inside an explicit Pneuma project root
+  --role <text>                Describe this session's role within the project
+```
+
+- [ ] **Step 6: Run foundation tests**
+
+Run:
+
+```bash
+bun test core/__tests__/project.test.ts bin/__tests__/pneuma-cli-helpers.test.ts
+```
+
+Expected: PASS.
+
+## Task 6: Launcher Routes for Project Records
+
+**Files:**
+- Modify: `server/index.ts`
+- Create: `server/__tests__/project-routes.test.ts`
+
+- [ ] **Step 1: Add failing route tests**
+
+Create `server/__tests__/project-routes.test.ts`:
+
+```ts
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { startServer } from "../index.js";
+
+const TEST_PORT = 19891;
+const TEST_WORKSPACE = join(tmpdir(), `pneuma-project-routes-workspace-${Date.now()}`);
+const TEST_PROJECT = join(tmpdir(), `pneuma-project-routes-project-${Date.now()}`);
+
+let server: Awaited<ReturnType<typeof startServer>>;
+
+function api(path: string, init?: RequestInit) {
+  return fetch(`http://localhost:${TEST_PORT}${path}`, init);
+}
+
+describe("project launcher routes", () => {
+  beforeAll(async () => {
+    mkdirSync(TEST_WORKSPACE, { recursive: true });
+    mkdirSync(TEST_PROJECT, { recursive: true });
+    server = await startServer({
+      port: TEST_PORT,
+      workspace: TEST_WORKSPACE,
+      launcherMode: true,
+    });
+  });
+
+  afterAll(() => {
+    server?.stop?.();
+    rmSync(TEST_WORKSPACE, { recursive: true, force: true });
+    rmSync(TEST_PROJECT, { recursive: true, force: true });
+  });
+
+  test("GET /api/projects returns a projects array", async () => {
+    const res = await api("/api/projects");
+    expect(res.status).toBe(200);
+    const body = await res.json() as { projects: unknown[] };
+    expect(Array.isArray(body.projects)).toBe(true);
+  });
+
+  test("POST /api/projects creates an explicit project", async () => {
+    const res = await api("/api/projects", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        root: TEST_PROJECT,
+        name: "Route Project",
+        description: "Created from the launcher API",
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as { project: { name: string; root: string } };
+    expect(body.project.name).toBe("Route Project");
+    expect(body.project.root).toBe(TEST_PROJECT);
+  });
+
+  test("GET /api/projects includes newly created projects", async () => {
+    const res = await api("/api/projects");
+    const body = await res.json() as { projects: Array<{ name: string; root: string }> };
+    expect(body.projects.some((p) => p.name === "Route Project" && p.root === TEST_PROJECT)).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run route tests and confirm failure**
+
+Run:
+
+```bash
+bun test server/__tests__/project-routes.test.ts
+```
+
+Expected: FAIL because `/api/projects` does not exist.
+
+- [ ] **Step 3: Add project routes inside Launcher mode**
+
+In `server/index.ts`, import project helpers:
+
+```ts
+import { createProject, loadRecentProjects, recordRecentProject } from "../core/project.js";
+```
+
+Inside `if (options.launcherMode)`, near the existing `/api/sessions` route, add:
+
+```ts
+app.get("/api/projects", (c) => {
+  const projects = loadRecentProjects();
+  return c.json({ projects });
+});
+
+app.post("/api/projects", async (c) => {
+  try {
+    const body = await c.req.json<{ root?: string; name?: string; description?: string }>();
+    const rawRoot = body.root?.trim();
+    if (!rawRoot) return c.json({ error: "root is required" }, 400);
+    const root = resolve(rawRoot.replace(/^~/, homedir()));
+    mkdirSync(root, { recursive: true });
+    const project = createProject(root, {
+      name: body.name,
+      description: body.description,
+    });
+    recordRecentProject(root);
+    return c.json({ project });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return c.json({ error: message }, 500);
+  }
+});
+```
+
+- [ ] **Step 4: Extend `/api/launch` request body and child args**
+
+In the `/api/launch` route, extend the destructured body:
+
+```ts
+const { specifier, workspace: targetWorkspace, projectRoot, role, initParams, skipSkill, backendType, replayPackage: replayPkg, replaySource, sessionName, viewing } = await c.req.json<{
+  specifier: string;
+  workspace: string;
+  projectRoot?: string;
+  role?: string;
+  initParams?: Record<string, string | number>;
+  skipSkill?: boolean;
+  backendType?: AgentBackendType;
+  replayPackage?: string;
+  replaySource?: string;
+  sessionName?: string;
+  viewing?: boolean;
+}>();
+```
+
+When building child args, use project launch when `projectRoot` is present:
+
+```ts
+const args = projectRoot
+  ? ["bun", pneumaBin, specifier, "--project", resolve(projectRoot.replace(/^~/, homedir())), "--no-prompt", "--no-open"]
+  : ["bun", pneumaBin, specifier, "--workspace", resolvedWorkspace, "--no-prompt", "--no-open"];
+
+if (role?.trim()) args.push("--role", role.trim());
+```
+
+Keep the existing `--backend`, `--skip-skill`, `--viewing`, replay, debug, and dev argument pushes unchanged.
+
+- [ ] **Step 5: Run route tests**
+
+Run:
+
+```bash
+bun test server/__tests__/project-routes.test.ts
+```
+
+Expected: PASS.
+
+## Task 7: Verification and Commit
+
+**Files:**
+- Modify all files touched in Tasks 1-6.
+
+- [ ] **Step 1: Run focused tests**
+
+Run:
+
+```bash
+bun test core/__tests__/project.test.ts bin/__tests__/pneuma-cli-helpers.test.ts server/__tests__/project-routes.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run broader relevant tests**
+
+Run:
+
+```bash
+bun test bin/__tests__/pneuma-cli-helpers.test.ts server/__tests__/security-path-traversal.test.ts server/__tests__/skill-installer.test.ts core/__tests__/project.test.ts server/__tests__/project-routes.test.ts
+```
+
+Expected: PASS. If `security-path-traversal.test.ts` fails because fixed ports are occupied, rerun once after confirming no local Pneuma test server is still active.
+
+- [ ] **Step 3: Run full test suite if the focused set passes**
+
+Run:
+
+```bash
+bun test
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Inspect quick-session behavior by launching help and parser-only paths**
+
+Run:
+
+```bash
+bun bin/pneuma.ts --help
+```
+
+Expected: the command prints usage and includes both `--workspace` and `--project`.
+
+- [ ] **Step 5: Commit the foundation**
+
+```bash
+git add core/project.ts core/__tests__/project.test.ts bin/pneuma-cli-helpers.ts bin/__tests__/pneuma-cli-helpers.test.ts bin/pneuma.ts server/index.ts server/__tests__/project-routes.test.ts
+git commit -m "feat: add project session foundation"
+```
+
+## Follow-Up Board Cards
+
+These are intentionally outside this foundation plan:
+
+1. Launcher Project Overview UI
+   - Recent Projects section.
+   - Project detail screen.
+   - Start/resume project session actions.
+
+2. Project Context and Preferences Injection
+   - Inject project identity, role, and peer session summaries.
+   - Add project preference layer after global preferences.
+   - Make project-over-personal conflict ordering explicit.
+
+3. Cross-Mode Handoff Flow
+   - Generate editable handoff drafts.
+   - Write `.pneuma/handoffs/<handoff-id>.md`.
+   - Resume latest matching mode session or start a new session.
+
+4. Quick Session to Project Upgrade
+   - Seed project from an existing quick session.
+   - Choose or create project root.
+   - Fork session state without destroying the source quick session.
+
+5. Project-Level Evolve
+   - Scan project sessions, handoffs, and timeline.
+   - Write only to `.pneuma/project-preferences.md`.
+
+## Self-Review
+
+- Spec coverage for the foundation is complete: project identity, project session sandbox, recent-project registry, explicit project activation, quick-session preservation, and basic Launcher launch plumbing all map to tasks.
+- Deferred items match independently testable subsystems from the design spec and are listed as follow-up board cards.
+- No task requires changing existing quick-session storage paths.
+- `workspace` continues to mean backend cwd and watcher root; for project sessions it resolves to the session sandbox.
+- The plan avoids hidden cross-session reads and does not introduce project-wide file watching.

--- a/docs/superpowers/specs/2026-04-28-project-layer-design.md
+++ b/docs/superpowers/specs/2026-04-28-project-layer-design.md
@@ -1,0 +1,528 @@
+# Pneuma Project Layer Design
+
+**Date:** 2026-04-28  
+**Status:** Draft, direction approved  
+**Decision:** Project Root / Session Sandbox model
+
+## Overview
+
+Introduce an optional Project layer above Pneuma sessions. A project is a user-owned directory with a persistent identity, multiple isolated sessions, project-scoped preferences, explicit cross-mode handoffs, and a Launcher-level overview.
+
+The design preserves the 2.x quick-session workflow. Users can still run `pneuma <mode>` for a one-off session without creating or understanding projects. A project only exists after the user explicitly creates one or upgrades an existing quick session.
+
+**Core formula:** `ProjectRoot(deliverables) + SessionSandbox(process state) + ExplicitHandoff(cross-mode context)`
+
+## Goals
+
+1. **Optional organization layer** - projects are useful for long-running work, but not required for quick sessions.
+2. **User-owned directory** - project roots are normal directories the user can open in Finder, initialize with git, and push to GitHub.
+3. **Multiple isolated sessions** - a project can host many sessions across one or more modes without session histories bleeding into each other.
+4. **Clean deliverable surface** - final outputs live in the project root or an explicit project-approved location, while agent process files stay inside session sandboxes.
+5. **Explicit cross-mode collaboration** - mode switches transfer reviewed handoff context, not hidden access to another session's private history.
+6. **Project-scoped memory** - project preferences and project evolution exist separately from global user preferences.
+7. **Git-friendly metadata** - Pneuma metadata is visible, centralized, and easy to ignore.
+8. **Recoverable state** - copying a project directory should preserve project identity, sessions, handoffs, and project preferences.
+
+## Non-Goals
+
+- Strong multi-writer consistency. Concurrent writes use last-write-wins semantics.
+- Realtime syncing into already-running sessions. Project preference changes apply on next session start or activation.
+- Automatic migration of existing workspaces into projects.
+- Mode-specific handoff protocols. All modes use the same handoff contract.
+- Hidden session introspection. Sessions do not inspect each other's private history unless the user creates a handoff.
+- Full git workflow management. Projects are git-friendly, but Pneuma does not own commit or push semantics.
+
+## Design Principles
+
+### Project Root / Session Sandbox
+
+The project root is the user's deliverable directory. It should look like the actual product, website, document set, deck, video source, or course material being built.
+
+Each project session gets its own sandbox under `.pneuma/sessions/<session-id>/`. Agent scratch files, private process state, session history, and transient workspace artifacts stay there by default.
+
+```text
+<project-root>/
+  deliverables...
+  .pneuma/
+    project.json
+    project-preferences.md
+    timeline.jsonl
+    sessions/
+      <session-id>/
+        session.json
+        history.json
+        workspace/
+        scratch/
+    handoffs/
+      <handoff-id>.md
+```
+
+This model gives Pneuma two explicit roots:
+
+- `projectRoot` - user-visible deliverables and project metadata.
+- `sessionWorkspace` - agent working area for one session.
+
+### Explicit Publish Boundary
+
+A session does not naturally leak its workspace into the project root. Deliverables reach the project root through explicit writes:
+
+- The user asks for a concrete output path.
+- The mode already has a known deliverable path.
+- The agent performs a project publish action and records it in the project timeline.
+
+This is stricter than the current workspace-only model, but it matches the project promise: opening the project root should show outcomes, not process debris.
+
+### Session Isolation
+
+Sessions in the same project share identity, project preferences, and project-level summaries, but not raw internal histories.
+
+Allowed shared inputs:
+
+- `project.json`
+- `project-preferences.md`
+- project session index metadata
+- user-approved handoffs
+- project timeline facts
+- deliverables in `projectRoot`
+
+Disallowed implicit inputs:
+
+- another session's full `history.json`
+- another session's scratch files
+- another session's private workspace
+- hidden mode-specific state
+
+## Project Metadata
+
+### `.pneuma/project.json`
+
+```ts
+interface ProjectManifest {
+  schemaVersion: 1;
+  projectId: string;
+  name: string;
+  description?: string;
+  createdAt: string;
+  updatedAt: string;
+  root: string;
+  deliverablePaths?: string[];
+  defaultBackendType?: "claude" | "codex";
+}
+```
+
+Rules:
+
+- Creating or activating a project writes this file.
+- Name and description changes are explicit project metadata edits.
+- Metadata edits append to `.pneuma/timeline.jsonl`.
+- `root` is advisory and may be refreshed if the directory is moved.
+
+### Session Index
+
+Each project session has a local session manifest:
+
+```ts
+interface ProjectSessionManifest {
+  schemaVersion: 1;
+  sessionId: string;
+  projectId: string;
+  mode: string;
+  role?: string;
+  displayName: string;
+  backendType: "claude" | "codex";
+  status: "active" | "idle" | "archived";
+  createdAt: string;
+  lastAccessed: string;
+  sessionWorkspace: string;
+  deliverablePaths?: string[];
+  sourceQuickSessionId?: string;
+}
+```
+
+The project overview can derive its session list by scanning `.pneuma/sessions/*/session.json`. A global recent-projects registry may cache this for Launcher performance, but the project directory remains the source of truth.
+
+## Storage Layout
+
+### Project Root
+
+```text
+<project-root>/
+  README.md
+  index.html
+  deck.pptx
+  assets/
+  .pneuma/
+```
+
+The root contains user-recognizable outputs. Pneuma should not fill it with logs, snapshots, temporary prompts, or backend-specific internal files unless the user explicitly wants those as deliverables.
+
+### `.pneuma/`
+
+```text
+.pneuma/
+  project.json
+  project-preferences.md
+  timeline.jsonl
+  sessions/
+    webcraft-20260428-abc123/
+      session.json
+      history.json
+      config.json
+      workspace/
+      scratch/
+      shadow.git/
+      checkpoints.jsonl
+      replay-checkout/
+      resumed-context.xml
+    doc-20260428-def456/
+      ...
+  handoffs/
+    20260428T101500-webcraft-to-doc.md
+```
+
+Existing per-workspace `.pneuma` files move inside the project session sandbox for project sessions. Quick sessions keep the current 2.x layout.
+
+### Git Ignore Recommendation
+
+Project creation should offer or write a local ignore block:
+
+```gitignore
+# Pneuma project metadata and session state
+.pneuma/
+```
+
+This keeps normal project commits clean. Users who want to back up project sessions can opt into tracking `.pneuma/` or copy the project directory outside git.
+
+## Launcher Experience
+
+The Launcher gets two top-level recency sections:
+
+1. **Recent Projects** - persistent workspaces with project identity.
+2. **Recent Sessions** - independent quick sessions.
+
+Opening a project shows:
+
+- Project name, description, root path, created time.
+- Session list with mode, role, backend, activity, and status.
+- Actions to start a new session in any mode.
+- Actions to resume an existing session.
+- Project actions: edit identity, evolve project, open folder, upgrade/export/backup affordances as they become available.
+
+Creating a project is a Launcher-level action. It does not require first starting a session.
+
+## Session Startup
+
+### Quick Session
+
+Existing behavior remains:
+
+```text
+pneuma <mode> --workspace <workspace>
+```
+
+The session uses the current workspace-local `.pneuma/` structure. No project metadata is required.
+
+### New Project Session
+
+Project session startup takes both a project root and a session sandbox:
+
+```text
+pneuma <mode> --project <project-root> --role "Build the landing page"
+```
+
+Resolved runtime context:
+
+```ts
+interface RuntimeSessionContext {
+  mode: string;
+  backendType: "claude" | "codex";
+  project?: {
+    projectId: string;
+    name: string;
+    description?: string;
+    root: string;
+    preferencesPath: string;
+    sessions: ProjectSessionSummary[];
+  };
+  workspace: string;          // sessionWorkspace, not projectRoot
+  projectRoot?: string;       // deliverable root
+  role?: string;
+}
+```
+
+The backend still receives a normal workspace. For project sessions, that workspace is the session sandbox. Project information is injected as explicit context so the agent knows where deliverables belong.
+
+## Agent Context Injection
+
+At session start, Pneuma injects a project section into backend instructions:
+
+```markdown
+### Project Context
+
+Project: <name>
+Root: <project-root>
+Description: <description>
+This session role: <role>
+
+Deliverables should be written to the project root or explicit deliverable paths.
+Scratch work and intermediate files should stay in this session workspace.
+
+Other sessions:
+- <mode> - <role/displayName> - <status> - last active <time>
+```
+
+Project preferences are injected after global preferences and before mode-specific runtime instructions. If project and personal preferences conflict, project preferences win and the agent should briefly state that it is following the project-specific constraint.
+
+## Cross-Mode Handoffs
+
+Mode switching is explicit, reviewable, and non-destructive.
+
+### Flow
+
+1. User chooses "Switch mode" from a project session.
+2. Source session generates a handoff draft:
+   - current goal
+   - key decisions
+   - constraints
+   - relevant deliverables
+   - open questions
+   - recommended next mode action
+3. UI shows the handoff draft.
+4. User can cancel, edit, or confirm.
+5. On confirm, Pneuma writes `.pneuma/handoffs/<handoff-id>.md`.
+6. Target mode either resumes the most recent session for that mode or starts a new session.
+7. Target session receives the handoff as startup context.
+8. Project timeline records the handoff event.
+
+### Handoff File
+
+```markdown
+---
+handoffId: 20260428T101500-webcraft-to-doc
+projectId: ...
+fromSessionId: ...
+toSessionId: ...
+fromMode: webcraft
+toMode: doc
+createdAt: 2026-04-28T10:15:00Z
+---
+
+# Handoff: webcraft to doc
+
+## Goal
+
+## Decisions
+
+## Constraints
+
+## Relevant Files
+
+## Open Questions
+
+## Suggested Next Step
+```
+
+Handoff files are the collaboration boundary. The target session does not read raw source session history unless the user explicitly includes excerpts in the handoff.
+
+## Project Preferences
+
+Pneuma keeps two orthogonal preference layers:
+
+- Personal preferences: `~/.pneuma/preferences/`
+- Project preferences: `<project-root>/.pneuma/project-preferences.md`
+
+Project preferences apply to all sessions in that project only. They are natural-language documents managed by agents and users, with the same "observe carefully, record sparingly" standard as personal preferences.
+
+Conflict rule:
+
+1. Project preference wins over personal preference.
+2. Mode-specific critical constraints still apply unless the project explicitly narrows or overrides them.
+3. The agent should mention the conflict briefly when it affects visible behavior.
+
+Running sessions are not required to hot-reload project preference changes. The updated preferences apply on next start or activation.
+
+## Project Evolution
+
+Project evolution is a project-scoped version of the existing preference analysis flow.
+
+Inputs:
+
+- all project session manifests
+- handoff files
+- project timeline
+- project deliverable summaries
+- user-approved session summaries
+
+Outputs:
+
+- updates to `.pneuma/project-preferences.md`
+- a timeline event describing the evolution run
+
+Project evolution must not write to `~/.pneuma/preferences/`. Its output is local to the project.
+
+## Upgrade From Quick Session
+
+A quick session can be upgraded into a project without destroying the original session.
+
+### Flow
+
+1. User chooses "Create project from this session" or creates a project and selects a seed quick session.
+2. User selects or creates the project root.
+3. Pneuma creates `.pneuma/project.json` in the project root.
+4. Pneuma copies or summarizes the quick session into a new project session sandbox.
+5. Existing deliverables can be copied, moved, or left in place depending on the user's selected root.
+6. The original quick session remains recoverable.
+7. The project timeline records the upgrade.
+
+Upgrade is a fork. It does not convert old workspaces in place unless the user selected that same directory as the project root.
+
+## File Watching
+
+Project sessions default to watching `sessionWorkspace`, not the whole project root.
+
+Mode viewers that need deliverable previews may subscribe to explicit deliverable paths in `projectRoot`. This should be opt-in per mode or per project session, because watching the whole project root would make unrelated deliverable edits flood the session.
+
+Watcher policy:
+
+- Always watch session-owned files.
+- Watch project deliverable paths only when declared.
+- Do not watch `.pneuma/sessions/*` from other sessions.
+- Never infer cross-session collaboration from filesystem changes alone.
+
+## Timeline
+
+`.pneuma/timeline.jsonl` records project-level facts:
+
+```ts
+type ProjectTimelineEvent =
+  | { type: "project.created"; at: string; projectId: string; name: string }
+  | { type: "project.updated"; at: string; changes: Record<string, unknown> }
+  | { type: "session.created"; at: string; sessionId: string; mode: string; role?: string }
+  | { type: "session.resumed"; at: string; sessionId: string }
+  | { type: "handoff.created"; at: string; handoffId: string; fromSessionId: string; toSessionId?: string }
+  | { type: "deliverable.published"; at: string; sessionId: string; paths: string[] }
+  | { type: "project.evolved"; at: string; sourceSessionCount: number };
+```
+
+This is not a full audit log. It is a user-visible collaboration timeline for recovery, explanation, and future analysis.
+
+## Global Registries
+
+Quick sessions continue to use the existing global recent-session registry.
+
+Projects add a separate recent-projects registry:
+
+```text
+~/.pneuma/projects.json
+```
+
+```ts
+interface RecentProjectRecord {
+  projectId: string;
+  name: string;
+  description?: string;
+  root: string;
+  lastAccessed: string;
+}
+```
+
+The registry is a cache for Launcher convenience. If it is missing or stale, Pneuma can rebuild recent project metadata from known roots when the user opens a project.
+
+## Error Handling
+
+- Missing `.pneuma/project.json`: the directory is not a project until the user activates it.
+- Corrupt `project.json`: show a repair prompt; do not silently create a different project identity.
+- Missing session sandbox: mark the session as unavailable in the project overview.
+- Missing handoff file: target session starts without that handoff and records a warning.
+- Moved project directory: refresh the advisory `root` value after user confirmation.
+- Preference parse issues: project preferences are Markdown; unreadable files are skipped with a visible warning.
+
+## Backward Compatibility
+
+2.x quick sessions remain valid. Existing workspaces continue to use:
+
+```text
+<workspace>/.pneuma/session.json
+<workspace>/.pneuma/history.json
+```
+
+Project sessions use:
+
+```text
+<project-root>/.pneuma/sessions/<session-id>/session.json
+<project-root>/.pneuma/sessions/<session-id>/history.json
+```
+
+This avoids a forced migration and keeps old workspace restore semantics intact.
+
+## Implementation Decomposition
+
+This should become several board cards after spec approval:
+
+1. **Project metadata and registry**
+   - create/read/update `project.json`
+   - recent-projects registry
+   - explicit project activation
+
+2. **Project session sandbox runtime**
+   - resolve `projectRoot` and `sessionWorkspace`
+   - write project session manifests
+   - preserve quick-session behavior
+
+3. **Launcher project overview**
+   - Recent Projects section
+   - project detail view
+   - create project and start/resume project session actions
+
+4. **Project context and preferences injection**
+   - inject project identity, role, session summaries, and project preferences
+   - implement project-over-personal conflict ordering
+
+5. **Mode switch handoff**
+   - generate editable handoff drafts
+   - write handoff files
+   - resume latest matching mode session or create a new one
+   - record timeline events
+
+6. **Quick-session upgrade**
+   - seed project from existing session
+   - choose root
+   - fork session state without destroying original session
+
+7. **Project evolution**
+   - scan project sessions and handoffs
+   - update project preferences only
+   - record project evolution timeline event
+
+## Testing Strategy
+
+### Unit Tests
+
+- Project manifest read/write and validation.
+- Recent-project registry update and stale-path handling.
+- Session sandbox path resolution.
+- Preference merge ordering.
+- Handoff file frontmatter parsing.
+
+### Integration Tests
+
+- Create a project from Launcher and start a session.
+- Start two sessions in the same project with different modes.
+- Verify each session writes process files only inside its sandbox.
+- Switch modes and confirm handoff context appears in the target session.
+- Upgrade a quick session into a project and verify the original remains recoverable.
+
+### Regression Tests
+
+- `pneuma <mode>` without project arguments behaves exactly like a quick session.
+- Existing workspace `.pneuma/session.json` restore still works.
+- File watcher does not subscribe to the whole project root by default.
+- Ignoring `.pneuma/` keeps project deliverables git-clean.
+
+## Open Decisions Resolved
+
+- **Directory model:** project root is the deliverable directory; sessions use isolated sandboxes.
+- **Project creation:** explicit only; no automatic project detection.
+- **Cross-session collaboration:** handoff files only; no hidden session-history reads.
+- **Preference conflict:** project preferences override personal preferences.
+- **Upgrade semantics:** fork, not in-place migration.

--- a/docs/superpowers/specs/2026-04-28-project-layer-design.md
+++ b/docs/superpowers/specs/2026-04-28-project-layer-design.md
@@ -1,7 +1,7 @@
 # Pneuma Project Layer Design
 
-**Date:** 2026-04-28  
-**Status:** Draft, direction approved  
+**Date:** 2026-04-28
+**Status:** Draft, direction approved
 **Decision:** Project Root / Session Sandbox model
 
 ## Overview

--- a/server/__tests__/project-routes.test.ts
+++ b/server/__tests__/project-routes.test.ts
@@ -1,0 +1,75 @@
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { homedir, tmpdir } from "node:os";
+import { startServer } from "../index.js";
+import { recentProjectsRegistryPath } from "../../core/project.js";
+
+const TEST_PORT = 19891;
+const TEST_WORKSPACE = join(tmpdir(), `pneuma-project-routes-workspace-${Date.now()}`);
+const TEST_PROJECT = join(tmpdir(), `pneuma-project-routes-project-${Date.now()}`);
+const REGISTRY_PATH = recentProjectsRegistryPath(homedir());
+
+let server: Awaited<ReturnType<typeof startServer>>;
+let registryBackup: string | null = null;
+let hadRegistry = false;
+
+function api(path: string, init?: RequestInit) {
+  return fetch(`http://localhost:${TEST_PORT}${path}`, init);
+}
+
+describe("project launcher routes", () => {
+  beforeAll(async () => {
+    mkdirSync(TEST_WORKSPACE, { recursive: true });
+    mkdirSync(TEST_PROJECT, { recursive: true });
+    hadRegistry = existsSync(REGISTRY_PATH);
+    if (hadRegistry) registryBackup = readFileSync(REGISTRY_PATH, "utf-8");
+
+    server = await startServer({
+      port: TEST_PORT,
+      workspace: TEST_WORKSPACE,
+      launcherMode: true,
+    });
+  });
+
+  afterAll(() => {
+    server?.stop?.();
+    rmSync(TEST_WORKSPACE, { recursive: true, force: true });
+    rmSync(TEST_PROJECT, { recursive: true, force: true });
+    if (hadRegistry && registryBackup !== null) {
+      writeFileSync(REGISTRY_PATH, registryBackup);
+    } else {
+      rmSync(REGISTRY_PATH, { force: true });
+    }
+  });
+
+  test("GET /api/projects returns a projects array", async () => {
+    const res = await api("/api/projects");
+    expect(res.status).toBe(200);
+    const body = await res.json() as { projects: unknown[] };
+    expect(Array.isArray(body.projects)).toBe(true);
+  });
+
+  test("POST /api/projects creates an explicit project", async () => {
+    const res = await api("/api/projects", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        root: TEST_PROJECT,
+        name: "Route Project",
+        description: "Created from the launcher API",
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as { project: { name: string; root: string } };
+    expect(body.project.name).toBe("Route Project");
+    expect(body.project.root).toBe(TEST_PROJECT);
+  });
+
+  test("GET /api/projects includes newly created projects", async () => {
+    const res = await api("/api/projects");
+    const body = await res.json() as { projects: Array<{ name: string; root: string }> };
+    expect(body.projects.some((p) => p.name === "Route Project" && p.root === TEST_PROJECT)).toBe(true);
+  });
+});

--- a/server/index.ts
+++ b/server/index.ts
@@ -31,6 +31,7 @@ import { createProxyMiddleware, mergeProxyConfig, type ProxyConfigRef } from "./
 import type { ProxyRoute } from "../core/types/mode-manifest.js";
 import { startProxyWatcher, registerSelfWrite, registerSelfDelete } from "./file-watcher.js";
 import { mountNativeRoutes } from "./native-bridge.js";
+import { createProject, loadRecentProjects, recordRecentProject } from "../core/project.js";
 
 const DEFAULT_PORT = 17007;
 
@@ -172,6 +173,31 @@ export async function startServer(options: ServerOptions) {
         return { ...desc, available: avail?.available ?? false, reason: avail?.reason };
       });
       return c.json({ backends, defaultBackendType: getDefaultBackendType() });
+    });
+
+    app.get("/api/projects", (c) => {
+      const projects = loadRecentProjects();
+      return c.json({ projects });
+    });
+
+    app.post("/api/projects", async (c) => {
+      try {
+        const body = await c.req.json<{ root?: string; name?: string; description?: string }>();
+        const rawRoot = body.root?.trim();
+        if (!rawRoot) return c.json({ error: "root is required" }, 400);
+
+        const root = resolve(rawRoot.replace(/^~/, homedir()));
+        mkdirSync(root, { recursive: true });
+        const project = createProject(root, {
+          name: body.name,
+          description: body.description,
+        });
+        recordRecentProject(root);
+        return c.json({ project });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return c.json({ error: message }, 500);
+      }
     });
 
     // Install a mode from a remote source (url tar.gz or github:user/repo).
@@ -597,9 +623,11 @@ export async function startServer(options: ServerOptions) {
     });
 
     app.post("/api/launch", async (c) => {
-      const { specifier, workspace: targetWorkspace, initParams, skipSkill, backendType, replayPackage: replayPkg, replaySource, sessionName, viewing } = await c.req.json<{
+      const { specifier, workspace: targetWorkspace, projectRoot: launchProjectRoot, role, initParams, skipSkill, backendType, replayPackage: replayPkg, replaySource, sessionName, viewing } = await c.req.json<{
         specifier: string;
-        workspace: string;
+        workspace?: string;
+        projectRoot?: string;
+        role?: string;
         initParams?: Record<string, string | number>;
         skipSkill?: boolean;
         backendType?: AgentBackendType;
@@ -610,13 +638,21 @@ export async function startServer(options: ServerOptions) {
       }>();
 
       try {
-        const resolvedWorkspace = resolve(targetWorkspace.replace(/^~/, homedir()));
+        const resolvedProjectRoot = launchProjectRoot
+          ? resolve(launchProjectRoot.replace(/^~/, homedir()))
+          : "";
+        const resolvedWorkspace = targetWorkspace
+          ? resolve(targetWorkspace.replace(/^~/, homedir()))
+          : resolvedProjectRoot || homedir();
 
-        // 1. Create workspace dir
-        mkdirSync(resolvedWorkspace, { recursive: true });
+        // 1. Create workspace/project dir
+        mkdirSync(resolvedProjectRoot || resolvedWorkspace, { recursive: true });
 
-        // 2. Save initParams to .pneuma/config.json if provided
-        if (initParams && Object.keys(initParams).length > 0) {
+        // 2. Save initParams to .pneuma/config.json if provided.
+        // Project sessions create their sandbox in the child process, so
+        // project init-param persistence is handled after project session
+        // routing grows a stable session selector.
+        if (!resolvedProjectRoot && initParams && Object.keys(initParams).length > 0) {
           const pneumaDir = join(resolvedWorkspace, ".pneuma");
           mkdirSync(pneumaDir, { recursive: true });
           writeFileSync(join(pneumaDir, "config.json"), JSON.stringify(initParams, null, 2));
@@ -625,8 +661,11 @@ export async function startServer(options: ServerOptions) {
         // 3. Spawn pneuma process
         const projectRoot = options.projectRoot || resolve(dirname(import.meta.path), "..");
         const pneumaBin = join(projectRoot, "bin", "pneuma.ts");
-        const args = ["bun", pneumaBin, specifier, "--workspace", resolvedWorkspace, "--no-prompt", "--no-open"];
+        const args = resolvedProjectRoot
+          ? ["bun", pneumaBin, specifier, "--project", resolvedProjectRoot, "--no-prompt", "--no-open"]
+          : ["bun", pneumaBin, specifier, "--workspace", resolvedWorkspace, "--no-prompt", "--no-open"];
         args.push("--backend", backendType || getDefaultBackendType());
+        if (role?.trim()) args.push("--role", role.trim());
         if (skipSkill) args.push("--skip-skill");
         if (viewing) args.push("--viewing");
         if (replayPkg) args.push("--replay", replayPkg);
@@ -692,7 +731,7 @@ export async function startServer(options: ServerOptions) {
         childProcesses.set(pid, {
           proc: child,
           specifier,
-          workspace: resolvedWorkspace,
+          workspace: resolvedProjectRoot || resolvedWorkspace,
           url: readyUrl,
           startedAt: Date.now(),
         });
@@ -702,7 +741,7 @@ export async function startServer(options: ServerOptions) {
           childProcesses.delete(pid);
         });
 
-        return c.json({ url: readyUrl, workspace: resolvedWorkspace, mode: specifier });
+        return c.json({ url: readyUrl, workspace: resolvedProjectRoot || resolvedWorkspace, mode: specifier });
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         return c.json({ error: message }, 500);


### PR DESCRIPTION
## Automated Verification

- [x] `git diff --check origin/main...HEAD` — pass
- [x] `bun test core/__tests__/project.test.ts bin/__tests__/pneuma-cli-helpers.test.ts server/__tests__/project-routes.test.ts` — pass (20 pass, 0 fail, 64 expect)
- [x] `bun test` — pass (751 pass, 0 fail, 1893 expect)
- [x] `bun run build` — pass; Vite emitted the existing Node 22.11.0 version warning plus existing chunk-size/dynamic-import warnings, exit 0

## Human Verification TODO

- [ ] Run `bun bin/pneuma.ts --help` and confirm `--project` plus `--role` appear in CLI help.
- [ ] With a working backend, launch `pneuma webcraft --project <tmp-root> --role "Build intro page" --no-prompt --no-open` and confirm the project root contains `.pneuma/project.json` plus a session sandbox under `.pneuma/sessions/<session-id>/workspace`.

## Retro Notes

- Keep `projectRoot` as the deliverable directory and `workspace` as the backend cwd in follow-up cards; mixing them would break the isolation model.
- Project launch init-param persistence is intentionally deferred until a stable project-session selector exists, so modes with required init params need that follow-up before full Launcher UI rollout.


---
Closes #81 — board-superpowers v0.2.0 claim trailer.
