### PR TITLE
Add project context instruction injection

### DIFF
--- a/bin/pneuma.ts
+++ b/bin/pneuma.ts
@@ -20,6 +20,7 @@ import { initShadowGit } from "../server/shadow-git.js";
 import { loadModeManifest, listBuiltinModes, registerExternalMode } from "../core/mode-loader.js";
 import type { ModeManifest } from "../core/types/mode-manifest.js";
 import type { AgentBackendType } from "../core/types/agent-backend.js";
+import type { ProjectInstructionContext } from "../core/project.js";
 import { applyTemplateParams } from "../server/skill-installer.js";
 import { resolveMode as resolveModeSource, isExternalMode } from "../core/mode-resolver.js";
 import type { ResolvedMode } from "../core/mode-resolver.js";
@@ -1256,9 +1257,10 @@ Options:
 
   let activeProjectRoot = "";
   let projectSessionId = "";
+  let projectInstructionContext: ProjectInstructionContext | undefined;
 
   if (projectRoot) {
-    const { resolveProjectRuntime } = await import("../core/project.js");
+    const { buildProjectInstructionContext, resolveProjectRuntime } = await import("../core/project.js");
     const runtime = resolveProjectRuntime({
       projectRoot,
       mode: modeName,
@@ -1268,6 +1270,7 @@ Options:
     });
     activeProjectRoot = runtime.projectRoot;
     projectSessionId = runtime.session.sessionId;
+    projectInstructionContext = buildProjectInstructionContext(runtime);
     workspace = runtime.workspace;
     p.log.info(`Project: ${runtime.project.name} (${activeProjectRoot})`);
     p.log.info(`Project session: ${projectSessionId}`);
@@ -1381,7 +1384,9 @@ Options:
     }
 
     p.log.step("Installing skill and preparing environment...");
-    installSkill(workspace, manifest.skill, modeSourceDir, resolvedParams, manifest.viewerApi, backendType, manifest.proxy);
+    installSkill(workspace, manifest.skill, modeSourceDir, resolvedParams, manifest.viewerApi, backendType, manifest.proxy, {
+      projectContext: projectInstructionContext,
+    });
     // Record installed skill version for update detection
     const skillVersionPath = join(workspace, ".pneuma", "skill-version.json");
     mkdirSync(join(workspace, ".pneuma"), { recursive: true });
@@ -1614,6 +1619,7 @@ Options:
     editing: initialEditing,
     editingSupported: !!manifest.editing?.supported,
     backendType,
+    projectInstructionContext,
   });
 
   // 4. Launch Agent backend or set up replay mode
@@ -1657,7 +1663,9 @@ Options:
       }
 
       p.log.step("Continue Work: installing skill...");
-      installSkill(workspace, manifest.skill, modeSourceDir, resolvedParams, manifest.viewerApi, backendType, manifest.proxy);
+      installSkill(workspace, manifest.skill, modeSourceDir, resolvedParams, manifest.viewerApi, backendType, manifest.proxy, {
+        projectContext: projectInstructionContext,
+      });
 
       // Record installed skill version
       const skillVersionPath = join(workspace, ".pneuma", "skill-version.json");
