### PR TITLE
Add launcher project overview

### DIFF
--- a/bin/__tests__/pneuma-cli-helpers.test.ts
+++ b/bin/__tests__/pneuma-cli-helpers.test.ts
@@ -57,6 +57,8 @@ describe("pneuma CLI helpers", () => {
         "webcraft",
         "--project",
         "./site",
+        "--project-session",
+        "web-123",
         "--role",
         "Build the home page",
       ],
@@ -65,6 +67,7 @@ describe("pneuma CLI helpers", () => {
 
     expect(parsed.mode).toBe("webcraft");
     expect(parsed.projectRoot).toBe("/tmp/base/site");
+    expect(parsed.projectSessionId).toBe("web-123");
     expect(parsed.role).toBe("Build the home page");
     expect(parsed.workspace).toBe("/tmp/base");
   });

--- a/bin/pneuma-cli-helpers.ts
+++ b/bin/pneuma-cli-helpers.ts
@@ -26,6 +26,7 @@ export interface ParsedCliArgs {
   mode: string;
   workspace: string;
   projectRoot: string;
+  projectSessionId: string;
   role: string;
   port: number;
   backendType: AgentBackendType;
@@ -66,6 +67,7 @@ export function parseCliArgs(argv: string[], cwd = process.cwd()): ParsedCliArgs
   let mode = "";
   let workspace = cwd;
   let projectRoot = "";
+  let projectSessionId = "";
   let role = "";
   let port = 0;
   let backendType: AgentBackendType = getDefaultBackendType();
@@ -87,6 +89,8 @@ export function parseCliArgs(argv: string[], cwd = process.cwd()): ParsedCliArgs
       workspace = args[++i];
     } else if (arg === "--project" && i + 1 < args.length) {
       projectRoot = resolve(cwd, args[++i]);
+    } else if (arg === "--project-session" && i + 1 < args.length) {
+      projectSessionId = args[++i];
     } else if (arg === "--role" && i + 1 < args.length) {
       role = args[++i];
     } else if (arg === "--port" && i + 1 < args.length) {
@@ -124,6 +128,7 @@ export function parseCliArgs(argv: string[], cwd = process.cwd()): ParsedCliArgs
     mode,
     workspace: resolve(cwd, workspace),
     projectRoot,
+    projectSessionId,
     role,
     port,
     backendType,

--- a/bin/pneuma.ts
+++ b/bin/pneuma.ts
@@ -733,6 +733,7 @@ Modes:
 Options:
   --workspace <path>           Target workspace directory (default: cwd)
   --project <path>             Launch inside an explicit Pneuma project root
+  --project-session <id>       Resume an existing project session inside --project
   --role <text>                Describe this session's role within the project
   --port <number>              Preferred server port
   --backend <type>             Agent backend to launch (default: claude-code)
@@ -1095,7 +1096,7 @@ Options:
     return;
   }
 
-  const { mode, port, backendType, noOpen, debug, forceDev, noPrompt, skipSkill, replaySource, sessionName, viewing, projectRoot, role } = parsedArgs;
+  const { mode, port, backendType, noOpen, debug, forceDev, noPrompt, skipSkill, replaySource, sessionName, viewing, projectRoot, projectSessionId: requestedProjectSessionId, role } = parsedArgs;
   let { workspace, replayPackage } = parsedArgs;
 
   // Launcher mode — no mode arg → start marketplace UI
@@ -1264,6 +1265,7 @@ Options:
       mode: modeName,
       displayName: manifest.displayName,
       backendType,
+      sessionId: requestedProjectSessionId || undefined,
       role,
     });
     activeProjectRoot = runtime.projectRoot;
@@ -1718,7 +1720,9 @@ Options:
         backendType,
         createdAt: Date.now(),
       });
-      recordSession(modeName, manifest.displayName, workspace, backendType, sessionName || undefined);
+      if (!activeProjectRoot) {
+        recordSession(modeName, manifest.displayName, workspace, backendType, sessionName || undefined);
+      }
 
       // Start file watcher
       startFileWatcher(workspace, manifest.viewer, (files) => {
@@ -1844,7 +1848,9 @@ Options:
         createdAt: existing?.createdAt || Date.now(),
         editing: false,
       });
-      recordSession(modeName, manifest.displayName, workspace, sessionBackendType, sessionName || undefined, false);
+      if (!activeProjectRoot) {
+        recordSession(modeName, manifest.displayName, workspace, sessionBackendType, sessionName || undefined, false);
+      }
 
       // Load persisted message history
       const savedHistory = loadHistory(workspace);
@@ -1927,7 +1933,9 @@ Options:
         createdAt: existing?.createdAt || Date.now(),
         editing: true,
       });
-      recordSession(modeName, manifest.displayName, workspace, sessionBackendType, sessionName || undefined, true);
+      if (!activeProjectRoot) {
+        recordSession(modeName, manifest.displayName, workspace, sessionBackendType, sessionName || undefined, true);
+      }
 
       p.log.info(`Agent session: ${session.sessionId}`);
       wsBridge.getOrCreateSession(session.sessionId, sessionBackendType);

--- a/core/__tests__/project.test.ts
+++ b/core/__tests__/project.test.ts
@@ -6,6 +6,7 @@ import {
   createProject,
   createProjectSession,
   listProjectSessions,
+  loadProjectSession,
   loadProject,
   loadRecentProjects,
   projectManifestPath,
@@ -192,5 +193,36 @@ describe("project runtime", () => {
     expect(runtime.session.sessionId).toBe("web-runtime");
     expect(runtime.workspace).toBe(join(root, ".pneuma", "sessions", "web-runtime", "workspace"));
     expect(runtime.projectRoot).toBe(root);
+  });
+
+  test("resolveProjectRuntime resumes an existing project session when sessionId is provided", () => {
+    createProject(root, {
+      name: "Resume Project",
+      now: () => "2026-04-28T00:00:00.000Z",
+      idFactory: () => "project_resume",
+    });
+    createProjectSession(root, {
+      mode: "doc",
+      displayName: "Doc",
+      backendType: "codex",
+      role: "Draft copy",
+      now: () => "2026-04-28T01:00:00.000Z",
+      idFactory: () => "doc-existing",
+    });
+
+    const runtime = resolveProjectRuntime({
+      projectRoot: root,
+      mode: "doc",
+      displayName: "Doc",
+      backendType: "codex",
+      sessionId: "doc-existing",
+      now: () => "2026-04-28T06:00:00.000Z",
+    });
+
+    expect(runtime.session.sessionId).toBe("doc-existing");
+    expect(runtime.session.role).toBe("Draft copy");
+    expect(runtime.workspace).toBe(projectSessionWorkspace(root, "doc-existing"));
+    expect(listProjectSessions(root)).toHaveLength(1);
+    expect(loadProjectSession(root, "doc-existing")?.lastAccessed).toBe("2026-04-28T06:00:00.000Z");
   });
 });