@@ -1862,7 +1870,9 @@ Options:
       // Register launch callback for viewing → edit switching
       onEditingLaunch!(async () => {
         p.log.step("Switching to edit mode: installing skill and launching agent...");
-        installSkill(workspace, manifest.skill, modeSourceDir, resolvedParams, manifest.viewerApi, sessionBackendType, manifest.proxy);
+        installSkill(workspace, manifest.skill, modeSourceDir, resolvedParams, manifest.viewerApi, sessionBackendType, manifest.proxy, {
+          projectContext: projectInstructionContext,
+        });
         const skillVersionPath = join(workspace, ".pneuma", "skill-version.json");
         writeFileSync(skillVersionPath, JSON.stringify({ mode: modeName, version: manifest.version }));
 
@@ -1963,7 +1973,9 @@ Options:
         // Register launch callback for subsequent viewing → edit switch
         onEditingLaunch!(async () => {
           p.log.step("Switching to edit mode: installing skill and launching agent...");
-          installSkill(workspace, manifest.skill, modeSourceDir, resolvedParams, manifest.viewerApi, sessionBackendType, manifest.proxy);
+          installSkill(workspace, manifest.skill, modeSourceDir, resolvedParams, manifest.viewerApi, sessionBackendType, manifest.proxy, {
+            projectContext: projectInstructionContext,
+          });
 
           backend = createBackend(sessionBackendType, actualPort);
           wireCLISessionId();

--- a/core/__tests__/project.test.ts
+++ b/core/__tests__/project.test.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
+  buildProjectInstructionContext,
   createProject,
   createProjectSession,
   listProjectSessions,
@@ -192,5 +193,70 @@ describe("project runtime", () => {
     expect(runtime.session.sessionId).toBe("web-runtime");
     expect(runtime.workspace).toBe(join(root, ".pneuma", "sessions", "web-runtime", "workspace"));
     expect(runtime.projectRoot).toBe(root);
+  });
+});
+
+describe("project instruction context", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = join(tmpdir(), `pneuma-project-context-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(root, { recursive: true });
+    createProject(root, {
+      name: "Context Project",
+      description: "Cross-mode project",
+      now: () => "2026-04-28T00:00:00.000Z",
+      idFactory: () => "project_context",
+    });
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test("buildProjectInstructionContext summarizes project identity and peer sessions without workspace paths", () => {
+    createProjectSession(root, {
+      mode: "doc",
+      displayName: "Doc",
+      backendType: "claude-code",
+      role: "Draft the copy",
+      now: () => "2026-04-28T01:00:00.000Z",
+      idFactory: () => "doc-peer",
+    });
+    const runtime = resolveProjectRuntime({
+      projectRoot: root,
+      mode: "webcraft",
+      displayName: "Webcraft",
+      backendType: "codex",
+      role: "Build the page",
+      now: () => "2026-04-28T02:00:00.000Z",
+      sessionIdFactory: () => "web-current",
+    });
+
+    const context = buildProjectInstructionContext(runtime);
+
+    expect(context).toMatchObject({
+      projectId: "project_context",
+      projectName: "Context Project",
+      projectRoot: root,
+      description: "Cross-mode project",
+      role: "Build the page",
+      currentSessionId: "web-current",
+      currentMode: "webcraft",
+      currentSessionDisplayName: "Webcraft",
+    });
+    expect(context.peerSessions).toEqual([
+      {
+        sessionId: "doc-peer",
+        mode: "doc",
+        displayName: "Doc",
+        role: "Draft the copy",
+        backendType: "claude-code",
+        status: "active",
+        lastAccessed: "2026-04-28T01:00:00.000Z",
+      },
+    ]);
+    expect(JSON.stringify(context)).not.toContain("sessionWorkspace");
+    expect(JSON.stringify(context)).not.toContain(projectSessionWorkspace(root, "doc-peer"));
   });
 });

--- a/core/project.ts
+++ b/core/project.ts
@@ -80,6 +80,28 @@ export interface ProjectRuntime {
   session: ProjectSessionManifest;
 }
 
+export interface ProjectInstructionSessionSummary {
+  sessionId: string;
+  mode: string;
+  displayName: string;
+  role?: string;
+  backendType: ProjectBackendType;
+  status: ProjectSessionManifest["status"];
+  lastAccessed: string;
+}
+
+export interface ProjectInstructionContext {
+  projectId: string;
+  projectName: string;
+  projectRoot: string;
+  description?: string;
+  role?: string;
+  currentSessionId: string;
+  currentMode: string;
+  currentSessionDisplayName: string;
+  peerSessions: ProjectInstructionSessionSummary[];
+}
+
 export type ProjectTimelineEvent =
   | { type: "project.created"; at: string; projectId: string; name: string }
   | { type: "project.updated"; at: string; changes: Record<string, unknown> }
@@ -289,5 +311,32 @@ export function resolveProjectRuntime(options: ResolveProjectRuntimeOptions): Pr
     workspace: session.sessionWorkspace,
     project,
     session,
+  };
+}
+
+export function buildProjectInstructionContext(
+  runtime: ProjectRuntime,
+  sessions: ProjectSessionManifest[] = listProjectSessions(runtime.projectRoot),
+): ProjectInstructionContext {
+  return {
+    projectId: runtime.project.projectId,
+    projectName: runtime.project.name,
+    projectRoot: runtime.projectRoot,
+    ...(runtime.project.description ? { description: runtime.project.description } : {}),
+    ...(runtime.session.role ? { role: runtime.session.role } : {}),
+    currentSessionId: runtime.session.sessionId,
+    currentMode: runtime.session.mode,
+    currentSessionDisplayName: runtime.session.displayName,
+    peerSessions: sessions
+      .filter((session) => session.sessionId !== runtime.session.sessionId)
+      .map((session) => ({
+        sessionId: session.sessionId,
+        mode: session.mode,
+        displayName: session.displayName,
+        ...(session.role ? { role: session.role } : {}),
+        backendType: session.backendType,
+        status: session.status,
+        lastAccessed: session.lastAccessed,
+      })),
   };
 }

--- a/server/__tests__/skill-installer.test.ts
+++ b/server/__tests__/skill-installer.test.ts
@@ -8,8 +8,9 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from "node:fs";
 import { join } from "node:path";
-import { applyTemplateParams, installSkill, generateViewerApiSection, installMcpServers, installSkillDependencies } from "../skill-installer.js";
+import { applyTemplateParams, installSkill, generateViewerApiSection, installMcpServers, installSkillDependencies, buildAndInjectPreferences } from "../skill-installer.js";
 import type { SkillConfig, ViewerApiConfig, McpServerConfig, SkillDependency } from "../../core/types/mode-manifest.js";
+import { HookBus } from "../../core/hook-bus.js";
 
 // ── applyTemplateParams (pure) ──────────────────────────────────────────────
 
@@ -357,6 +358,152 @@ describe("installSkill", () => {
     // Also when omitted
     installSkill(workspace, defaultSkillConfig, modeSourceDir);
     expect(existsSync(join(workspace, "AGENTS.md"))).toBe(false);
+  });
+
+  test("injects project context and project preferences into CLAUDE.md", () => {
+    const projectRoot = join(tmpDir, "project-root");
+    mkdirSync(join(projectRoot, ".pneuma"), { recursive: true });
+    writeFileSync(
+      join(projectRoot, ".pneuma", "project-preferences.md"),
+      "# Project Preferences\n\n- Use a quiet editorial tone.\n",
+    );
+
+    installSkill(workspace, defaultSkillConfig, modeSourceDir, undefined, undefined, "claude-code", undefined, {
+      projectContext: {
+        projectId: "project_123",
+        projectName: "Launch Project",
+        projectRoot,
+        description: "Marketing site",
+        role: "Build the intro page",
+        currentSessionId: "web-1",
+        currentMode: "webcraft",
+        currentSessionDisplayName: "Webcraft",
+        peerSessions: [
+          {
+            sessionId: "doc-1",
+            mode: "doc",
+            displayName: "Doc",
+            role: "Draft the copy",
+            backendType: "claude-code",
+            status: "idle",
+            lastAccessed: "2026-04-28T03:00:00.000Z",
+          },
+        ],
+      },
+    });
+
+    const content = readFileSync(join(workspace, "CLAUDE.md"), "utf-8");
+    expect(content).toContain("<!-- pneuma:project-context:start -->");
+    expect(content).toContain("## Project Context");
+    expect(content).toContain("Launch Project");
+    expect(content).toContain(projectRoot);
+    expect(content).toContain("Marketing site");
+    expect(content).toContain("Build the intro page");
+    expect(content).toContain("Doc (`doc`) — role: Draft the copy");
+    expect(content).not.toContain("sessionWorkspace");
+    expect(content).toContain("<!-- pneuma:preferences:start -->");
+    expect(content).toContain("**Project:**");
+    expect(content).toContain("Project preferences override personal preferences when they conflict.");
+    expect(content).toContain("Use a quiet editorial tone.");
+  });
+
+  test("injects project context into AGENTS.md for codex sessions", () => {
+    const projectRoot = join(tmpDir, "codex-project-root");
+    mkdirSync(join(projectRoot, ".pneuma"), { recursive: true });
+
+    installSkill(workspace, defaultSkillConfig, modeSourceDir, undefined, undefined, "codex", undefined, {
+      projectContext: {
+        projectId: "project_codex",
+        projectName: "Codex Project",
+        projectRoot,
+        role: "Review implementation",
+        currentSessionId: "codex-1",
+        currentMode: "doc",
+        currentSessionDisplayName: "Doc",
+        peerSessions: [],
+      },
+    });
+
+    const content = readFileSync(join(workspace, "AGENTS.md"), "utf-8");
+    expect(content).toContain("<!-- pneuma:project-context:start -->");
+    expect(content).toContain("Codex Project");
+    expect(content).toContain("Review implementation");
+    expect(existsSync(join(workspace, "CLAUDE.md"))).toBe(false);
+  });
+
+  test("does not infer project context from workspace files for quick sessions", () => {
+    mkdirSync(join(workspace, ".pneuma"), { recursive: true });
+    writeFileSync(join(workspace, ".pneuma", "project.json"), JSON.stringify({ name: "Should Not Load" }));
+    writeFileSync(join(workspace, ".pneuma", "project-preferences.md"), "- Should not be injected\n");
+    writeFileSync(
+      join(workspace, "CLAUDE.md"),
+      "<!-- pneuma:project-context:start -->\nstale project\n<!-- pneuma:project-context:end -->\n",
+    );
+
+    installSkill(workspace, defaultSkillConfig, modeSourceDir);
+
+    const content = readFileSync(join(workspace, "CLAUDE.md"), "utf-8");
+    expect(content).not.toContain("<!-- pneuma:project-context:start -->");
+    expect(content).not.toContain("Should Not Load");
+    expect(content).not.toContain("Should not be injected");
+  });
+});
+
+describe("buildAndInjectPreferences project layer", () => {
+  let tmpDir: string;
+  let workspace: string;
+  let projectRoot: string;
+
+  beforeEach(() => {
+    tmpDir = join(import.meta.dir, `.tmp-project-prefs-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    workspace = join(tmpDir, "workspace");
+    projectRoot = join(tmpDir, "project-root");
+    mkdirSync(workspace, { recursive: true });
+    mkdirSync(join(projectRoot, ".pneuma"), { recursive: true });
+    writeFileSync(join(workspace, "CLAUDE.md"), "# Project\n");
+    writeFileSync(
+      join(projectRoot, ".pneuma", "project-preferences.md"),
+      "# Project Preferences\n\n- Prefer restrained visual density.\n",
+    );
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("preserves project preferences when plugin preference enrichment runs", async () => {
+    const hookBus = new HookBus();
+    hookBus.on("preferences:build", "test-plugin", async ({ payload }) => ({
+      ...(payload as any),
+      globalCritical: "Always cite assumptions.",
+    }));
+
+    await buildAndInjectPreferences(
+      workspace,
+      "pneuma-webcraft",
+      "claude-code",
+      hookBus,
+      { sessionId: "s1", mode: "webcraft", workspace, backendType: "claude-code" },
+      {
+        projectContext: {
+          projectId: "project_123",
+          projectName: "Launch Project",
+          projectRoot,
+          currentSessionId: "s1",
+          currentMode: "webcraft",
+          currentSessionDisplayName: "Webcraft",
+          peerSessions: [],
+        },
+      },
+    );
+
+    const content = readFileSync(join(workspace, "CLAUDE.md"), "utf-8");
+    expect(content).toContain("<!-- pneuma:project-context:start -->");
+    expect(content).toContain("Launch Project");
+    expect(content).toContain("**Global:**");
+    expect(content).toContain("Always cite assumptions.");
+    expect(content).toContain("**Project:**");
+    expect(content).toContain("Prefer restrained visual density.");
   });
 });
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -31,7 +31,7 @@ import { createProxyMiddleware, mergeProxyConfig, type ProxyConfigRef } from "./
 import type { ProxyRoute } from "../core/types/mode-manifest.js";
 import { startProxyWatcher, registerSelfWrite, registerSelfDelete } from "./file-watcher.js";
 import { mountNativeRoutes } from "./native-bridge.js";
-import { createProject, loadRecentProjects, recordRecentProject } from "../core/project.js";
+import { createProject, loadRecentProjects, recordRecentProject, type ProjectInstructionContext } from "../core/project.js";
 
 const DEFAULT_PORT = 17007;
 
@@ -57,6 +57,7 @@ export interface ServerOptions {
   editingSupported?: boolean; // Mode supports editing ↔ viewing toggle
   backendType?: string; // Backend type for correct instructions file selection (claude-code | codex)
   refreshStrategy?: "auto" | "manual"; // Viewer refresh strategy (default: "auto")
+  projectInstructionContext?: ProjectInstructionContext; // Explicit project context for agent instructions
 }
 
 export async function startServer(options: ServerOptions) {
@@ -1198,7 +1199,9 @@ export async function startServer(options: ServerOptions) {
   {
     const { buildAndInjectPreferences } = await import("./skill-installer.js");
     const installName = `pneuma-${options.modeName ?? ""}`;
-    await buildAndInjectPreferences(workspace, installName, options.backendType ?? "claude-code", hookBus, sessionInfo);
+    await buildAndInjectPreferences(workspace, installName, options.backendType ?? "claude-code", hookBus, sessionInfo, {
+      projectContext: options.projectInstructionContext,
+    });
   }
 
   // Mount plugin routes

--- a/server/skill-installer.ts
+++ b/server/skill-installer.ts
@@ -10,6 +10,7 @@ import { mkdirSync, existsSync, readFileSync, writeFileSync, cpSync, readdirSync
 import { join, dirname, extname } from "node:path";
 import { homedir } from "node:os";
 import type { SkillConfig, ViewerApiConfig, McpServerConfig, SkillDependency } from "../core/types/mode-manifest.js";
+import { projectPreferencesPath, type ProjectInstructionContext } from "../core/project.js";
 
 /** Return the workspace-relative skills directory for a given backend. */
 function skillsDir(backendType?: string): string {
@@ -29,6 +30,12 @@ const SKILLS_MARKER_START = "<!-- pneuma:skills:start -->";
 const SKILLS_MARKER_END = "<!-- pneuma:skills:end -->";
 const PREFS_MARKER_START = "<!-- pneuma:preferences:start -->";
 const PREFS_MARKER_END = "<!-- pneuma:preferences:end -->";
+const PROJECT_CONTEXT_MARKER_START = "<!-- pneuma:project-context:start -->";
+const PROJECT_CONTEXT_MARKER_END = "<!-- pneuma:project-context:end -->";
+
+export interface InstallSkillOptions {
+  projectContext?: ProjectInstructionContext;
+}
 
 /**
  * Extract critical preferences from a preference file.
@@ -46,6 +53,86 @@ export function extractPreferenceCritical(filePath: string): string | null {
   } catch {
     return null;
   }
+}
+
+function removeMarkedSection(content: string, markerStart: string, markerEnd: string): string {
+  const start = content.indexOf(markerStart);
+  const end = content.indexOf(markerEnd);
+  if (start === -1 || end === -1) return content;
+  return content.substring(0, start) + content.substring(end + markerEnd.length);
+}
+
+function upsertMarkedSection(
+  content: string,
+  markerStart: string,
+  markerEnd: string,
+  section: string,
+): string {
+  const start = content.indexOf(markerStart);
+  const end = content.indexOf(markerEnd);
+  if (start !== -1 && end !== -1) {
+    return content.substring(0, start) + section + content.substring(end + markerEnd.length);
+  }
+  if (content.length > 0 && !content.endsWith("\n")) content += "\n";
+  return content + "\n" + section + "\n";
+}
+
+function readProjectPreferences(projectContext?: ProjectInstructionContext): string | null {
+  if (!projectContext) return null;
+  try {
+    const raw = readFileSync(projectPreferencesPath(projectContext.projectRoot), "utf-8");
+    const withoutTitle = raw.replace(/^# Project Preferences\s*/i, "").trim();
+    return withoutTitle || null;
+  } catch {
+    return null;
+  }
+}
+
+function injectProjectContextSection(
+  content: string,
+  projectContext?: ProjectInstructionContext,
+): string {
+  if (!projectContext) {
+    return removeMarkedSection(content, PROJECT_CONTEXT_MARKER_START, PROJECT_CONTEXT_MARKER_END);
+  }
+
+  const lines = [
+    "## Project Context",
+    "",
+    "This session is running inside an explicit Pneuma project.",
+    "",
+    `- Project: ${projectContext.projectName}`,
+    `- Project root: ${projectContext.projectRoot}`,
+  ];
+  if (projectContext.description) lines.push(`- Description: ${projectContext.description}`);
+  lines.push(`- Current session: ${projectContext.currentSessionDisplayName} (\`${projectContext.currentMode}\`)`);
+  if (projectContext.currentSessionId) lines.push(`- Current session id: ${projectContext.currentSessionId}`);
+  if (projectContext.role) lines.push(`- Role: ${projectContext.role}`);
+
+  lines.push("", "### Other Project Sessions");
+  if (projectContext.peerSessions.length === 0) {
+    lines.push("", "No other project sessions recorded yet.");
+  } else {
+    lines.push("");
+    for (const session of projectContext.peerSessions) {
+      const parts = [
+        `${session.displayName} (\`${session.mode}\`)`,
+        session.role ? `role: ${session.role}` : "role: unspecified",
+        `backend: ${session.backendType}`,
+        `status: ${session.status}`,
+        `last active: ${session.lastAccessed}`,
+      ];
+      lines.push(`- ${parts.join(" — ")}`);
+    }
+  }
+
+  lines.push(
+    "",
+    "Project context is shared project metadata only. Do not inspect another session's raw history, scratch files, or workspace unless the user provides an explicit handoff.",
+  );
+
+  const section = `${PROJECT_CONTEXT_MARKER_START}\n${lines.join("\n")}\n${PROJECT_CONTEXT_MARKER_END}`;
+  return upsertMarkedSection(content, PROJECT_CONTEXT_MARKER_START, PROJECT_CONTEXT_MARKER_END, section);
 }
 
 export interface PreferencesBuildPayload {
@@ -68,6 +155,7 @@ function injectPreferencesSection(
   installName: string,
   globalCritical?: string | null,
   modeCritical?: string | null,
+  projectContext?: ProjectInstructionContext,
 ): string {
   const prefModeName = installName.replace(/^pneuma-/, "");
 
@@ -78,31 +166,29 @@ function injectPreferencesSection(
   const mc = modeCritical !== undefined
     ? modeCritical
     : extractPreferenceCritical(join(homedir(), ".pneuma", "preferences", `mode-${prefModeName}.md`));
+  const pc = readProjectPreferences(projectContext);
 
-  if (gc || mc) {
+  if (gc || pc || mc) {
     const prefsLines: string[] = ["### User Preferences (Critical)", ""];
     if (gc) {
       prefsLines.push("**Global:**", gc, "");
+    }
+    if (pc) {
+      prefsLines.push(
+        "**Project:**",
+        "Project preferences override personal preferences when they conflict.",
+        pc,
+        "",
+      );
     }
     if (mc) {
       prefsLines.push(`**${prefModeName} Mode:**`, mc);
     }
     const prefsSection = `${PREFS_MARKER_START}\n${prefsLines.join("\n")}\n${PREFS_MARKER_END}`;
-    const pStart = content.indexOf(PREFS_MARKER_START);
-    const pEnd = content.indexOf(PREFS_MARKER_END);
-    if (pStart !== -1 && pEnd !== -1) {
-      content = content.substring(0, pStart) + prefsSection + content.substring(pEnd + PREFS_MARKER_END.length);
-    } else {
-      if (content.length > 0 && !content.endsWith("\n")) content += "\n";
-      content += "\n" + prefsSection + "\n";
-    }
+    content = upsertMarkedSection(content, PREFS_MARKER_START, PREFS_MARKER_END, prefsSection);
   } else {
     // Remove stale preferences section
-    const pStart = content.indexOf(PREFS_MARKER_START);
-    const pEnd = content.indexOf(PREFS_MARKER_END);
-    if (pStart !== -1 && pEnd !== -1) {
-      content = content.substring(0, pStart) + content.substring(pEnd + PREFS_MARKER_END.length);
-    }
+    content = removeMarkedSection(content, PREFS_MARKER_START, PREFS_MARKER_END);
   }
 
   return content;
@@ -127,6 +213,7 @@ export async function buildAndInjectPreferences(
   backendType: string,
   hookBus: import("../core/hook-bus.js").HookBus,
   sessionInfo: import("../core/types/plugin.js").SessionInfo,
+  options: InstallSkillOptions = {},
 ): Promise<void> {
   const instrFile = backendType === "codex" ? "AGENTS.md" : "CLAUDE.md";
   const instructionsPath = join(workspace, instrFile);
@@ -151,13 +238,21 @@ export async function buildAndInjectPreferences(
     modeName: prefModeName,
   } satisfies PreferencesBuildPayload, sessionInfo);
 
-  // Only rewrite if plugins actually changed something
-  if (enriched.globalCritical === globalCritical && enriched.modeCritical === modeCritical) {
+  let nextContent = injectProjectContextSection(content, options.projectContext);
+  nextContent = injectPreferencesSection(
+    nextContent,
+    installName,
+    enriched.globalCritical,
+    enriched.modeCritical,
+    options.projectContext,
+  );
+
+  // Only rewrite if plugins or the project preference layer changed something
+  if (nextContent === content) {
     return;
   }
 
-  content = injectPreferencesSection(content, installName, enriched.globalCritical, enriched.modeCritical);
-  writeFileSync(instructionsPath, content, "utf-8");
+  writeFileSync(instructionsPath, nextContent, "utf-8");
   console.log(`[skill-installer] Enriched preferences in ${instructionsPath}`);
 }
 
@@ -654,6 +749,7 @@ export function installSkill(
   viewerApi?: ViewerApiConfig,
   backendType?: string,
   proxyConfig?: Record<string, import("../core/types/mode-manifest.js").ProxyRoute>,
+  options: InstallSkillOptions = {},
 ): void {
   // 1. Copy skill to the backend-appropriate skills directory
   const skillSource = join(modeSourceDir, skillConfig.sourceDir);
@@ -824,8 +920,11 @@ export function installSkill(
     }
   }
 
-  // 2d. Inject/update preferences critical section
-  content = injectPreferencesSection(content, skillConfig.installName);
+  // 2d. Inject/update explicit project context section
+  content = injectProjectContextSection(content, options.projectContext);
+
+  // 2e. Inject/update preferences critical section
+  content = injectPreferencesSection(content, skillConfig.installName, undefined, undefined, options.projectContext);
 
   // Write instructions file
   mkdirSync(dirname(primaryInstructionsPath), { recursive: true });


### PR DESCRIPTION
## Automated Verification

- [x] Focused project-context/preference tests — pass
- [x] `bun test` — pass
- [x] `bun run build` — pass; Vite emitted the existing Node 22.11.0 version warning and existing chunk-size/dynamic-import warnings, exit 0
- [x] Subagent review — no blocking findings

## Human Verification TODO

- [ ] Launch a project session with `--project` and inspect backend instructions for the Project Context section.
- [ ] Add `.pneuma/project-preferences.md` content and confirm it appears separately from personal preferences.
- [ ] Launch a quick session without `--project` and confirm no project context/preferences are injected.

## Retro Notes

- Project context belongs in the existing backend-aware instruction injection path, not in per-mode prompt code.
- Quick-session cleanup should remove stale project instruction blocks so reusing a workspace does not leak project identity.

---
Closes #83 — board-superpowers v0.2.0 claim trailer.