--- a/core/project.ts
+++ b/core/project.ts
@@ -1,5 +1,5 @@
 import { existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
-import { basename, join, resolve } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 import { homedir } from "node:os";
 
 export type ProjectBackendType = "claude-code" | "codex";
@@ -68,6 +68,7 @@ export interface ResolveProjectRuntimeOptions {
   displayName: string;
   backendType: ProjectBackendType;
   role?: string;
+  sessionId?: string;
   now?: () => string;
   projectIdFactory?: () => string;
   sessionIdFactory?: () => string;
@@ -111,8 +112,24 @@ export function projectSessionDir(projectRoot: string, sessionId: string): strin
   return join(projectSessionsDir(projectRoot), sessionId);
 }
 
+export function projectSessionManifestPath(projectRoot: string, sessionId: string): string {
+  return join(projectSessionDir(projectRoot, sessionId), "session.json");
+}
+
 export function projectSessionWorkspace(projectRoot: string, sessionId: string): string {
   return join(projectSessionDir(projectRoot, sessionId), "workspace");
+}
+
+export function isProjectSessionWorkspace(workspace: string): boolean {
+  const resolvedWorkspace = resolve(workspace);
+  if (basename(resolvedWorkspace) !== "workspace") return false;
+
+  const sessionDir = dirname(resolvedWorkspace);
+  const sessionsDir = dirname(sessionDir);
+  const pneumaDir = dirname(sessionsDir);
+  if (basename(sessionsDir) !== "sessions" || basename(pneumaDir) !== ".pneuma") return false;
+
+  return existsSync(join(pneumaDir, "project.json")) && existsSync(join(sessionDir, "session.json"));
 }
 
 export function recentProjectsRegistryPath(homeDir = homedir()): string {
@@ -207,7 +224,7 @@ export function createProjectSession(
     sessionWorkspace: workspace,
   };
 
-  writeFileSync(join(dir, "session.json"), JSON.stringify(session, null, 2));
+  writeFileSync(projectSessionManifestPath(projectRoot, sessionId), JSON.stringify(session, null, 2));
   appendProjectTimelineEvent(projectRoot, {
     type: "session.created",
     at: now,
@@ -216,6 +233,22 @@ export function createProjectSession(
     ...(options.role?.trim() ? { role: options.role.trim() } : {}),
   });
   return session;
+}
+
+export function loadProjectSession(projectRoot: string, sessionId: string): ProjectSessionManifest | null {
+  const filePath = projectSessionManifestPath(projectRoot, sessionId);
+  if (!existsSync(filePath)) return null;
+
+  const parsed = JSON.parse(readFileSync(filePath, "utf-8")) as ProjectSessionManifest;
+  if (parsed.schemaVersion !== 1 || !parsed.sessionId || parsed.sessionId !== sessionId) {
+    throw new Error(`Invalid Pneuma project session manifest: ${filePath}`);
+  }
+  return parsed;
+}
+
+export function saveProjectSession(projectRoot: string, session: ProjectSessionManifest): void {
+  mkdirSync(projectSessionDir(projectRoot, session.sessionId), { recursive: true });
+  writeFileSync(projectSessionManifestPath(projectRoot, session.sessionId), JSON.stringify(session, null, 2));
 }
 
 export function listProjectSessions(projectRoot: string): ProjectSessionManifest[] {
@@ -275,6 +308,40 @@ export function resolveProjectRuntime(options: ResolveProjectRuntimeOptions): Pr
     now: options.now,
     idFactory: options.projectIdFactory,
   });
+
+  if (options.sessionId) {
+    const existing = loadProjectSession(options.projectRoot, options.sessionId);
+    if (!existing) {
+      throw new Error(`Project session not found: ${options.sessionId}`);
+    }
+    if (existing.mode !== options.mode) {
+      throw new Error(`Project session "${options.sessionId}" belongs to mode "${existing.mode}", not "${options.mode}".`);
+    }
+    if (existing.backendType !== options.backendType) {
+      throw new Error(`Project session "${options.sessionId}" uses backend "${existing.backendType}", not "${options.backendType}".`);
+    }
+
+    const now = options.now?.() ?? defaultNow();
+    const session: ProjectSessionManifest = {
+      ...existing,
+      status: "active",
+      lastAccessed: now,
+    };
+    saveProjectSession(options.projectRoot, session);
+    appendProjectTimelineEvent(options.projectRoot, {
+      type: "session.resumed",
+      at: now,
+      sessionId: session.sessionId,
+    });
+    recordRecentProject(options.projectRoot, { now: options.now });
+    return {
+      projectRoot: resolve(options.projectRoot),
+      workspace: session.sessionWorkspace,
+      project,
+      session,
+    };
+  }
+
   const session = createProjectSession(options.projectRoot, {
     mode: options.mode,
     displayName: options.displayName,

--- a/server/__tests__/project-routes.test.ts
+++ b/server/__tests__/project-routes.test.ts
@@ -3,16 +3,20 @@ import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node
 import { join } from "node:path";
 import { homedir, tmpdir } from "node:os";
 import { startServer } from "../index.js";
-import { recentProjectsRegistryPath } from "../../core/project.js";
+import { createProjectSession, recentProjectsRegistryPath } from "../../core/project.js";
 
 const TEST_PORT = 19891;
 const TEST_WORKSPACE = join(tmpdir(), `pneuma-project-routes-workspace-${Date.now()}`);
 const TEST_PROJECT = join(tmpdir(), `pneuma-project-routes-project-${Date.now()}`);
+const TEST_QUICK_WORKSPACE = join(tmpdir(), `pneuma-project-routes-quick-${Date.now()}`);
 const REGISTRY_PATH = recentProjectsRegistryPath(homedir());
+const SESSION_REGISTRY_PATH = join(homedir(), ".pneuma", "sessions.json");
 
 let server: Awaited<ReturnType<typeof startServer>>;
 let registryBackup: string | null = null;
 let hadRegistry = false;
+let sessionRegistryBackup: string | null = null;
+let hadSessionRegistry = false;
 
 function api(path: string, init?: RequestInit) {
   return fetch(`http://localhost:${TEST_PORT}${path}`, init);
@@ -22,8 +26,12 @@ describe("project launcher routes", () => {
   beforeAll(async () => {
     mkdirSync(TEST_WORKSPACE, { recursive: true });
     mkdirSync(TEST_PROJECT, { recursive: true });
+    mkdirSync(TEST_QUICK_WORKSPACE, { recursive: true });
+    mkdirSync(join(homedir(), ".pneuma"), { recursive: true });
     hadRegistry = existsSync(REGISTRY_PATH);
     if (hadRegistry) registryBackup = readFileSync(REGISTRY_PATH, "utf-8");
+    hadSessionRegistry = existsSync(SESSION_REGISTRY_PATH);
+    if (hadSessionRegistry) sessionRegistryBackup = readFileSync(SESSION_REGISTRY_PATH, "utf-8");
 
     server = await startServer({
       port: TEST_PORT,
@@ -36,10 +44,16 @@ describe("project launcher routes", () => {
     server?.stop?.();
     rmSync(TEST_WORKSPACE, { recursive: true, force: true });
     rmSync(TEST_PROJECT, { recursive: true, force: true });
+    rmSync(TEST_QUICK_WORKSPACE, { recursive: true, force: true });
     if (hadRegistry && registryBackup !== null) {
       writeFileSync(REGISTRY_PATH, registryBackup);
     } else {
       rmSync(REGISTRY_PATH, { force: true });
+    }
+    if (hadSessionRegistry && sessionRegistryBackup !== null) {
+      writeFileSync(SESSION_REGISTRY_PATH, sessionRegistryBackup);
+    } else {
+      rmSync(SESSION_REGISTRY_PATH, { force: true });
     }
   });
 
@@ -71,5 +85,102 @@ describe("project launcher routes", () => {
     const res = await api("/api/projects");
     const body = await res.json() as { projects: Array<{ name: string; root: string }> };
     expect(body.projects.some((p) => p.name === "Route Project" && p.root === TEST_PROJECT)).toBe(true);
+  });
+
+  test("GET /api/projects/:projectId returns project identity and sessions", async () => {
+    createProjectSession(TEST_PROJECT, {
+      mode: "webcraft",
+      displayName: "Webcraft",
+      backendType: "codex",
+      role: "Build the home page",
+      now: () => "2026-04-28T08:00:00.000Z",
+      idFactory: () => "web-overview",
+    });
+
+    const listRes = await api("/api/projects");
+    const listBody = await listRes.json() as { projects: Array<{ projectId: string; name: string }> };
+    const record = listBody.projects.find((p) => p.name === "Route Project");
+    expect(record).toBeDefined();
+
+    const res = await api(`/api/projects/${encodeURIComponent(record!.projectId)}`);
+    expect(res.status).toBe(200);
+    const body = await res.json() as {
+      project: { name: string; description?: string; root: string; createdAt: string };
+      sessions: Array<{ sessionId: string; mode: string; role?: string; backendType: string; status: string; lastAccessed: string }>;
+    };
+
+    expect(body.project).toMatchObject({
+      name: "Route Project",
+      description: "Created from the launcher API",
+      root: TEST_PROJECT,
+    });
+    expect(body.project.createdAt).toBeTruthy();
+    expect(body.sessions).toEqual([
+      expect.objectContaining({
+        sessionId: "web-overview",
+        mode: "webcraft",
+        role: "Build the home page",
+        backendType: "codex",
+        status: "active",
+        lastAccessed: "2026-04-28T08:00:00.000Z",
+      }),
+    ]);
+  });
+
+  test("GET /api/sessions filters stale project session registry entries", async () => {
+    const projectSession = createProjectSession(TEST_PROJECT, {
+      mode: "doc",
+      displayName: "Doc",
+      backendType: "codex",
+      now: () => "2026-04-28T09:00:00.000Z",
+      idFactory: () => "doc-stale-registry",
+    });
+
+    writeFileSync(SESSION_REGISTRY_PATH, JSON.stringify([
+      {
+        id: `${projectSession.sessionWorkspace}::doc`,
+        mode: "doc",
+        displayName: "Doc",
+        workspace: projectSession.sessionWorkspace,
+        backendType: "codex",
+        lastAccessed: 2,
+      },
+      {
+        id: `${TEST_QUICK_WORKSPACE}::doc`,
+        mode: "doc",
+        displayName: "Doc",
+        workspace: TEST_QUICK_WORKSPACE,
+        backendType: "codex",
+        lastAccessed: 1,
+      },
+    ]));
+
+    const res = await api("/api/sessions");
+    expect(res.status).toBe(200);
+    const body = await res.json() as { sessions: Array<{ workspace: string }> };
+    expect(body.sessions.map((session) => session.workspace)).toEqual([TEST_QUICK_WORKSPACE]);
+  });
+
+  test("GET /api/processes/children exposes project metadata for launched project sessions", async () => {
+    const pid = 424242;
+    server.childProcesses.set(pid, {
+      proc: {} as never,
+      specifier: "webcraft",
+      workspace: TEST_PROJECT,
+      projectRoot: TEST_PROJECT,
+      projectSessionId: "web-overview",
+      url: "http://localhost:18000",
+      startedAt: 123,
+    });
+
+    const res = await api("/api/processes/children");
+    expect(res.status).toBe(200);
+    const body = await res.json() as { processes: Array<{ pid: number; projectRoot?: string; projectSessionId?: string }> };
+    expect(body.processes.find((process) => process.pid === pid)).toMatchObject({
+      projectRoot: TEST_PROJECT,
+      projectSessionId: "web-overview",
+    });
+
+    server.childProcesses.delete(pid);
   });
 });

--- a/server/index.ts
+++ b/server/index.ts
@@ -31,7 +31,7 @@ import { createProxyMiddleware, mergeProxyConfig, type ProxyConfigRef } from "./
 import type { ProxyRoute } from "../core/types/mode-manifest.js";
 import { startProxyWatcher, registerSelfWrite, registerSelfDelete } from "./file-watcher.js";
 import { mountNativeRoutes } from "./native-bridge.js";
-import { createProject, loadRecentProjects, recordRecentProject } from "../core/project.js";
+import { createProject, isProjectSessionWorkspace, listProjectSessions, loadProject, loadRecentProjects, recordRecentProject } from "../core/project.js";
 
 const DEFAULT_PORT = 17007;
 
@@ -91,6 +91,8 @@ export async function startServer(options: ServerOptions) {
       proc: ReturnType<typeof Bun.spawn>;
       specifier: string;
       workspace: string;
+      projectRoot?: string;
+      projectSessionId?: string;
       url: string;
       startedAt: number;
     }>();
@@ -178,6 +180,28 @@ export async function startServer(options: ServerOptions) {
     app.get("/api/projects", (c) => {
       const projects = loadRecentProjects();
       return c.json({ projects });
+    });
+
+    app.get("/api/projects/:projectId", (c) => {
+      const projectId = c.req.param("projectId");
+      const record = loadRecentProjects().find((project) => project.projectId === projectId);
+      if (!record) return c.json({ error: "Project not found" }, 404);
+
+      const project = loadProject(record.root);
+      if (!project) return c.json({ error: "Project metadata not found" }, 404);
+
+      const sessions = listProjectSessions(record.root).map((session) => ({
+        sessionId: session.sessionId,
+        mode: session.mode,
+        displayName: session.displayName,
+        ...(session.role ? { role: session.role } : {}),
+        backendType: session.backendType,
+        status: session.status,
+        createdAt: session.createdAt,
+        lastAccessed: session.lastAccessed,
+      }));
+
+      return c.json({ project, sessions });
     });
 
     app.post("/api/projects", async (c) => {
@@ -336,8 +360,9 @@ export async function startServer(options: ServerOptions) {
         ...session,
         backendType: session.backendType || getDefaultBackendType(),
       }));
-      // Filter out sessions whose workspace no longer exists
-      sessions = sessions.filter((s) => existsSync(s.workspace));
+      // Filter out sessions whose workspace no longer exists or belongs to a
+      // project sandbox. Project sessions are surfaced from the project view.
+      sessions = sessions.filter((s) => existsSync(s.workspace) && !isProjectSessionWorkspace(s.workspace));
       // Sort by lastAccessed descending
       sessions.sort((a, b) => b.lastAccessed - a.lastAccessed);
       // Check for thumbnails
@@ -367,7 +392,9 @@ export async function startServer(options: ServerOptions) {
       try {
         const raw = readFileSync(registryPath, "utf-8");
         const sessions = JSON.parse(raw) as Array<{ workspace: string }>;
-        knownWorkspaces = sessions.map((s) => resolve(s.workspace));
+        knownWorkspaces = sessions
+          .filter((s) => existsSync(s.workspace) && !isProjectSessionWorkspace(s.workspace))
+          .map((s) => resolve(s.workspace));
       } catch { /* no registry yet */ }
       const resolvedWorkspace = resolve(workspace);
       if (!knownWorkspaces.includes(resolvedWorkspace)) {
@@ -623,10 +650,11 @@ export async function startServer(options: ServerOptions) {
     });
 
     app.post("/api/launch", async (c) => {
-      const { specifier, workspace: targetWorkspace, projectRoot: launchProjectRoot, role, initParams, skipSkill, backendType, replayPackage: replayPkg, replaySource, sessionName, viewing } = await c.req.json<{
+      const { specifier, workspace: targetWorkspace, projectRoot: launchProjectRoot, projectSessionId, role, initParams, skipSkill, backendType, replayPackage: replayPkg, replaySource, sessionName, viewing } = await c.req.json<{
         specifier: string;
         workspace?: string;
         projectRoot?: string;
+        projectSessionId?: string;
         role?: string;
         initParams?: Record<string, string | number>;
         skipSkill?: boolean;
@@ -665,6 +693,7 @@ export async function startServer(options: ServerOptions) {
           ? ["bun", pneumaBin, specifier, "--project", resolvedProjectRoot, "--no-prompt", "--no-open"]
           : ["bun", pneumaBin, specifier, "--workspace", resolvedWorkspace, "--no-prompt", "--no-open"];
         args.push("--backend", backendType || getDefaultBackendType());
+        if (projectSessionId?.trim()) args.push("--project-session", projectSessionId.trim());
         if (role?.trim()) args.push("--role", role.trim());
         if (skipSkill) args.push("--skip-skill");
         if (viewing) args.push("--viewing");
@@ -732,6 +761,8 @@ export async function startServer(options: ServerOptions) {
           proc: child,
           specifier,
           workspace: resolvedProjectRoot || resolvedWorkspace,
+          ...(resolvedProjectRoot ? { projectRoot: resolvedProjectRoot } : {}),
+          ...(resolvedProjectRoot && projectSessionId?.trim() ? { projectSessionId: projectSessionId.trim() } : {}),
           url: readyUrl,
           startedAt: Date.now(),
         });
@@ -754,6 +785,8 @@ export async function startServer(options: ServerOptions) {
         pid,
         specifier: info.specifier,
         workspace: info.workspace,
+        ...(info.projectRoot ? { projectRoot: info.projectRoot } : {}),
+        ...(info.projectSessionId ? { projectSessionId: info.projectSessionId } : {}),
         url: info.url,
         startedAt: info.startedAt,
       }));

--- a/src/components/Launcher.tsx
+++ b/src/components/Launcher.tsx
@@ -3,6 +3,7 @@ import { getApiBase } from "../utils/api.js";
 import { motion, AnimatePresence, LayoutGroup } from "framer-motion";
 import SpotlightCard from "./reactbits/SpotlightCard";
 import Galaxy from "./reactbits/Galaxy";
+import { buildContinueItems } from "./launcher-helpers";
 import type { InitParam } from "../../core/types/mode-manifest.js";
 
 type BackendType = "claude-code" | "codex";
@@ -80,10 +81,43 @@ interface RecentSession {
   layout?: "editor" | "app";
 }
 
+interface RecentProject {
+  projectId: string;
+  name: string;
+  description?: string;
+  root: string;
+  lastAccessed: string | number;
+}
+
+interface ProjectOverviewSession {
+  sessionId: string;
+  mode: string;
+  displayName: string;
+  role?: string;
+  backendType: BackendType;
+  status: "active" | "idle" | "archived";
+  createdAt: string | number;
+  lastAccessed: string | number;
+}
+
+interface ProjectOverviewData {
+  project: {
+    projectId: string;
+    name: string;
+    description?: string;
+    root: string;
+    createdAt: string | number;
+    updatedAt: string | number;
+  };
+  sessions: ProjectOverviewSession[];
+}
+
 interface ChildProcess {
   pid: number;
   specifier: string;
   workspace: string;
+  projectRoot?: string;
+  projectSessionId?: string;
   url: string;
   startedAt: number;
 }
@@ -362,6 +396,28 @@ function timeAgo(timestamp: number): string {
   const days = Math.floor(hours / 24);
   if (days < 30) return `${days}d ago`;
   return `${Math.floor(days / 30)}mo ago`;
+}
+
+function timestampFromDateLike(value: string | number): number {
+  if (typeof value === "number") return value;
+  return Date.parse(value);
+}
+
+function timeAgoIso(value: string | number): string {
+  const timestamp = timestampFromDateLike(value);
+  return Number.isFinite(timestamp) ? timeAgo(timestamp) : "";
+}
+
+function formatIsoDate(value: string | number): string {
+  const timestamp = timestampFromDateLike(value);
+  if (!Number.isFinite(timestamp)) return String(value);
+  return new Intl.DateTimeFormat(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(timestamp);
 }
 
 function runningDuration(startedAt: number): string {
@@ -3246,6 +3302,224 @@ function ImportDialog({
   );
 }
 
+function ProjectCard({
+  project,
+  homeDir,
+  onOpen,
+}: {
+  project: RecentProject;
+  homeDir: string;
+  onOpen: () => void;
+}) {
+  return (
+    <button
+      onClick={onOpen}
+      className="group text-left rounded-lg border border-cc-border bg-cc-bg-secondary hover:border-cc-primary/40 transition-all p-4 cursor-pointer min-h-[116px] flex flex-col"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="text-sm font-medium text-cc-fg truncate">{project.name}</div>
+          {project.description && (
+            <div className="text-xs text-cc-muted/70 line-clamp-2 mt-1">{project.description}</div>
+          )}
+        </div>
+        <span className="text-[10px] text-cc-muted/40 shrink-0">{timeAgoIso(project.lastAccessed)}</span>
+      </div>
+      <div className="mt-auto pt-3 text-[10px] text-cc-muted/50 font-mono truncate">
+        {shortenPath(project.root, homeDir)}
+      </div>
+    </button>
+  );
+}
+
+function CreateProjectDialog({
+  homeDir,
+  onClose,
+  onCreated,
+}: {
+  homeDir: string;
+  onClose: () => void;
+  onCreated: (project: RecentProject) => void;
+}) {
+  const stamp = new Date().toISOString().slice(0, 10).replace(/-/g, "");
+  const defaultRoot = homeDir ? `${homeDir}/pneuma-projects/project-${stamp}` : `~/pneuma-projects/project-${stamp}`;
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [root, setRoot] = useState(defaultRoot);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+
+  const submit = async () => {
+    if (!root.trim() || saving) return;
+    setSaving(true);
+    setError("");
+    try {
+      const res = await fetch(`${getApiBase()}/api/projects`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          root: root.trim(),
+          ...(name.trim() ? { name: name.trim() } : {}),
+          ...(description.trim() ? { description: description.trim() } : {}),
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "Failed to create project");
+      onCreated(data.project as RecentProject);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to create project");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/30 backdrop-blur-[2px] flex items-center justify-center z-50 font-body py-12" style={{ animation: "overlayFadeIn 0.2s ease-out" }}>
+      <div className="launcher-card-elevated bg-cc-surface border border-cc-border/50 rounded-2xl overflow-hidden w-full max-w-lg mx-4">
+        <div className="p-6 border-b border-cc-border/40">
+          <h2 className="text-lg font-medium text-cc-fg">Create Project</h2>
+          <p className="text-xs text-cc-muted/60 mt-1">Choose a real folder that you can open, git init, or push later.</p>
+        </div>
+        <div className="p-6 space-y-4">
+          <div>
+            <label className="block text-xs text-cc-muted/70 mb-1">Name</label>
+            <input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Project name"
+              className="w-full px-3 py-2 bg-cc-input-bg border border-cc-border rounded-lg text-cc-fg text-sm focus:outline-none focus:border-cc-primary/50"
+            />
+          </div>
+          <div>
+            <label className="block text-xs text-cc-muted/70 mb-1">Description</label>
+            <textarea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              rows={3}
+              placeholder="Optional"
+              className="w-full px-3 py-2 bg-cc-input-bg border border-cc-border rounded-lg text-cc-fg text-sm focus:outline-none focus:border-cc-primary/50 resize-none"
+            />
+          </div>
+          <div>
+            <label className="block text-xs text-cc-muted/70 mb-1">Root folder</label>
+            <input
+              value={root}
+              onChange={(e) => setRoot(e.target.value)}
+              className="w-full px-3 py-2 bg-cc-input-bg border border-cc-border rounded-lg text-cc-fg text-sm font-mono focus:outline-none focus:border-cc-primary/50"
+            />
+          </div>
+          {error && <div className="text-xs text-cc-error">{error}</div>}
+        </div>
+        <div className="p-6 pt-0 flex justify-end gap-3">
+          <button onClick={onClose} className="px-4 py-2 text-sm rounded-lg border border-cc-border/50 text-cc-muted hover:text-cc-fg transition-colors cursor-pointer">
+            Cancel
+          </button>
+          <PrimaryButton onClick={submit} disabled={saving || !root.trim()}>
+            {saving ? "Creating..." : "Create"}
+          </PrimaryButton>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ProjectOverview({
+  data,
+  modes,
+  homeDir,
+  iconMap,
+  defaultBackendType,
+  onClose,
+  onResume,
+  onStartNew,
+}: {
+  data: ProjectOverviewData;
+  modes: AnyMode[];
+  homeDir: string;
+  iconMap: Record<string, string>;
+  defaultBackendType: BackendType;
+  onClose: () => void;
+  onResume: (session: ProjectOverviewSession) => void;
+  onStartNew: (mode: AnyMode) => void;
+}) {
+  const project = data.project;
+  const launchableModes = modes.filter((m) => m.name !== "evolve");
+
+  return (
+    <div className="fixed inset-0 bg-black/30 backdrop-blur-[2px] flex items-center justify-center z-50 font-body py-12" style={{ animation: "overlayFadeIn 0.2s ease-out" }}>
+      <div className="launcher-card-elevated bg-cc-surface border border-cc-border/50 rounded-2xl overflow-hidden w-full max-w-5xl mx-4 flex flex-col max-h-full">
+        <div className="p-6 border-b border-cc-border/40 flex items-start justify-between gap-6">
+          <div className="min-w-0">
+            <div className="text-lg font-medium text-cc-fg truncate">{project.name}</div>
+            {project.description && <p className="text-sm text-cc-muted/70 mt-1">{project.description}</p>}
+            <div className="mt-3 flex flex-wrap gap-x-4 gap-y-1 text-[11px] text-cc-muted/55">
+              <span className="font-mono truncate max-w-[520px]">{shortenPath(project.root, homeDir)}</span>
+              <span>Created {formatIsoDate(project.createdAt)}</span>
+            </div>
+          </div>
+          <button onClick={onClose} className="p-2 text-cc-muted/60 hover:text-cc-fg transition-colors cursor-pointer" title="Close">
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+        <div className="p-6 overflow-y-auto grid grid-cols-1 lg:grid-cols-[1fr_320px] gap-6">
+          <section>
+            <div className="flex items-baseline justify-between mb-3">
+              <h3 className="text-sm font-medium text-cc-fg/75">Project Sessions</h3>
+              <span className="text-xs text-cc-muted/45">{data.sessions.length}</span>
+            </div>
+            {data.sessions.length === 0 ? (
+              <div className="rounded-lg border border-cc-border/50 bg-cc-bg-secondary p-5 text-sm text-cc-muted/65">
+                No sessions yet.
+              </div>
+            ) : (
+              <div className="space-y-2">
+                {data.sessions.map((session) => (
+                  <div key={session.sessionId} className="rounded-lg border border-cc-border/50 bg-cc-bg-secondary p-3 flex items-center gap-3">
+                    {iconMap[session.mode] && <img src={iconMap[session.mode]} alt="" className="w-8 h-8 rounded" />}
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2 min-w-0">
+                        <span className="text-sm font-medium text-cc-fg truncate">{session.displayName}</span>
+                        <span className="text-[10px] px-1.5 py-0.5 rounded bg-cc-surface text-cc-muted/65">{session.status}</span>
+                      </div>
+                      <div className="text-xs text-cc-muted/60 truncate">
+                        {session.role || "No role set"} · {session.mode} · {backendLabel(session.backendType)} · {timeAgoIso(session.lastAccessed)}
+                      </div>
+                    </div>
+                    <PrimaryButton size="sm" onClick={() => onResume(session)}>
+                      Resume
+                    </PrimaryButton>
+                  </div>
+                ))}
+              </div>
+            )}
+          </section>
+
+          <aside>
+            <h3 className="text-sm font-medium text-cc-fg/75 mb-3">New Session</h3>
+            <div className="space-y-2 max-h-[420px] overflow-y-auto pr-1">
+              {launchableModes.map((mode) => (
+                <button
+                  key={`${mode.source}:${mode.specifier}`}
+                  onClick={() => onStartNew(mode)}
+                  className="w-full rounded-lg border border-cc-border/50 bg-cc-bg-secondary hover:border-cc-primary/40 transition-colors p-3 flex items-center gap-3 text-left cursor-pointer"
+                >
+                  {mode.icon && <img src={mode.icon} alt="" className="w-7 h-7 rounded" />}
+                  <div className="min-w-0">
+                    <div className="text-sm text-cc-fg truncate">{mode.displayName}</div>
+                    <div className="text-[10px] text-cc-muted/50 truncate">{backendLabel(defaultBackendType)}</div>
+                  </div>
+                </button>
+              ))}
+            </div>
+          </aside>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 // ── Main Launcher ────────────────────────────────────────────────────────
 
 export default function Launcher() {
@@ -3256,12 +3530,15 @@ export default function Launcher() {
   const [builtins, setBuiltins] = useState<BuiltinMode[]>([]);
   const [published, setPublished] = useState<PublishedMode[]>([]);
   const [local, setLocal] = useState<LocalMode[]>([]);
+  const [projects, setProjects] = useState<RecentProject[]>([]);
   const [sessions, setSessions] = useState<RecentSession[]>([]);
   const [running, setRunning] = useState<ChildProcess[]>([]);
   const [homeDir, setHomeDir] = useState("");
   const [loading, setLoading] = useState(true);
   const [showGallery, setShowGallery] = useState(false);
   const [showAllSessions, setShowAllSessions] = useState(false);
+  const [showCreateProject, setShowCreateProject] = useState(false);
+  const [projectOverview, setProjectOverview] = useState<ProjectOverviewData | null>(null);
   const [showSettings, setShowSettings] = useState(false);
   const [showImportDialog, setShowImportDialog] = useState(() => {
     const params = new URLSearchParams(window.location.search);
@@ -3313,7 +3590,7 @@ export default function Launcher() {
   const lastLaunchTarget = useRef(launchTarget);
   if (launchTarget) lastLaunchTarget.current = launchTarget;
 
-  const hasOverlay = showGallery || showAllSessions || launchTarget !== null;
+  const hasOverlay = showGallery || showAllSessions || launchTarget !== null || showCreateProject || projectOverview !== null;
 
   // Lock body scroll when any overlay is open
   useEffect(() => {
@@ -3328,14 +3605,16 @@ export default function Launcher() {
     if (!hasOverlay) return;
     const handler = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
-        if (launchTarget) setLaunchTarget(null);
+        if (projectOverview) setProjectOverview(null);
+        else if (showCreateProject) setShowCreateProject(false);
+        else if (launchTarget) setLaunchTarget(null);
         else if (showGallery) setShowGallery(false);
         else if (showAllSessions) setShowAllSessions(false);
       }
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
-  }, [hasOverlay, launchTarget, showGallery, showAllSessions]);
+  }, [hasOverlay, launchTarget, projectOverview, showCreateProject, showGallery, showAllSessions]);
 
   const refreshModes = useCallback(() => {
     fetch(`${getApiBase()}/api/registry`)
@@ -3358,6 +3637,13 @@ export default function Launcher() {
       .catch(() => { });
   }, []);
 
+  const refreshProjects = useCallback(() => {
+    fetch(`${getApiBase()}/api/projects`)
+      .then((r) => r.json())
+      .then((data) => setProjects(data.projects || []))
+      .catch(() => { });
+  }, []);
+
   const refreshRunning = useCallback(() => {
     fetch(`${getApiBase()}/api/processes/children`)
       .then((r) => r.json())
@@ -3369,10 +3655,11 @@ export default function Launcher() {
     Promise.all([
       fetch(`${getApiBase()}/api/backends`).then((r) => r.json()),
       fetch(`${getApiBase()}/api/registry`).then((r) => r.json()),
+      fetch(`${getApiBase()}/api/projects`).then((r) => r.json()),
       fetch(`${getApiBase()}/api/sessions`).then((r) => r.json()),
       fetch(`${getApiBase()}/api/processes/children`).then((r) => r.json()),
     ])
-      .then(([backendData, registryData, sessionsData, runningData]) => {
+      .then(([backendData, registryData, projectsData, sessionsData, runningData]) => {
         setBackendOptions(backendData.backends || []);
         if (backendData.defaultBackendType) {
           setDefaultBackendType(backendData.defaultBackendType);
@@ -3380,6 +3667,7 @@ export default function Launcher() {
         setBuiltins(registryData.builtins || []);
         setPublished(registryData.published || []);
         setLocal(registryData.local || []);
+        setProjects(projectsData.projects || []);
         setSessions(sessionsData.sessions || []);
         if (sessionsData.homeDir) setHomeDir(sessionsData.homeDir);
         setRunning(runningData.processes || []);
@@ -3392,9 +3680,10 @@ export default function Launcher() {
     const interval = setInterval(() => {
       refreshRunning();
       refreshSessions();
+      refreshProjects();
     }, 3000);
     return () => clearInterval(interval);
-  }, [refreshRunning, refreshSessions]);
+  }, [refreshRunning, refreshSessions, refreshProjects]);
 
   // Refresh sessions + running when tab regains focus (picks up new thumbnails)
   useEffect(() => {
@@ -3402,11 +3691,12 @@ export default function Launcher() {
       if (document.visibilityState === "visible") {
         refreshSessions();
         refreshRunning();
+        refreshProjects();
       }
     };
     document.addEventListener("visibilitychange", handleVisibility);
     return () => document.removeEventListener("visibilitychange", handleVisibility);
-  }, [refreshSessions, refreshRunning]);
+  }, [refreshSessions, refreshRunning, refreshProjects]);
 
   const deleteLocalMode = useCallback(async (name: string) => {
     try {
@@ -3505,6 +3795,42 @@ export default function Launcher() {
     } catch { }
   }, [refreshSessions, refreshRunning]);
 
+  const openProject = useCallback(async (projectId: string) => {
+    try {
+      const res = await fetch(`${getApiBase()}/api/projects/${encodeURIComponent(projectId)}`);
+      if (!res.ok) return;
+      const data = await res.json();
+      setProjectOverview(data as ProjectOverviewData);
+    } catch { }
+  }, []);
+
+  const launchProjectSession = useCallback(async (
+    projectRoot: string,
+    mode: string,
+    backendType: BackendType,
+    projectSessionId?: string,
+  ) => {
+    try {
+      const res = await fetch(`${getApiBase()}/api/launch`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          specifier: mode,
+          projectRoot,
+          backendType,
+          ...(projectSessionId ? { projectSessionId } : {}),
+        }),
+      });
+      const data = await res.json();
+      if (data.url) {
+        refreshProjects();
+        refreshSessions();
+        refreshRunning();
+        setTimeout(() => window.open(data.url, "_blank"), 400);
+      }
+    } catch { }
+  }, [refreshProjects, refreshSessions, refreshRunning]);
+
   // Build icon lookup
   const iconMap = React.useMemo(() => {
     const map: Record<string, string> = {};
@@ -3517,32 +3843,9 @@ export default function Launcher() {
 
   // Separate app sessions (layout=app, not editing) from regular sessions
   const appSessions = sessions.filter((s) => s.layout === "app" && s.editing === false);
-  const appWorkspaces = new Set(appSessions.map((s) => s.workspace));
 
   // Merge sessions + running for the "Continue" section (max 3 on homepage)
-  const runningWorkspaces = new Set(running.map((r) => r.workspace));
-  const allContinueItems = [
-    // Running processes first (exclude app sessions)
-    ...running
-      .filter((proc) => !appWorkspaces.has(proc.workspace))
-      .map((proc) => ({
-        type: "running" as const,
-        key: proc.workspace,
-        process: proc,
-        session: sessions.find((s) => s.workspace === proc.workspace),
-        modeName: proc.specifier.split("/").pop() || proc.specifier,
-      })),
-    // Then recent sessions (not currently running, not app sessions)
-    ...sessions
-      .filter((s) => !runningWorkspaces.has(s.workspace) && !appWorkspaces.has(s.workspace))
-      .map((s) => ({
-        type: "recent" as const,
-        key: s.workspace,
-        session: s,
-        process: undefined as ChildProcess | undefined,
-        modeName: s.mode,
-      })),
-  ];
+  const allContinueItems = buildContinueItems<RecentSession, ChildProcess>(sessions, running);
   const continueItems = allContinueItems.slice(0, 3);
 
   // Featured mode — random builtin with showcase, picked once on first data load
@@ -3652,7 +3955,7 @@ export default function Launcher() {
             </a>
           </div>
           <button
-            onClick={() => { setShowGallery(false); setShowAllSessions(false); setLaunchTarget(null); }}
+            onClick={() => { setShowGallery(false); setShowAllSessions(false); setLaunchTarget(null); setShowCreateProject(false); setProjectOverview(null); }}
             className={`p-2 text-cc-muted/50 hover:text-cc-fg transition-all duration-300 ease-out cursor-pointer ${
               hasOverlay ? "opacity-100 translate-x-0 scale-100" : "opacity-0 translate-x-3 scale-75 pointer-events-none"
             }`}
@@ -3687,6 +3990,42 @@ export default function Launcher() {
               onExplore={() => setShowGallery(true)}
             />
           )}
+
+          {/* Recent Projects */}
+          <section
+            className="mb-10 pt-8 border-t border-cc-border"
+            style={{ animation: "launcherFadeIn 0.5s cubic-bezier(0.16, 1, 0.3, 1) 0.08s both" }}
+          >
+            <div className="flex items-baseline justify-between mb-5">
+              <h2 className="text-sm font-medium text-cc-fg/70 tracking-wide">Recent Projects</h2>
+              <button
+                onClick={() => setShowCreateProject(true)}
+                className="text-xs text-cc-muted/50 hover:text-cc-primary transition-colors cursor-pointer"
+              >
+                Create Project
+              </button>
+            </div>
+            {projects.length > 0 ? (
+              <div className="grid gap-3" style={{ gridTemplateColumns: "repeat(auto-fill, minmax(220px, 1fr))" }}>
+                {projects.slice(0, 6).map((project) => (
+                  <ProjectCard
+                    key={project.projectId}
+                    project={project}
+                    homeDir={homeDir}
+                    onOpen={() => openProject(project.projectId)}
+                  />
+                ))}
+              </div>
+            ) : (
+              <div className="rounded-lg border border-cc-border/50 bg-cc-bg-secondary p-5 flex items-center justify-between gap-4">
+                <div>
+                  <div className="text-sm text-cc-fg/80">No projects yet</div>
+                  <div className="text-xs text-cc-muted/55 mt-1">Projects keep related sessions under one real folder.</div>
+                </div>
+                <PrimaryButton size="sm" onClick={() => setShowCreateProject(true)}>Create</PrimaryButton>
+              </div>
+            )}
+          </section>
 
           {/* My Apps — app-layout sessions in use mode */}
           {appSessions.length > 0 && (
@@ -3738,7 +4077,7 @@ export default function Launcher() {
               style={{ animation: "launcherFadeIn 0.5s cubic-bezier(0.16, 1, 0.3, 1) 0.15s both" }}
             >
               <div className="flex items-baseline justify-between mb-5">
-                <h2 className="text-sm font-medium text-cc-fg/70 tracking-wide">Continue</h2>
+                <h2 className="text-sm font-medium text-cc-fg/70 tracking-wide">Recent Sessions</h2>
                 <div className="flex items-center gap-3">
                   <button
                     onClick={() => setShowImportDialog(true)}
@@ -3961,6 +4300,37 @@ export default function Launcher() {
           homeDir={homeDir}
           onClose={() => setLaunchTarget(null)}
           closing={launchAnim.closing}
+        />
+      )}
+
+      {showCreateProject && (
+        <CreateProjectDialog
+          homeDir={homeDir}
+          onClose={() => setShowCreateProject(false)}
+          onCreated={(project) => {
+            setShowCreateProject(false);
+            refreshProjects();
+            openProject(project.projectId);
+          }}
+        />
+      )}
+
+      {projectOverview && (
+        <ProjectOverview
+          data={projectOverview}
+          modes={allModes}
+          homeDir={homeDir}
+          iconMap={iconMap}
+          defaultBackendType={defaultBackendType}
+          onClose={() => setProjectOverview(null)}
+          onResume={(session) => {
+            setProjectOverview(null);
+            launchProjectSession(projectOverview.project.root, session.mode, session.backendType, session.sessionId);
+          }}
+          onStartNew={(mode) => {
+            setProjectOverview(null);
+            launchProjectSession(projectOverview.project.root, mode.specifier, defaultBackendType);
+          }}
         />
       )}
 

--- a/src/components/__tests__/launcher-helpers.test.ts
+++ b/src/components/__tests__/launcher-helpers.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test";
+import { buildContinueItems } from "../launcher-helpers";
+
+describe("buildContinueItems", () => {
+  test("excludes running project processes from global recent sessions", () => {
+    const items = buildContinueItems(
+      [
+        { workspace: "/tmp/quick", mode: "doc" },
+      ],
+      [
+        { pid: 1, specifier: "webcraft", workspace: "/tmp/project", projectRoot: "/tmp/project" },
+        { pid: 2, specifier: "doc", workspace: "/tmp/quick" },
+      ],
+    );
+
+    expect(items.map((item) => item.key)).toEqual(["running:2"]);
+  });
+});

--- a/src/components/launcher-helpers.ts
+++ b/src/components/launcher-helpers.ts
@@ -1,0 +1,55 @@
+export interface ContinueSessionLike {
+  workspace: string;
+  mode: string;
+  layout?: "editor" | "app";
+  editing?: boolean;
+}
+
+export interface ContinueProcessLike {
+  pid?: number;
+  specifier: string;
+  workspace: string;
+  projectRoot?: string;
+}
+
+export interface ContinueItem<S extends ContinueSessionLike, P extends ContinueProcessLike> {
+  type: "running" | "recent";
+  key: string;
+  session?: S;
+  process?: P;
+  modeName: string;
+}
+
+export function buildContinueItems<S extends ContinueSessionLike, P extends ContinueProcessLike>(
+  sessions: S[],
+  running: P[],
+): Array<ContinueItem<S, P>> {
+  const appWorkspaces = new Set(
+    sessions
+      .filter((session) => session.layout === "app" && session.editing === false)
+      .map((session) => session.workspace),
+  );
+  const independentRunning = running.filter((process) => !process.projectRoot);
+  const runningWorkspaces = new Set(independentRunning.map((process) => process.workspace));
+
+  return [
+    ...independentRunning
+      .filter((process) => !appWorkspaces.has(process.workspace))
+      .map((process) => ({
+        type: "running" as const,
+        key: process.pid ? `running:${process.pid}` : `running:${process.workspace}:${process.specifier}`,
+        process,
+        session: sessions.find((session) => session.workspace === process.workspace),
+        modeName: process.specifier.split("/").pop() || process.specifier,
+      })),
+    ...sessions
+      .filter((session) => !runningWorkspaces.has(session.workspace) && !appWorkspaces.has(session.workspace))
+      .map((session) => ({
+        type: "recent" as const,
+        key: session.workspace,
+        session,
+        process: undefined,
+        modeName: session.mode,
+      })),
+  ];
+}


### PR DESCRIPTION
## Automated Verification

- [x] `bun test` — pass (756 pass, 0 fail, 1909 expect)
- [x] `bun run build` — pass; Vite emitted the existing Node 22.11.0 version warning and existing chunk-size/dynamic-import warnings, exit 0
- [x] `git diff --check` — pass
- [x] Playwright Chrome screenshot against the launcher dev server — Recent Projects rendered with project cards
- [x] Subagent review — no blocking findings after follow-up fixes

## Human Verification TODO

- [ ] Open Launcher and confirm Recent Projects and Recent Sessions are visually distinct top-level sections.
- [ ] Open a project card and confirm identity metadata plus session rows show mode, role, backend, activity, and status.
- [ ] Create a project from Launcher and confirm it opens the new project overview.
- [ ] Start a new project session and resume an existing one from the overview.

## Retro Notes

- Running project processes must carry `projectRoot` metadata so Launcher can keep project sessions out of global Recent Sessions.
- Filtering stale `.pneuma/sessions.json` entries matters because write-path fixes alone do not clean up older registry pollution.

---
Closes #82 — board-superpowers v0.2.0 claim trailer.
