### PR TITLE
Project layer integrated experience branch

### DIFF
--- a/bin/__tests__/pneuma-cli-helpers.test.ts
+++ b/bin/__tests__/pneuma-cli-helpers.test.ts
@@ -59,6 +59,8 @@ describe("pneuma CLI helpers", () => {
         "./site",
         "--project-session",
         "web-123",
+        "--handoff",
+        "handoff-123",
         "--role",
         "Build the home page",
       ],
@@ -68,6 +70,7 @@ describe("pneuma CLI helpers", () => {
     expect(parsed.mode).toBe("webcraft");
     expect(parsed.projectRoot).toBe("/tmp/base/site");
     expect(parsed.projectSessionId).toBe("web-123");
+    expect(parsed.handoffId).toBe("handoff-123");
     expect(parsed.role).toBe("Build the home page");
     expect(parsed.workspace).toBe("/tmp/base");
   });

--- a/bin/__tests__/pneuma-cli-helpers.test.ts
+++ b/bin/__tests__/pneuma-cli-helpers.test.ts
@@ -12,6 +12,8 @@ describe("pneuma CLI helpers", () => {
 
     expect(parsed.mode).toBe("doc");
     expect(parsed.workspace).toBe("/tmp/workspace");
+    expect(parsed.projectRoot).toBe("");
+    expect(parsed.role).toBe("");
     expect(parsed.backendType).toBe("claude-code");
   });
 
@@ -45,6 +47,26 @@ describe("pneuma CLI helpers", () => {
     expect(parsed.skipSkill).toBe(true);
     expect(parsed.debug).toBe(true);
     expect(parsed.forceDev).toBe(true);
+  });
+
+  test("parseCliArgs parses project and role flags", () => {
+    const parsed = parseCliArgs(
+      [
+        "bun",
+        "bin/pneuma.ts",
+        "webcraft",
+        "--project",
+        "./site",
+        "--role",
+        "Build the home page",
+      ],
+      "/tmp/base",
+    );
+
+    expect(parsed.mode).toBe("webcraft");
+    expect(parsed.projectRoot).toBe("/tmp/base/site");
+    expect(parsed.role).toBe("Build the home page");
+    expect(parsed.workspace).toBe("/tmp/base");
   });
 
   test("parseCliArgs recognizes top-level help and version flags", () => {

--- a/bin/__tests__/pneuma-cli-helpers.test.ts
+++ b/bin/__tests__/pneuma-cli-helpers.test.ts
@@ -57,6 +57,8 @@ describe("pneuma CLI helpers", () => {
         "webcraft",
         "--project",
         "./site",
+        "--project-session",
+        "web-123",
         "--role",
         "Build the home page",
       ],
@@ -65,6 +67,7 @@ describe("pneuma CLI helpers", () => {
 
     expect(parsed.mode).toBe("webcraft");
     expect(parsed.projectRoot).toBe("/tmp/base/site");
+    expect(parsed.projectSessionId).toBe("web-123");
     expect(parsed.role).toBe("Build the home page");
     expect(parsed.workspace).toBe("/tmp/base");
   });

--- a/bin/pneuma-cli-helpers.ts
+++ b/bin/pneuma-cli-helpers.ts
@@ -27,6 +27,7 @@ export interface ParsedCliArgs {
   workspace: string;
   projectRoot: string;
   projectSessionId: string;
+  handoffId: string;
   role: string;
   port: number;
   backendType: AgentBackendType;
@@ -68,6 +69,7 @@ export function parseCliArgs(argv: string[], cwd = process.cwd()): ParsedCliArgs
   let workspace = cwd;
   let projectRoot = "";
   let projectSessionId = "";
+  let handoffId = "";
   let role = "";
   let port = 0;
   let backendType: AgentBackendType = getDefaultBackendType();
@@ -91,6 +93,8 @@ export function parseCliArgs(argv: string[], cwd = process.cwd()): ParsedCliArgs
       projectRoot = resolve(cwd, args[++i]);
     } else if (arg === "--project-session" && i + 1 < args.length) {
       projectSessionId = args[++i];
+    } else if (arg === "--handoff" && i + 1 < args.length) {
+      handoffId = args[++i];
     } else if (arg === "--role" && i + 1 < args.length) {
       role = args[++i];
     } else if (arg === "--port" && i + 1 < args.length) {
@@ -129,6 +133,7 @@ export function parseCliArgs(argv: string[], cwd = process.cwd()): ParsedCliArgs
     workspace: resolve(cwd, workspace),
     projectRoot,
     projectSessionId,
+    handoffId,
     role,
     port,
     backendType,

--- a/bin/pneuma-cli-helpers.ts
+++ b/bin/pneuma-cli-helpers.ts
@@ -26,6 +26,7 @@ export interface ParsedCliArgs {
   mode: string;
   workspace: string;
   projectRoot: string;
+  projectSessionId: string;
   role: string;
   port: number;
   backendType: AgentBackendType;
@@ -66,6 +67,7 @@ export function parseCliArgs(argv: string[], cwd = process.cwd()): ParsedCliArgs
   let mode = "";
   let workspace = cwd;
   let projectRoot = "";
+  let projectSessionId = "";
   let role = "";
   let port = 0;
   let backendType: AgentBackendType = getDefaultBackendType();
@@ -87,6 +89,8 @@ export function parseCliArgs(argv: string[], cwd = process.cwd()): ParsedCliArgs
       workspace = args[++i];
     } else if (arg === "--project" && i + 1 < args.length) {
       projectRoot = resolve(cwd, args[++i]);
+    } else if (arg === "--project-session" && i + 1 < args.length) {
+      projectSessionId = args[++i];
     } else if (arg === "--role" && i + 1 < args.length) {
       role = args[++i];
     } else if (arg === "--port" && i + 1 < args.length) {
@@ -124,6 +128,7 @@ export function parseCliArgs(argv: string[], cwd = process.cwd()): ParsedCliArgs
     mode,
     workspace: resolve(cwd, workspace),
     projectRoot,
+    projectSessionId,
     role,
     port,
     backendType,

--- a/bin/pneuma-cli-helpers.ts
+++ b/bin/pneuma-cli-helpers.ts
@@ -25,6 +25,8 @@ export interface SessionRecord {
 export interface ParsedCliArgs {
   mode: string;
   workspace: string;
+  projectRoot: string;
+  role: string;
   port: number;
   backendType: AgentBackendType;
   showHelp: boolean;
@@ -63,6 +65,8 @@ export function parseCliArgs(argv: string[], cwd = process.cwd()): ParsedCliArgs
   const args = argv.slice(2);
   let mode = "";
   let workspace = cwd;
+  let projectRoot = "";
+  let role = "";
   let port = 0;
   let backendType: AgentBackendType = getDefaultBackendType();
   let showHelp = false;
@@ -81,6 +85,10 @@ export function parseCliArgs(argv: string[], cwd = process.cwd()): ParsedCliArgs
     const arg = args[i];
     if (arg === "--workspace" && i + 1 < args.length) {
       workspace = args[++i];
+    } else if (arg === "--project" && i + 1 < args.length) {
+      projectRoot = resolve(cwd, args[++i]);
+    } else if (arg === "--role" && i + 1 < args.length) {
+      role = args[++i];
     } else if (arg === "--port" && i + 1 < args.length) {
       port = Number(args[++i]);
     } else if (arg === "--backend" && i + 1 < args.length) {
@@ -115,6 +123,8 @@ export function parseCliArgs(argv: string[], cwd = process.cwd()): ParsedCliArgs
   return {
     mode,
     workspace: resolve(cwd, workspace),
+    projectRoot,
+    role,
     port,
     backendType,
     showHelp,

--- a/bin/pneuma.ts
+++ b/bin/pneuma.ts
@@ -732,6 +732,8 @@ Modes:
 
 Options:
   --workspace <path>           Target workspace directory (default: cwd)
+  --project <path>             Launch inside an explicit Pneuma project root
+  --role <text>                Describe this session's role within the project
   --port <number>              Preferred server port
   --backend <type>             Agent backend to launch (default: claude-code)
   --no-open                    Don't auto-open the browser
@@ -1093,7 +1095,7 @@ Options:
     return;
   }
 
-  const { mode, port, backendType, noOpen, debug, forceDev, noPrompt, skipSkill, replaySource, sessionName, viewing } = parsedArgs;
+  const { mode, port, backendType, noOpen, debug, forceDev, noPrompt, skipSkill, replaySource, sessionName, viewing, projectRoot, role } = parsedArgs;
   let { workspace, replayPackage } = parsedArgs;
 
   // Launcher mode — no mode arg → start marketplace UI
@@ -1250,6 +1252,25 @@ Options:
       );
       process.exit(1);
     }
+  }
+
+  let activeProjectRoot = "";
+  let projectSessionId = "";
+
+  if (projectRoot) {
+    const { resolveProjectRuntime } = await import("../core/project.js");
+    const runtime = resolveProjectRuntime({
+      projectRoot,
+      mode: modeName,
+      displayName: manifest.displayName,
+      backendType,
+      role,
+    });
+    activeProjectRoot = runtime.projectRoot;
+    projectSessionId = runtime.session.sessionId;
+    workspace = runtime.workspace;
+    p.log.info(`Project: ${runtime.project.name} (${activeProjectRoot})`);
+    p.log.info(`Project session: ${projectSessionId}`);
   }
 
   if (!existsSync(workspace)) {

--- a/bin/pneuma.ts
+++ b/bin/pneuma.ts
@@ -1097,7 +1097,7 @@ Options:
     return;
   }
 
-  const { mode, port, backendType, noOpen, debug, forceDev, noPrompt, skipSkill, replaySource, sessionName, viewing, projectRoot, projectSessionId: requestedProjectSessionId, role } = parsedArgs;
+  const { mode, port, backendType, noOpen, debug, forceDev, noPrompt, skipSkill, replaySource, sessionName, viewing, projectRoot, projectSessionId: requestedProjectSessionId, handoffId, role } = parsedArgs;
   let { workspace, replayPackage } = parsedArgs;
 
   // Launcher mode — no mode arg → start marketplace UI
@@ -1268,6 +1268,7 @@ Options:
       displayName: manifest.displayName,
       backendType,
       sessionId: requestedProjectSessionId || undefined,
+      handoffId: handoffId || undefined,
       role,
     });
     activeProjectRoot = runtime.projectRoot;

--- a/bin/pneuma.ts
+++ b/bin/pneuma.ts
@@ -20,6 +20,7 @@ import { initShadowGit } from "../server/shadow-git.js";
 import { loadModeManifest, listBuiltinModes, registerExternalMode } from "../core/mode-loader.js";
 import type { ModeManifest } from "../core/types/mode-manifest.js";
 import type { AgentBackendType } from "../core/types/agent-backend.js";
+import type { ProjectInstructionContext } from "../core/project.js";
 import { applyTemplateParams } from "../server/skill-installer.js";
 import { resolveMode as resolveModeSource, isExternalMode } from "../core/mode-resolver.js";
 import type { ResolvedMode } from "../core/mode-resolver.js";
@@ -1257,9 +1258,10 @@ Options:
 
   let activeProjectRoot = "";
   let projectSessionId = "";
+  let projectInstructionContext: ProjectInstructionContext | undefined;
 
   if (projectRoot) {
-    const { resolveProjectRuntime } = await import("../core/project.js");
+    const { buildProjectInstructionContext, resolveProjectRuntime } = await import("../core/project.js");
     const runtime = resolveProjectRuntime({
       projectRoot,
       mode: modeName,
@@ -1270,6 +1272,7 @@ Options:
     });
     activeProjectRoot = runtime.projectRoot;
     projectSessionId = runtime.session.sessionId;
+    projectInstructionContext = buildProjectInstructionContext(runtime);
     workspace = runtime.workspace;
     p.log.info(`Project: ${runtime.project.name} (${activeProjectRoot})`);
     p.log.info(`Project session: ${projectSessionId}`);
@@ -1383,7 +1386,9 @@ Options:
     }
 
     p.log.step("Installing skill and preparing environment...");
-    installSkill(workspace, manifest.skill, modeSourceDir, resolvedParams, manifest.viewerApi, backendType, manifest.proxy);
+    installSkill(workspace, manifest.skill, modeSourceDir, resolvedParams, manifest.viewerApi, backendType, manifest.proxy, {
+      projectContext: projectInstructionContext,
+    });
     // Record installed skill version for update detection
     const skillVersionPath = join(workspace, ".pneuma", "skill-version.json");
     mkdirSync(join(workspace, ".pneuma"), { recursive: true });
@@ -1616,6 +1621,7 @@ Options:
     editing: initialEditing,
     editingSupported: !!manifest.editing?.supported,
     backendType,
+    projectInstructionContext,
   });
 
   // 4. Launch Agent backend or set up replay mode
@@ -1659,7 +1665,9 @@ Options:
       }
 
       p.log.step("Continue Work: installing skill...");
-      installSkill(workspace, manifest.skill, modeSourceDir, resolvedParams, manifest.viewerApi, backendType, manifest.proxy);
+      installSkill(workspace, manifest.skill, modeSourceDir, resolvedParams, manifest.viewerApi, backendType, manifest.proxy, {
+        projectContext: projectInstructionContext,
+      });
 
       // Record installed skill version
       const skillVersionPath = join(workspace, ".pneuma", "skill-version.json");
@@ -1868,7 +1876,9 @@ Options:
       // Register launch callback for viewing → edit switching
       onEditingLaunch!(async () => {
         p.log.step("Switching to edit mode: installing skill and launching agent...");
-        installSkill(workspace, manifest.skill, modeSourceDir, resolvedParams, manifest.viewerApi, sessionBackendType, manifest.proxy);
+        installSkill(workspace, manifest.skill, modeSourceDir, resolvedParams, manifest.viewerApi, sessionBackendType, manifest.proxy, {
+          projectContext: projectInstructionContext,
+        });
         const skillVersionPath = join(workspace, ".pneuma", "skill-version.json");
         writeFileSync(skillVersionPath, JSON.stringify({ mode: modeName, version: manifest.version }));
 
@@ -1971,7 +1981,9 @@ Options:
         // Register launch callback for subsequent viewing → edit switch
         onEditingLaunch!(async () => {
           p.log.step("Switching to edit mode: installing skill and launching agent...");
-          installSkill(workspace, manifest.skill, modeSourceDir, resolvedParams, manifest.viewerApi, sessionBackendType, manifest.proxy);
+          installSkill(workspace, manifest.skill, modeSourceDir, resolvedParams, manifest.viewerApi, sessionBackendType, manifest.proxy, {
+            projectContext: projectInstructionContext,
+          });
 
           backend = createBackend(sessionBackendType, actualPort);
           wireCLISessionId();

--- a/bin/pneuma.ts
+++ b/bin/pneuma.ts
@@ -733,6 +733,7 @@ Modes:
 Options:
   --workspace <path>           Target workspace directory (default: cwd)
   --project <path>             Launch inside an explicit Pneuma project root
+  --project-session <id>       Resume an existing project session inside --project
   --role <text>                Describe this session's role within the project
   --port <number>              Preferred server port
   --backend <type>             Agent backend to launch (default: claude-code)
@@ -1095,7 +1096,7 @@ Options:
     return;
   }
 
-  const { mode, port, backendType, noOpen, debug, forceDev, noPrompt, skipSkill, replaySource, sessionName, viewing, projectRoot, role } = parsedArgs;
+  const { mode, port, backendType, noOpen, debug, forceDev, noPrompt, skipSkill, replaySource, sessionName, viewing, projectRoot, projectSessionId: requestedProjectSessionId, role } = parsedArgs;
   let { workspace, replayPackage } = parsedArgs;
 
   // Launcher mode — no mode arg → start marketplace UI
@@ -1264,6 +1265,7 @@ Options:
       mode: modeName,
       displayName: manifest.displayName,
       backendType,
+      sessionId: requestedProjectSessionId || undefined,
       role,
     });
     activeProjectRoot = runtime.projectRoot;
@@ -1718,7 +1720,9 @@ Options:
         backendType,
         createdAt: Date.now(),
       });
-      recordSession(modeName, manifest.displayName, workspace, backendType, sessionName || undefined);
+      if (!activeProjectRoot) {
+        recordSession(modeName, manifest.displayName, workspace, backendType, sessionName || undefined);
+      }
 
       // Start file watcher
       startFileWatcher(workspace, manifest.viewer, (files) => {
@@ -1844,7 +1848,9 @@ Options:
         createdAt: existing?.createdAt || Date.now(),
         editing: false,
       });
-      recordSession(modeName, manifest.displayName, workspace, sessionBackendType, sessionName || undefined, false);
+      if (!activeProjectRoot) {
+        recordSession(modeName, manifest.displayName, workspace, sessionBackendType, sessionName || undefined, false);
+      }
 
       // Load persisted message history
       const savedHistory = loadHistory(workspace);
@@ -1927,7 +1933,9 @@ Options:
         createdAt: existing?.createdAt || Date.now(),
         editing: true,
       });
-      recordSession(modeName, manifest.displayName, workspace, sessionBackendType, sessionName || undefined, true);
+      if (!activeProjectRoot) {
+        recordSession(modeName, manifest.displayName, workspace, sessionBackendType, sessionName || undefined, true);
+      }
 
       p.log.info(`Agent session: ${session.sessionId}`);
       wsBridge.getOrCreateSession(session.sessionId, sessionBackendType);

--- a/core/__tests__/project.test.ts
+++ b/core/__tests__/project.test.ts
@@ -6,6 +6,7 @@ import {
   createProject,
   createProjectSession,
   listProjectSessions,
+  loadProjectSession,
   loadProject,
   loadRecentProjects,
   projectManifestPath,
@@ -192,5 +193,36 @@ describe("project runtime", () => {
     expect(runtime.session.sessionId).toBe("web-runtime");
     expect(runtime.workspace).toBe(join(root, ".pneuma", "sessions", "web-runtime", "workspace"));
     expect(runtime.projectRoot).toBe(root);
+  });
+
+  test("resolveProjectRuntime resumes an existing project session when sessionId is provided", () => {
+    createProject(root, {
+      name: "Resume Project",
+      now: () => "2026-04-28T00:00:00.000Z",
+      idFactory: () => "project_resume",
+    });
+    createProjectSession(root, {
+      mode: "doc",
+      displayName: "Doc",
+      backendType: "codex",
+      role: "Draft copy",
+      now: () => "2026-04-28T01:00:00.000Z",
+      idFactory: () => "doc-existing",
+    });
+
+    const runtime = resolveProjectRuntime({
+      projectRoot: root,
+      mode: "doc",
+      displayName: "Doc",
+      backendType: "codex",
+      sessionId: "doc-existing",
+      now: () => "2026-04-28T06:00:00.000Z",
+    });
+
+    expect(runtime.session.sessionId).toBe("doc-existing");
+    expect(runtime.session.role).toBe("Draft copy");
+    expect(runtime.workspace).toBe(projectSessionWorkspace(root, "doc-existing"));
+    expect(listProjectSessions(root)).toHaveLength(1);
+    expect(loadProjectSession(root, "doc-existing")?.lastAccessed).toBe("2026-04-28T06:00:00.000Z");
   });
 });

--- a/core/__tests__/project.test.ts
+++ b/core/__tests__/project.test.ts
@@ -1,0 +1,196 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  createProject,
+  createProjectSession,
+  listProjectSessions,
+  loadProject,
+  loadRecentProjects,
+  projectManifestPath,
+  projectPneumaDir,
+  projectSessionDir,
+  projectSessionWorkspace,
+  recentProjectsRegistryPath,
+  recordRecentProject,
+  resolveProjectRuntime,
+} from "../project.js";
+
+describe("project manifest", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = join(tmpdir(), `pneuma-project-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(root, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test("createProject writes project.json and project-preferences.md", () => {
+    const project = createProject(root, {
+      name: "Launch Site",
+      description: "Marketing site for Pneuma",
+      now: () => "2026-04-28T00:00:00.000Z",
+      idFactory: () => "project_123",
+    });
+
+    expect(project.projectId).toBe("project_123");
+    expect(project.name).toBe("Launch Site");
+    expect(project.root).toBe(root);
+    expect(existsSync(projectManifestPath(root))).toBe(true);
+    expect(existsSync(join(projectPneumaDir(root), "project-preferences.md"))).toBe(true);
+
+    const loaded = loadProject(root);
+    expect(loaded?.description).toBe("Marketing site for Pneuma");
+  });
+
+  test("createProject derives a readable name from the directory when name is omitted", () => {
+    const project = createProject(root, {
+      now: () => "2026-04-28T00:00:00.000Z",
+      idFactory: () => "project_derived",
+    });
+
+    expect(project.name).toBe(root.split("/").pop());
+  });
+
+  test("loadProject returns null when project.json is absent", () => {
+    expect(loadProject(root)).toBeNull();
+  });
+});
+
+describe("project sessions", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = join(tmpdir(), `pneuma-project-session-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(root, { recursive: true });
+    createProject(root, {
+      name: "Session Project",
+      now: () => "2026-04-28T00:00:00.000Z",
+      idFactory: () => "project_sessions",
+    });
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test("createProjectSession creates session.json, workspace, and scratch", () => {
+    const session = createProjectSession(root, {
+      mode: "webcraft",
+      displayName: "Webcraft",
+      backendType: "claude-code",
+      role: "Build the landing page",
+      now: () => "2026-04-28T01:00:00.000Z",
+      idFactory: () => "webcraft-abc",
+    });
+
+    expect(session.sessionId).toBe("webcraft-abc");
+    expect(session.projectId).toBe("project_sessions");
+    expect(session.sessionWorkspace).toBe(projectSessionWorkspace(root, "webcraft-abc"));
+    expect(existsSync(join(projectSessionDir(root, "webcraft-abc"), "session.json"))).toBe(true);
+    expect(existsSync(projectSessionWorkspace(root, "webcraft-abc"))).toBe(true);
+    expect(existsSync(join(projectSessionDir(root, "webcraft-abc"), "scratch"))).toBe(true);
+  });
+
+  test("listProjectSessions returns sessions sorted by lastAccessed descending", () => {
+    createProjectSession(root, {
+      mode: "doc",
+      displayName: "Doc",
+      backendType: "claude-code",
+      now: () => "2026-04-28T01:00:00.000Z",
+      idFactory: () => "doc-old",
+    });
+    createProjectSession(root, {
+      mode: "webcraft",
+      displayName: "Webcraft",
+      backendType: "codex",
+      now: () => "2026-04-28T02:00:00.000Z",
+      idFactory: () => "web-new",
+    });
+
+    expect(listProjectSessions(root).map((s) => s.sessionId)).toEqual(["web-new", "doc-old"]);
+  });
+});
+
+describe("recent project registry", () => {
+  let home: string;
+  let root: string;
+
+  beforeEach(() => {
+    home = join(tmpdir(), `pneuma-project-home-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    root = join(tmpdir(), `pneuma-project-registry-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(home, { recursive: true });
+    mkdirSync(root, { recursive: true });
+    createProject(root, {
+      name: "Registry Project",
+      now: () => "2026-04-28T00:00:00.000Z",
+      idFactory: () => "project_registry",
+    });
+  });
+
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test("recordRecentProject writes ~/.pneuma/projects.json style records", () => {
+    recordRecentProject(root, {
+      homeDir: home,
+      now: () => "2026-04-28T03:00:00.000Z",
+    });
+
+    expect(existsSync(recentProjectsRegistryPath(home))).toBe(true);
+    const records = loadRecentProjects(home);
+    expect(records).toHaveLength(1);
+    expect(records[0]).toMatchObject({
+      projectId: "project_registry",
+      name: "Registry Project",
+      root,
+      lastAccessed: "2026-04-28T03:00:00.000Z",
+    });
+  });
+
+  test("recordRecentProject de-duplicates by projectId and keeps newest first", () => {
+    recordRecentProject(root, { homeDir: home, now: () => "2026-04-28T03:00:00.000Z" });
+    recordRecentProject(root, { homeDir: home, now: () => "2026-04-28T04:00:00.000Z" });
+
+    const records = loadRecentProjects(home);
+    expect(records).toHaveLength(1);
+    expect(records[0].lastAccessed).toBe("2026-04-28T04:00:00.000Z");
+  });
+});
+
+describe("project runtime", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = join(tmpdir(), `pneuma-project-runtime-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(root, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test("resolveProjectRuntime creates a project session workspace", () => {
+    const runtime = resolveProjectRuntime({
+      projectRoot: root,
+      mode: "webcraft",
+      displayName: "Webcraft",
+      backendType: "claude-code",
+      role: "Build the hero section",
+      now: () => "2026-04-28T05:00:00.000Z",
+      projectIdFactory: () => "project_runtime",
+      sessionIdFactory: () => "web-runtime",
+    });
+
+    expect(runtime.project.projectId).toBe("project_runtime");
+    expect(runtime.session.sessionId).toBe("web-runtime");
+    expect(runtime.workspace).toBe(join(root, ".pneuma", "sessions", "web-runtime", "workspace"));
+    expect(runtime.projectRoot).toBe(root);
+  });
+});

--- a/core/__tests__/project.test.ts
+++ b/core/__tests__/project.test.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
+  buildProjectInstructionContext,
   createProject,
   createProjectSession,
   listProjectSessions,
@@ -224,5 +225,70 @@ describe("project runtime", () => {
     expect(runtime.workspace).toBe(projectSessionWorkspace(root, "doc-existing"));
     expect(listProjectSessions(root)).toHaveLength(1);
     expect(loadProjectSession(root, "doc-existing")?.lastAccessed).toBe("2026-04-28T06:00:00.000Z");
+  });
+});
+
+describe("project instruction context", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = join(tmpdir(), `pneuma-project-context-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(root, { recursive: true });
+    createProject(root, {
+      name: "Context Project",
+      description: "Cross-mode project",
+      now: () => "2026-04-28T00:00:00.000Z",
+      idFactory: () => "project_context",
+    });
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test("buildProjectInstructionContext summarizes project identity and peer sessions without workspace paths", () => {
+    createProjectSession(root, {
+      mode: "doc",
+      displayName: "Doc",
+      backendType: "claude-code",
+      role: "Draft the copy",
+      now: () => "2026-04-28T01:00:00.000Z",
+      idFactory: () => "doc-peer",
+    });
+    const runtime = resolveProjectRuntime({
+      projectRoot: root,
+      mode: "webcraft",
+      displayName: "Webcraft",
+      backendType: "codex",
+      role: "Build the page",
+      now: () => "2026-04-28T02:00:00.000Z",
+      sessionIdFactory: () => "web-current",
+    });
+
+    const context = buildProjectInstructionContext(runtime);
+
+    expect(context).toMatchObject({
+      projectId: "project_context",
+      projectName: "Context Project",
+      projectRoot: root,
+      description: "Cross-mode project",
+      role: "Build the page",
+      currentSessionId: "web-current",
+      currentMode: "webcraft",
+      currentSessionDisplayName: "Webcraft",
+    });
+    expect(context.peerSessions).toEqual([
+      {
+        sessionId: "doc-peer",
+        mode: "doc",
+        displayName: "Doc",
+        role: "Draft the copy",
+        backendType: "claude-code",
+        status: "active",
+        lastAccessed: "2026-04-28T01:00:00.000Z",
+      },
+    ]);
+    expect(JSON.stringify(context)).not.toContain("sessionWorkspace");
+    expect(JSON.stringify(context)).not.toContain(projectSessionWorkspace(root, "doc-peer"));
   });
 });

--- a/core/__tests__/project.test.ts
+++ b/core/__tests__/project.test.ts
@@ -1,15 +1,18 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
   buildProjectInstructionContext,
+  confirmProjectHandoff,
   createProject,
+  createProjectHandoffDraft,
   createProjectSession,
   listProjectSessions,
   loadProjectSession,
   loadProject,
   loadRecentProjects,
+  projectHandoffPath,
   projectManifestPath,
   projectPneumaDir,
   projectSessionDir,
@@ -17,6 +20,8 @@ import {
   recentProjectsRegistryPath,
   recordRecentProject,
   resolveProjectRuntime,
+  runProjectEvolution,
+  upgradeQuickSessionToProject,
 } from "../project.js";
 
 describe("project manifest", () => {
@@ -290,5 +295,264 @@ describe("project instruction context", () => {
     ]);
     expect(JSON.stringify(context)).not.toContain("sessionWorkspace");
     expect(JSON.stringify(context)).not.toContain(projectSessionWorkspace(root, "doc-peer"));
+  });
+});
+
+describe("project handoffs", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = join(tmpdir(), `pneuma-project-handoff-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(root, { recursive: true });
+    createProject(root, {
+      name: "Handoff Project",
+      now: () => "2026-04-28T00:00:00.000Z",
+      idFactory: () => "project_handoff",
+    });
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test("createProjectHandoffDraft creates a reviewable draft without raw source session history", () => {
+    createProjectSession(root, {
+      mode: "webcraft",
+      displayName: "Webcraft",
+      backendType: "codex",
+      role: "Build the landing page",
+      now: () => "2026-04-28T01:00:00.000Z",
+      idFactory: () => "web-source",
+    });
+    mkdirSync(join(projectSessionWorkspace(root, "web-source"), ".pneuma"), { recursive: true });
+    writeFileSync(join(projectSessionWorkspace(root, "web-source"), ".pneuma", "history.json"), "raw-history-secret");
+
+    const draft = createProjectHandoffDraft(root, {
+      fromSessionId: "web-source",
+      toMode: "doc",
+      goal: "Turn the landing page decisions into launch copy.",
+      now: () => "2026-04-28T02:00:00.000Z",
+      idFactory: () => "handoff-1",
+    });
+
+    expect(draft.handoffId).toBe("handoff-1");
+    expect(draft.content).toContain("handoffId: handoff-1");
+    expect(draft.content).toContain("fromSessionId: web-source");
+    expect(draft.content).toContain("fromMode: webcraft");
+    expect(draft.content).toContain("toMode: doc");
+    expect(draft.content).toContain("## Goal");
+    expect(draft.content).toContain("## Decisions");
+    expect(draft.content).toContain("## Constraints");
+    expect(draft.content).toContain("## Relevant Files");
+    expect(draft.content).toContain("## Open Questions");
+    expect(draft.content).toContain("## Suggested Next Step");
+    expect(draft.content).toContain("Turn the landing page decisions into launch copy.");
+    expect(draft.content).not.toContain("raw-history-secret");
+    expect(draft.content).not.toContain(projectSessionWorkspace(root, "web-source"));
+  });
+
+  test("confirmProjectHandoff writes a confirmed handoff and startup context can include it", () => {
+    createProjectSession(root, {
+      mode: "webcraft",
+      displayName: "Webcraft",
+      backendType: "codex",
+      now: () => "2026-04-28T01:00:00.000Z",
+      idFactory: () => "web-source",
+    });
+    createProjectSession(root, {
+      mode: "doc",
+      displayName: "Doc",
+      backendType: "codex",
+      now: () => "2026-04-28T02:00:00.000Z",
+      idFactory: () => "doc-target",
+    });
+    const draft = createProjectHandoffDraft(root, {
+      fromSessionId: "web-source",
+      toMode: "doc",
+      now: () => "2026-04-28T03:00:00.000Z",
+      idFactory: () => "handoff-2",
+    });
+
+    const handoff = confirmProjectHandoff(root, {
+      handoffId: draft.handoffId,
+      content: `${draft.content}\nReviewed context only.\n`,
+      toSessionId: "doc-target",
+      now: () => "2026-04-28T04:00:00.000Z",
+    });
+    const written = readFileSync(projectHandoffPath(root, "handoff-2"), "utf-8");
+
+    expect(handoff.toSessionId).toBe("doc-target");
+    expect(written).toContain("toSessionId: doc-target");
+    expect(written).toContain("confirmedAt: 2026-04-28T04:00:00.000Z");
+    expect(written).toContain("Reviewed context only.");
+
+    const runtime = resolveProjectRuntime({
+      projectRoot: root,
+      mode: "doc",
+      displayName: "Doc",
+      backendType: "codex",
+      sessionId: "doc-target",
+      handoffId: "handoff-2",
+      now: () => "2026-04-28T05:00:00.000Z",
+    });
+    const context = buildProjectInstructionContext(runtime);
+
+    expect(context.handoff).toMatchObject({
+      handoffId: "handoff-2",
+      fromSessionId: "web-source",
+      toSessionId: "doc-target",
+      fromMode: "webcraft",
+      toMode: "doc",
+    });
+    expect(context.handoff?.content).toContain("Reviewed context only.");
+    expect(readFileSync(join(root, ".pneuma", "timeline.jsonl"), "utf-8")).toContain("handoff.created");
+  });
+});
+
+describe("quick session upgrade", () => {
+  let sourceWorkspace: string;
+  let projectRoot: string;
+
+  beforeEach(() => {
+    sourceWorkspace = join(tmpdir(), `pneuma-quick-source-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    projectRoot = join(tmpdir(), `pneuma-upgraded-project-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(join(sourceWorkspace, ".pneuma"), { recursive: true });
+    writeFileSync(join(sourceWorkspace, ".pneuma", "session.json"), JSON.stringify({
+      sessionId: "quick-123",
+      mode: "doc",
+      backendType: "codex",
+      createdAt: 123,
+    }, null, 2));
+    writeFileSync(join(sourceWorkspace, ".pneuma", "history.json"), JSON.stringify([{ role: "user", content: "source history" }]));
+    writeFileSync(join(sourceWorkspace, ".pneuma", "config.json"), JSON.stringify({ topic: "launch" }));
+    writeFileSync(join(sourceWorkspace, "brief.md"), "# Quick Brief\n");
+  });
+
+  afterEach(() => {
+    rmSync(sourceWorkspace, { recursive: true, force: true });
+    rmSync(projectRoot, { recursive: true, force: true });
+  });
+
+  test("upgradeQuickSessionToProject forks a quick session into a project without mutating the source", () => {
+    const result = upgradeQuickSessionToProject(sourceWorkspace, projectRoot, {
+      name: "Upgraded Project",
+      description: "Long-running project",
+      displayName: "Doc",
+      copyDeliverables: true,
+      now: () => "2026-04-28T06:00:00.000Z",
+      projectIdFactory: () => "project_upgrade",
+      sessionIdFactory: () => "doc-upgraded",
+    });
+
+    expect(result.project.projectId).toBe("project_upgrade");
+    expect(result.session.sessionId).toBe("doc-upgraded");
+    expect(result.session.sourceQuickSessionId).toBe("quick-123");
+    expect(existsSync(join(sourceWorkspace, ".pneuma", "session.json"))).toBe(true);
+    expect(readFileSync(join(sourceWorkspace, "brief.md"), "utf-8")).toBe("# Quick Brief\n");
+    expect(readFileSync(join(projectRoot, "brief.md"), "utf-8")).toBe("# Quick Brief\n");
+    expect(readFileSync(join(projectSessionWorkspace(projectRoot, "doc-upgraded"), ".pneuma", "history.json"), "utf-8")).toContain("source history");
+    expect(readFileSync(join(projectSessionWorkspace(projectRoot, "doc-upgraded"), ".pneuma", "config.json"), "utf-8")).toContain("launch");
+    expect(readFileSync(join(projectRoot, ".pneuma", "timeline.jsonl"), "utf-8")).toContain("session.upgraded");
+  });
+
+  test("upgradeQuickSessionToProject can leave deliverables in place", () => {
+    upgradeQuickSessionToProject(sourceWorkspace, projectRoot, {
+      name: "Metadata Only Project",
+      displayName: "Doc",
+      copyDeliverables: false,
+      now: () => "2026-04-28T07:00:00.000Z",
+      projectIdFactory: () => "project_metadata_only",
+      sessionIdFactory: () => "doc-metadata-only",
+    });
+
+    expect(existsSync(join(projectRoot, "brief.md"))).toBe(false);
+    expect(existsSync(join(sourceWorkspace, "brief.md"))).toBe(true);
+  });
+
+  test("upgradeQuickSessionToProject refuses to overwrite existing project deliverables", () => {
+    mkdirSync(projectRoot, { recursive: true });
+    writeFileSync(join(projectRoot, "brief.md"), "# Existing Project Brief\n");
+
+    expect(() => upgradeQuickSessionToProject(sourceWorkspace, projectRoot, {
+      name: "Collision Project",
+      displayName: "Doc",
+      copyDeliverables: true,
+      now: () => "2026-04-28T07:30:00.000Z",
+      projectIdFactory: () => "project_collision",
+      sessionIdFactory: () => "doc-collision",
+    })).toThrow("Refusing to overwrite existing project deliverable");
+
+    expect(readFileSync(join(projectRoot, "brief.md"), "utf-8")).toBe("# Existing Project Brief\n");
+    expect(readFileSync(join(sourceWorkspace, "brief.md"), "utf-8")).toBe("# Quick Brief\n");
+  });
+});
+
+describe("project evolution", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = join(tmpdir(), `pneuma-project-evolve-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(root, { recursive: true });
+    createProject(root, {
+      name: "Evolution Project",
+      description: "Project-scoped learning",
+      now: () => "2026-04-28T00:00:00.000Z",
+      idFactory: () => "project_evolve",
+    });
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test("runProjectEvolution scans project evidence and writes only project preferences", () => {
+    createProjectSession(root, {
+      mode: "webcraft",
+      displayName: "Webcraft",
+      backendType: "codex",
+      role: "Build the site",
+      now: () => "2026-04-28T01:00:00.000Z",
+      idFactory: () => "web-evolve",
+    });
+    createProjectSession(root, {
+      mode: "doc",
+      displayName: "Doc",
+      backendType: "codex",
+      role: "Draft copy",
+      now: () => "2026-04-28T02:00:00.000Z",
+      idFactory: () => "doc-evolve",
+    });
+    const draft = createProjectHandoffDraft(root, {
+      fromSessionId: "web-evolve",
+      toMode: "doc",
+      now: () => "2026-04-28T03:00:00.000Z",
+      idFactory: () => "handoff-evolve",
+    });
+    confirmProjectHandoff(root, {
+      handoffId: draft.handoffId,
+      content: `${draft.content}\nKeep the tone concise.\n`,
+      toSessionId: "doc-evolve",
+      now: () => "2026-04-28T04:00:00.000Z",
+    });
+    writeFileSync(join(root, "index.html"), "<main>Launch</main>\n");
+    const before = readFileSync(join(root, ".pneuma", "project-preferences.md"), "utf-8");
+
+    const result = runProjectEvolution(root, {
+      now: () => "2026-04-28T08:00:00.000Z",
+    });
+    const after = readFileSync(join(root, ".pneuma", "project-preferences.md"), "utf-8");
+
+    expect(result.preferencesPath).toBe(join(root, ".pneuma", "project-preferences.md"));
+    expect(result.sourceSessionCount).toBe(2);
+    expect(result.handoffCount).toBe(1);
+    expect(result.deliverableCount).toBe(1);
+    expect(after).toContain(before);
+    expect(after).toContain("## Project Evolution - 2026-04-28T08:00:00.000Z");
+    expect(after).toContain("Sessions scanned: 2");
+    expect(after).toContain("Handoffs scanned: 1");
+    expect(after).toContain("Deliverables summarized: 1");
+    expect(after).toContain("webcraft");
+    expect(after).toContain("index.html");
+    expect(readFileSync(join(root, ".pneuma", "timeline.jsonl"), "utf-8")).toContain("project.evolved");
   });
 });

--- a/core/__tests__/project.test.ts
+++ b/core/__tests__/project.test.ts
@@ -459,7 +459,7 @@ describe("quick session upgrade", () => {
     upgradeQuickSessionToProject(sourceWorkspace, projectRoot, {
       name: "Metadata Only Project",
       displayName: "Doc",
-      copyDeliverables: false,
+      deliverableTransfer: "none",
       now: () => "2026-04-28T07:00:00.000Z",
       projectIdFactory: () => "project_metadata_only",
       sessionIdFactory: () => "doc-metadata-only",
@@ -467,6 +467,21 @@ describe("quick session upgrade", () => {
 
     expect(existsSync(join(projectRoot, "brief.md"))).toBe(false);
     expect(existsSync(join(sourceWorkspace, "brief.md"))).toBe(true);
+  });
+
+  test("upgradeQuickSessionToProject can move deliverables into the project root", () => {
+    upgradeQuickSessionToProject(sourceWorkspace, projectRoot, {
+      name: "Moved Project",
+      displayName: "Doc",
+      deliverableTransfer: "move",
+      now: () => "2026-04-28T07:15:00.000Z",
+      projectIdFactory: () => "project_moved",
+      sessionIdFactory: () => "doc-moved",
+    });
+
+    expect(readFileSync(join(projectRoot, "brief.md"), "utf-8")).toBe("# Quick Brief\n");
+    expect(existsSync(join(sourceWorkspace, "brief.md"))).toBe(false);
+    expect(existsSync(join(sourceWorkspace, ".pneuma", "session.json"))).toBe(true);
   });
 
   test("upgradeQuickSessionToProject refuses to overwrite existing project deliverables", () => {

--- a/core/project.ts
+++ b/core/project.ts
@@ -1,4 +1,4 @@
-import { cpSync, existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import { cpSync, existsSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { basename, dirname, join, resolve, sep } from "node:path";
 import { homedir } from "node:os";
 
@@ -72,6 +72,8 @@ export interface ConfirmProjectHandoffOptions {
   now?: () => string;
 }
 
+export type QuickDeliverableTransfer = "copy" | "move" | "none";
+
 export interface UpgradeQuickSessionToProjectOptions {
   name?: string;
   description?: string;
@@ -79,6 +81,7 @@ export interface UpgradeQuickSessionToProjectOptions {
   displayName?: string;
   backendType?: ProjectBackendType;
   role?: string;
+  deliverableTransfer?: QuickDeliverableTransfer;
   copyDeliverables?: boolean;
   now?: () => string;
   projectIdFactory?: () => string;
@@ -581,7 +584,13 @@ function copyQuickSessionState(sourceWorkspace: string, targetWorkspace: string)
   }
 }
 
-function copyQuickDeliverables(sourceWorkspace: string, projectRoot: string): void {
+function resolveQuickDeliverableTransfer(options: UpgradeQuickSessionToProjectOptions): QuickDeliverableTransfer {
+  if (options.deliverableTransfer) return options.deliverableTransfer;
+  return options.copyDeliverables === false ? "none" : "copy";
+}
+
+function transferQuickDeliverables(sourceWorkspace: string, projectRoot: string, transfer: QuickDeliverableTransfer): void {
+  if (transfer === "none") return;
   const source = resolve(sourceWorkspace);
   const target = resolve(projectRoot);
   if (source === target) return;
@@ -592,10 +601,14 @@ function copyQuickDeliverables(sourceWorkspace: string, projectRoot: string): vo
     const src = join(source, entry.name);
     const dst = join(target, entry.name);
     cpSync(src, dst, { recursive: entry.isDirectory(), force: true });
+    if (transfer === "move") {
+      rmSync(src, { recursive: entry.isDirectory(), force: true });
+    }
   }
 }
 
-function assertQuickDeliverableCopyIsNonDestructive(sourceWorkspace: string, projectRoot: string): void {
+function assertQuickDeliverableTransferIsNonDestructive(sourceWorkspace: string, projectRoot: string, transfer: QuickDeliverableTransfer): void {
+  if (transfer === "none") return;
   const source = resolve(sourceWorkspace);
   const target = resolve(projectRoot);
   if (source === target || !existsSync(target)) return;
@@ -618,9 +631,8 @@ export function upgradeQuickSessionToProject(
   const root = resolve(projectRoot);
   const quickSession = readQuickSessionMetadata(source);
   const now = options.now?.() ?? defaultNow();
-  if (options.copyDeliverables !== false) {
-    assertQuickDeliverableCopyIsNonDestructive(source, root);
-  }
+  const deliverableTransfer = resolveQuickDeliverableTransfer(options);
+  assertQuickDeliverableTransferIsNonDestructive(source, root, deliverableTransfer);
 
   const project = createProject(root, {
     name: options.name,
@@ -628,9 +640,7 @@ export function upgradeQuickSessionToProject(
     now: options.now,
     idFactory: options.projectIdFactory,
   });
-  if (options.copyDeliverables !== false) {
-    copyQuickDeliverables(source, root);
-  }
+  transferQuickDeliverables(source, root, deliverableTransfer);
 
   const created = createProjectSession(root, {
     mode: options.mode || quickSession.mode,

--- a/core/project.ts
+++ b/core/project.ts
@@ -1,0 +1,293 @@
+import { existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import { basename, join, resolve } from "node:path";
+import { homedir } from "node:os";
+
+export type ProjectBackendType = "claude-code" | "codex";
+
+export interface ProjectManifest {
+  schemaVersion: 1;
+  projectId: string;
+  name: string;
+  description?: string;
+  createdAt: string;
+  updatedAt: string;
+  root: string;
+  deliverablePaths?: string[];
+  defaultBackendType?: ProjectBackendType;
+}
+
+export interface CreateProjectOptions {
+  name?: string;
+  description?: string;
+  now?: () => string;
+  idFactory?: () => string;
+}
+
+export interface ProjectSessionManifest {
+  schemaVersion: 1;
+  sessionId: string;
+  projectId: string;
+  mode: string;
+  role?: string;
+  displayName: string;
+  backendType: ProjectBackendType;
+  status: "active" | "idle" | "archived";
+  createdAt: string;
+  lastAccessed: string;
+  sessionWorkspace: string;
+  deliverablePaths?: string[];
+  sourceQuickSessionId?: string;
+}
+
+export interface CreateProjectSessionOptions {
+  mode: string;
+  displayName: string;
+  backendType: ProjectBackendType;
+  role?: string;
+  now?: () => string;
+  idFactory?: () => string;
+}
+
+export interface RecentProjectRecord {
+  projectId: string;
+  name: string;
+  description?: string;
+  root: string;
+  lastAccessed: string;
+}
+
+export interface RecordRecentProjectOptions {
+  homeDir?: string;
+  now?: () => string;
+  limit?: number;
+}
+
+export interface ResolveProjectRuntimeOptions {
+  projectRoot: string;
+  mode: string;
+  displayName: string;
+  backendType: ProjectBackendType;
+  role?: string;
+  now?: () => string;
+  projectIdFactory?: () => string;
+  sessionIdFactory?: () => string;
+}
+
+export interface ProjectRuntime {
+  projectRoot: string;
+  workspace: string;
+  project: ProjectManifest;
+  session: ProjectSessionManifest;
+}
+
+export type ProjectTimelineEvent =
+  | { type: "project.created"; at: string; projectId: string; name: string }
+  | { type: "project.updated"; at: string; changes: Record<string, unknown> }
+  | { type: "session.created"; at: string; sessionId: string; mode: string; role?: string }
+  | { type: "session.resumed"; at: string; sessionId: string }
+  | { type: "deliverable.published"; at: string; sessionId: string; paths: string[] };
+
+export function projectPneumaDir(projectRoot: string): string {
+  return join(resolve(projectRoot), ".pneuma");
+}
+
+export function projectManifestPath(projectRoot: string): string {
+  return join(projectPneumaDir(projectRoot), "project.json");
+}
+
+export function projectPreferencesPath(projectRoot: string): string {
+  return join(projectPneumaDir(projectRoot), "project-preferences.md");
+}
+
+export function projectTimelinePath(projectRoot: string): string {
+  return join(projectPneumaDir(projectRoot), "timeline.jsonl");
+}
+
+export function projectSessionsDir(projectRoot: string): string {
+  return join(projectPneumaDir(projectRoot), "sessions");
+}
+
+export function projectSessionDir(projectRoot: string, sessionId: string): string {
+  return join(projectSessionsDir(projectRoot), sessionId);
+}
+
+export function projectSessionWorkspace(projectRoot: string, sessionId: string): string {
+  return join(projectSessionDir(projectRoot, sessionId), "workspace");
+}
+
+export function recentProjectsRegistryPath(homeDir = homedir()): string {
+  return join(homeDir, ".pneuma", "projects.json");
+}
+
+function defaultNow(): string {
+  return new Date().toISOString();
+}
+
+function defaultProjectId(): string {
+  return `project_${crypto.randomUUID()}`;
+}
+
+function defaultSessionId(mode: string): string {
+  const stamp = new Date().toISOString().replace(/[-:]/g, "").replace(/\.\d{3}Z$/, "Z");
+  return `${mode}-${stamp}-${crypto.randomUUID().slice(0, 8)}`;
+}
+
+export function loadProject(projectRoot: string): ProjectManifest | null {
+  const filePath = projectManifestPath(projectRoot);
+  if (!existsSync(filePath)) return null;
+
+  const parsed = JSON.parse(readFileSync(filePath, "utf-8")) as ProjectManifest;
+  if (parsed.schemaVersion !== 1 || !parsed.projectId || !parsed.name) {
+    throw new Error(`Invalid Pneuma project manifest: ${filePath}`);
+  }
+
+  return { ...parsed, root: resolve(projectRoot) };
+}
+
+export function appendProjectTimelineEvent(projectRoot: string, event: ProjectTimelineEvent): void {
+  mkdirSync(projectPneumaDir(projectRoot), { recursive: true });
+  writeFileSync(projectTimelinePath(projectRoot), `${JSON.stringify(event)}\n`, { flag: "a" });
+}
+
+export function createProject(projectRoot: string, options: CreateProjectOptions = {}): ProjectManifest {
+  const root = resolve(projectRoot);
+  const existing = loadProject(root);
+  if (existing) return existing;
+
+  const now = options.now?.() ?? defaultNow();
+  const manifest: ProjectManifest = {
+    schemaVersion: 1,
+    projectId: options.idFactory?.() ?? defaultProjectId(),
+    name: options.name?.trim() || basename(root),
+    ...(options.description?.trim() ? { description: options.description.trim() } : {}),
+    createdAt: now,
+    updatedAt: now,
+    root,
+  };
+
+  mkdirSync(projectPneumaDir(root), { recursive: true });
+  mkdirSync(projectSessionsDir(root), { recursive: true });
+  writeFileSync(projectManifestPath(root), JSON.stringify(manifest, null, 2));
+  if (!existsSync(projectPreferencesPath(root))) {
+    writeFileSync(projectPreferencesPath(root), "# Project Preferences\n\n");
+  }
+  appendProjectTimelineEvent(root, {
+    type: "project.created",
+    at: now,
+    projectId: manifest.projectId,
+    name: manifest.name,
+  });
+  return manifest;
+}
+
+export function createProjectSession(
+  projectRoot: string,
+  options: CreateProjectSessionOptions,
+): ProjectSessionManifest {
+  const project = createProject(projectRoot);
+  const now = options.now?.() ?? defaultNow();
+  const sessionId = options.idFactory?.() ?? defaultSessionId(options.mode);
+  const dir = projectSessionDir(projectRoot, sessionId);
+  const workspace = projectSessionWorkspace(projectRoot, sessionId);
+
+  mkdirSync(workspace, { recursive: true });
+  mkdirSync(join(dir, "scratch"), { recursive: true });
+
+  const session: ProjectSessionManifest = {
+    schemaVersion: 1,
+    sessionId,
+    projectId: project.projectId,
+    mode: options.mode,
+    ...(options.role?.trim() ? { role: options.role.trim() } : {}),
+    displayName: options.displayName,
+    backendType: options.backendType,
+    status: "active",
+    createdAt: now,
+    lastAccessed: now,
+    sessionWorkspace: workspace,
+  };
+
+  writeFileSync(join(dir, "session.json"), JSON.stringify(session, null, 2));
+  appendProjectTimelineEvent(projectRoot, {
+    type: "session.created",
+    at: now,
+    sessionId,
+    mode: options.mode,
+    ...(options.role?.trim() ? { role: options.role.trim() } : {}),
+  });
+  return session;
+}
+
+export function listProjectSessions(projectRoot: string): ProjectSessionManifest[] {
+  const dir = projectSessionsDir(projectRoot);
+  if (!existsSync(dir)) return [];
+
+  const sessions: ProjectSessionManifest[] = [];
+  for (const entry of readdirSync(dir)) {
+    const entryDir = join(dir, entry);
+    const filePath = join(entryDir, "session.json");
+    try {
+      if (!statSync(entryDir).isDirectory() || !existsSync(filePath)) continue;
+      sessions.push(JSON.parse(readFileSync(filePath, "utf-8")) as ProjectSessionManifest);
+    } catch {
+      continue;
+    }
+  }
+
+  return sessions.sort((a, b) => b.lastAccessed.localeCompare(a.lastAccessed));
+}
+
+export function loadRecentProjects(homeDir = homedir()): RecentProjectRecord[] {
+  try {
+    const records = JSON.parse(readFileSync(recentProjectsRegistryPath(homeDir), "utf-8")) as RecentProjectRecord[];
+    return records.filter((record) => existsSync(record.root));
+  } catch {
+    return [];
+  }
+}
+
+export function saveRecentProjects(records: RecentProjectRecord[], homeDir = homedir()): void {
+  mkdirSync(join(homeDir, ".pneuma"), { recursive: true });
+  writeFileSync(recentProjectsRegistryPath(homeDir), JSON.stringify(records, null, 2));
+}
+
+export function recordRecentProject(projectRoot: string, options: RecordRecentProjectOptions = {}): RecentProjectRecord {
+  const project = createProject(projectRoot);
+  const home = options.homeDir ?? homedir();
+  const record: RecentProjectRecord = {
+    projectId: project.projectId,
+    name: project.name,
+    ...(project.description ? { description: project.description } : {}),
+    root: resolve(projectRoot),
+    lastAccessed: options.now?.() ?? defaultNow(),
+  };
+  const next = [
+    record,
+    ...loadRecentProjects(home).filter((existing) => existing.projectId !== record.projectId),
+  ].slice(0, options.limit ?? 50);
+
+  saveRecentProjects(next, home);
+  return record;
+}
+
+export function resolveProjectRuntime(options: ResolveProjectRuntimeOptions): ProjectRuntime {
+  const project = createProject(options.projectRoot, {
+    now: options.now,
+    idFactory: options.projectIdFactory,
+  });
+  const session = createProjectSession(options.projectRoot, {
+    mode: options.mode,
+    displayName: options.displayName,
+    backendType: options.backendType,
+    role: options.role,
+    now: options.now,
+    idFactory: options.sessionIdFactory,
+  });
+  recordRecentProject(options.projectRoot, { now: options.now });
+  return {
+    projectRoot: resolve(options.projectRoot),
+    workspace: session.sessionWorkspace,
+    project,
+    session,
+  };
+}

--- a/core/project.ts
+++ b/core/project.ts
@@ -1,5 +1,5 @@
-import { existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
-import { basename, dirname, join, resolve } from "node:path";
+import { cpSync, existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import { basename, dirname, join, resolve, sep } from "node:path";
 import { homedir } from "node:os";
 
 export type ProjectBackendType = "claude-code" | "codex";
@@ -39,6 +39,70 @@ export interface ProjectSessionManifest {
   sourceQuickSessionId?: string;
 }
 
+export interface ProjectHandoffDraft {
+  handoffId: string;
+  content: string;
+}
+
+export interface ProjectHandoff {
+  handoffId: string;
+  projectId: string;
+  fromSessionId: string;
+  toSessionId?: string;
+  fromMode: string;
+  toMode: string;
+  createdAt: string;
+  confirmedAt?: string;
+  content: string;
+}
+
+export interface CreateProjectHandoffDraftOptions {
+  fromSessionId: string;
+  toMode: string;
+  goal?: string;
+  now?: () => string;
+  idFactory?: () => string;
+}
+
+export interface ConfirmProjectHandoffOptions {
+  handoffId: string;
+  content: string;
+  toSessionId?: string;
+  toMode?: string;
+  now?: () => string;
+}
+
+export interface UpgradeQuickSessionToProjectOptions {
+  name?: string;
+  description?: string;
+  mode?: string;
+  displayName?: string;
+  backendType?: ProjectBackendType;
+  role?: string;
+  copyDeliverables?: boolean;
+  now?: () => string;
+  projectIdFactory?: () => string;
+  sessionIdFactory?: () => string;
+}
+
+export interface UpgradeQuickSessionToProjectResult {
+  project: ProjectManifest;
+  session: ProjectSessionManifest;
+}
+
+export interface RunProjectEvolutionOptions {
+  now?: () => string;
+}
+
+export interface ProjectEvolutionResult {
+  preferencesPath: string;
+  sourceSessionCount: number;
+  handoffCount: number;
+  timelineEventCount: number;
+  deliverableCount: number;
+  appendedContent: string;
+}
+
 export interface CreateProjectSessionOptions {
   mode: string;
   displayName: string;
@@ -69,6 +133,7 @@ export interface ResolveProjectRuntimeOptions {
   backendType: ProjectBackendType;
   role?: string;
   sessionId?: string;
+  handoffId?: string;
   now?: () => string;
   projectIdFactory?: () => string;
   sessionIdFactory?: () => string;
@@ -79,6 +144,7 @@ export interface ProjectRuntime {
   workspace: string;
   project: ProjectManifest;
   session: ProjectSessionManifest;
+  handoff?: ProjectHandoff;
 }
 
 export interface ProjectInstructionSessionSummary {
@@ -101,6 +167,7 @@ export interface ProjectInstructionContext {
   currentMode: string;
   currentSessionDisplayName: string;
   peerSessions: ProjectInstructionSessionSummary[];
+  handoff?: ProjectHandoff;
 }
 
 export type ProjectTimelineEvent =
@@ -108,6 +175,9 @@ export type ProjectTimelineEvent =
   | { type: "project.updated"; at: string; changes: Record<string, unknown> }
   | { type: "session.created"; at: string; sessionId: string; mode: string; role?: string }
   | { type: "session.resumed"; at: string; sessionId: string }
+  | { type: "session.upgraded"; at: string; sessionId: string; sourceWorkspace: string; sourceQuickSessionId?: string }
+  | { type: "handoff.created"; at: string; handoffId: string; fromSessionId: string; toSessionId?: string }
+  | { type: "project.evolved"; at: string; sourceSessionCount: number }
   | { type: "deliverable.published"; at: string; sessionId: string; paths: string[] };
 
 export function projectPneumaDir(projectRoot: string): string {
@@ -142,6 +212,17 @@ export function projectSessionWorkspace(projectRoot: string, sessionId: string):
   return join(projectSessionDir(projectRoot, sessionId), "workspace");
 }
 
+export function projectHandoffsDir(projectRoot: string): string {
+  return join(projectPneumaDir(projectRoot), "handoffs");
+}
+
+export function projectHandoffPath(projectRoot: string, handoffId: string): string {
+  if (basename(handoffId) !== handoffId || handoffId.includes(sep)) {
+    throw new Error(`Invalid handoff id: ${handoffId}`);
+  }
+  return join(projectHandoffsDir(projectRoot), `${handoffId}.md`);
+}
+
 export function isProjectSessionWorkspace(workspace: string): boolean {
   const resolvedWorkspace = resolve(workspace);
   if (basename(resolvedWorkspace) !== "workspace") return false;
@@ -169,6 +250,67 @@ function defaultProjectId(): string {
 function defaultSessionId(mode: string): string {
   const stamp = new Date().toISOString().replace(/[-:]/g, "").replace(/\.\d{3}Z$/, "Z");
   return `${mode}-${stamp}-${crypto.randomUUID().slice(0, 8)}`;
+}
+
+function defaultHandoffId(fromMode: string, toMode: string, now: string): string {
+  const stamp = now.replace(/[-:]/g, "").replace(/\.\d{3}Z$/, "Z");
+  return `${stamp}-${fromMode}-to-${toMode}`.toLowerCase().replace(/[^a-z0-9-]/g, "-").replace(/-+/g, "-");
+}
+
+function parseFrontmatter(content: string): { fields: Record<string, string>; body: string } {
+  const match = content.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
+  if (!match) return { fields: {}, body: content };
+
+  const fields: Record<string, string> = {};
+  for (const line of match[1].split("\n")) {
+    const idx = line.indexOf(":");
+    if (idx === -1) continue;
+    const key = line.slice(0, idx).trim();
+    const value = line.slice(idx + 1).trim();
+    if (key) fields[key] = value;
+  }
+  return { fields, body: match[2] };
+}
+
+function upsertFrontmatterFields(content: string, fields: Record<string, string | undefined>): string {
+  const parsed = parseFrontmatter(content);
+  const merged: Record<string, string> = { ...parsed.fields };
+  for (const [key, value] of Object.entries(fields)) {
+    if (value !== undefined) merged[key] = value;
+  }
+
+  const orderedKeys = [
+    "handoffId",
+    "projectId",
+    "fromSessionId",
+    "toSessionId",
+    "fromMode",
+    "toMode",
+    "createdAt",
+    "confirmedAt",
+  ];
+  const remainingKeys = Object.keys(merged).filter((key) => !orderedKeys.includes(key)).sort();
+  const frontmatter = [...orderedKeys, ...remainingKeys]
+    .filter((key) => key in merged)
+    .map((key) => `${key}: ${merged[key]}`)
+    .join("\n");
+
+  return `---\n${frontmatter}\n---\n${parsed.body}`;
+}
+
+export function parseProjectHandoffContent(content: string): ProjectHandoff {
+  const { fields } = parseFrontmatter(content);
+  return {
+    handoffId: fields.handoffId || "",
+    projectId: fields.projectId || "",
+    fromSessionId: fields.fromSessionId || "",
+    ...(fields.toSessionId ? { toSessionId: fields.toSessionId } : {}),
+    fromMode: fields.fromMode || "",
+    toMode: fields.toMode || "",
+    createdAt: fields.createdAt || "",
+    ...(fields.confirmedAt ? { confirmedAt: fields.confirmedAt } : {}),
+    content,
+  };
 }
 
 export function loadProject(projectRoot: string): ProjectManifest | null {
@@ -257,6 +399,116 @@ export function createProjectSession(
   return session;
 }
 
+export function createProjectHandoffDraft(
+  projectRoot: string,
+  options: CreateProjectHandoffDraftOptions,
+): ProjectHandoffDraft {
+  const project = loadProject(projectRoot);
+  if (!project) {
+    throw new Error(`Project metadata not found: ${projectManifestPath(projectRoot)}`);
+  }
+
+  const sourceSession = loadProjectSession(projectRoot, options.fromSessionId);
+  if (!sourceSession) {
+    throw new Error(`Project session not found: ${options.fromSessionId}`);
+  }
+
+  const now = options.now?.() ?? defaultNow();
+  const handoffId = options.idFactory?.() ?? defaultHandoffId(sourceSession.mode, options.toMode, now);
+  const relevantFiles = [
+    ...(sourceSession.deliverablePaths ?? []),
+    ...(project.deliverablePaths ?? []),
+  ];
+  const relevantFileLines = relevantFiles.length > 0
+    ? relevantFiles.map((path) => `- ${path}`)
+    : ["- (Add reviewed deliverable paths before confirming.)"];
+
+  const content = [
+    "---",
+    `handoffId: ${handoffId}`,
+    `projectId: ${project.projectId}`,
+    `fromSessionId: ${sourceSession.sessionId}`,
+    "toSessionId: ",
+    `fromMode: ${sourceSession.mode}`,
+    `toMode: ${options.toMode}`,
+    `createdAt: ${now}`,
+    "---",
+    "",
+    `# Handoff: ${sourceSession.mode} to ${options.toMode}`,
+    "",
+    "## Goal",
+    "",
+    options.goal?.trim() || sourceSession.role || "(Summarize the goal for the target session.)",
+    "",
+    "## Decisions",
+    "",
+    "- (Add user-reviewed decisions from the source session.)",
+    "",
+    "## Constraints",
+    "",
+    "- Preserve project deliverables in the project root or explicit deliverable paths.",
+    "- Keep scratch and intermediate work in the target session workspace.",
+    "",
+    "## Relevant Files",
+    "",
+    ...relevantFileLines,
+    "",
+    "## Open Questions",
+    "",
+    "- (Add unresolved questions, or write \"None\".)",
+    "",
+    "## Suggested Next Step",
+    "",
+    `- Continue in ${options.toMode} using only this reviewed handoff plus project metadata.`,
+    "",
+  ].join("\n");
+
+  return { handoffId, content };
+}
+
+export function loadProjectHandoff(projectRoot: string, handoffId: string): ProjectHandoff | null {
+  const filePath = projectHandoffPath(projectRoot, handoffId);
+  if (!existsSync(filePath)) return null;
+  return parseProjectHandoffContent(readFileSync(filePath, "utf-8"));
+}
+
+export function confirmProjectHandoff(
+  projectRoot: string,
+  options: ConfirmProjectHandoffOptions,
+): ProjectHandoff {
+  const project = loadProject(projectRoot);
+  if (!project) {
+    throw new Error(`Project metadata not found: ${projectManifestPath(projectRoot)}`);
+  }
+
+  const now = options.now?.() ?? defaultNow();
+  const content = upsertFrontmatterFields(options.content, {
+    handoffId: options.handoffId,
+    projectId: project.projectId,
+    toSessionId: options.toSessionId,
+    confirmedAt: now,
+  });
+
+  const handoff = parseProjectHandoffContent(content);
+  if (!handoff.fromSessionId || !handoff.fromMode || !handoff.toMode) {
+    throw new Error("Handoff content is missing required frontmatter fields.");
+  }
+  if (options.toMode && handoff.toMode !== options.toMode) {
+    throw new Error(`Handoff targets mode "${handoff.toMode}", not "${options.toMode}".`);
+  }
+
+  mkdirSync(projectHandoffsDir(projectRoot), { recursive: true });
+  writeFileSync(projectHandoffPath(projectRoot, options.handoffId), content);
+  appendProjectTimelineEvent(projectRoot, {
+    type: "handoff.created",
+    at: now,
+    handoffId: options.handoffId,
+    fromSessionId: handoff.fromSessionId,
+    ...(handoff.toSessionId ? { toSessionId: handoff.toSessionId } : {}),
+  });
+  return { ...handoff, content };
+}
+
 export function loadProjectSession(projectRoot: string, sessionId: string): ProjectSessionManifest | null {
   const filePath = projectSessionManifestPath(projectRoot, sessionId);
   if (!existsSync(filePath)) return null;
@@ -292,6 +544,243 @@ export function listProjectSessions(projectRoot: string): ProjectSessionManifest
   return sessions.sort((a, b) => b.lastAccessed.localeCompare(a.lastAccessed));
 }
 
+function readQuickSessionMetadata(sourceWorkspace: string): {
+  sessionId?: string;
+  mode: string;
+  backendType: ProjectBackendType;
+} {
+  const filePath = join(resolve(sourceWorkspace), ".pneuma", "session.json");
+  const parsed = JSON.parse(readFileSync(filePath, "utf-8")) as {
+    sessionId?: string;
+    mode?: string;
+    backendType?: string;
+  };
+  if (!parsed.mode) {
+    throw new Error(`Quick session is missing mode: ${filePath}`);
+  }
+  return {
+    ...(parsed.sessionId ? { sessionId: parsed.sessionId } : {}),
+    mode: parsed.mode,
+    backendType: parsed.backendType === "codex" ? "codex" : "claude-code",
+  };
+}
+
+function copyQuickSessionState(sourceWorkspace: string, targetWorkspace: string): void {
+  const sourcePneuma = join(resolve(sourceWorkspace), ".pneuma");
+  const targetPneuma = join(resolve(targetWorkspace), ".pneuma");
+  mkdirSync(targetPneuma, { recursive: true });
+
+  for (const entry of ["history.json", "config.json", "thumbnail.png", "checkpoints.jsonl"]) {
+    const src = join(sourcePneuma, entry);
+    if (existsSync(src)) cpSync(src, join(targetPneuma, entry), { force: true });
+  }
+
+  const shadowGit = join(sourcePneuma, "shadow.git");
+  if (existsSync(shadowGit)) {
+    cpSync(shadowGit, join(targetPneuma, "shadow.git"), { recursive: true, force: true });
+  }
+}
+
+function copyQuickDeliverables(sourceWorkspace: string, projectRoot: string): void {
+  const source = resolve(sourceWorkspace);
+  const target = resolve(projectRoot);
+  if (source === target) return;
+  mkdirSync(target, { recursive: true });
+
+  for (const entry of readdirSync(source, { withFileTypes: true })) {
+    if (entry.name === ".pneuma" || entry.name === ".git" || entry.name === "node_modules") continue;
+    const src = join(source, entry.name);
+    const dst = join(target, entry.name);
+    cpSync(src, dst, { recursive: entry.isDirectory(), force: true });
+  }
+}
+
+function assertQuickDeliverableCopyIsNonDestructive(sourceWorkspace: string, projectRoot: string): void {
+  const source = resolve(sourceWorkspace);
+  const target = resolve(projectRoot);
+  if (source === target || !existsSync(target)) return;
+
+  for (const entry of readdirSync(source, { withFileTypes: true })) {
+    if (entry.name === ".pneuma" || entry.name === ".git" || entry.name === "node_modules") continue;
+    const dst = join(target, entry.name);
+    if (existsSync(dst)) {
+      throw new Error(`Refusing to overwrite existing project deliverable: ${dst}`);
+    }
+  }
+}
+
+export function upgradeQuickSessionToProject(
+  sourceWorkspace: string,
+  projectRoot: string,
+  options: UpgradeQuickSessionToProjectOptions = {},
+): UpgradeQuickSessionToProjectResult {
+  const source = resolve(sourceWorkspace);
+  const root = resolve(projectRoot);
+  const quickSession = readQuickSessionMetadata(source);
+  const now = options.now?.() ?? defaultNow();
+  if (options.copyDeliverables !== false) {
+    assertQuickDeliverableCopyIsNonDestructive(source, root);
+  }
+
+  const project = createProject(root, {
+    name: options.name,
+    description: options.description,
+    now: options.now,
+    idFactory: options.projectIdFactory,
+  });
+  if (options.copyDeliverables !== false) {
+    copyQuickDeliverables(source, root);
+  }
+
+  const created = createProjectSession(root, {
+    mode: options.mode || quickSession.mode,
+    displayName: options.displayName || options.mode || quickSession.mode,
+    backendType: options.backendType || quickSession.backendType,
+    role: options.role,
+    now: options.now,
+    idFactory: options.sessionIdFactory,
+  });
+  const session: ProjectSessionManifest = {
+    ...created,
+    ...(quickSession.sessionId ? { sourceQuickSessionId: quickSession.sessionId } : {}),
+  };
+  saveProjectSession(root, session);
+  copyQuickSessionState(source, session.sessionWorkspace);
+  appendProjectTimelineEvent(root, {
+    type: "session.upgraded",
+    at: now,
+    sessionId: session.sessionId,
+    sourceWorkspace: source,
+    ...(quickSession.sessionId ? { sourceQuickSessionId: quickSession.sessionId } : {}),
+  });
+  recordRecentProject(root, { now: options.now });
+
+  return { project, session };
+}
+
+function listProjectHandoffs(projectRoot: string): ProjectHandoff[] {
+  const dir = projectHandoffsDir(projectRoot);
+  if (!existsSync(dir)) return [];
+
+  const handoffs: ProjectHandoff[] = [];
+  for (const entry of readdirSync(dir)) {
+    if (!entry.endsWith(".md")) continue;
+    try {
+      handoffs.push(parseProjectHandoffContent(readFileSync(join(dir, entry), "utf-8")));
+    } catch {
+      continue;
+    }
+  }
+  return handoffs.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+}
+
+function summarizeProjectDeliverables(projectRoot: string): Array<{ path: string; kind: "file" | "directory"; size?: number }> {
+  const root = resolve(projectRoot);
+  if (!existsSync(root)) return [];
+
+  const summaries: Array<{ path: string; kind: "file" | "directory"; size?: number }> = [];
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    if (entry.name === ".pneuma" || entry.name === ".git" || entry.name === "node_modules") continue;
+    const fullPath = join(root, entry.name);
+    try {
+      const stat = statSync(fullPath);
+      summaries.push({
+        path: entry.name,
+        kind: entry.isDirectory() ? "directory" : "file",
+        ...(entry.isDirectory() ? {} : { size: stat.size }),
+      });
+    } catch {
+      continue;
+    }
+  }
+  return summaries.sort((a, b) => a.path.localeCompare(b.path));
+}
+
+function readProjectTimelineEvents(projectRoot: string): string[] {
+  try {
+    return readFileSync(projectTimelinePath(projectRoot), "utf-8")
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+export function runProjectEvolution(
+  projectRoot: string,
+  options: RunProjectEvolutionOptions = {},
+): ProjectEvolutionResult {
+  const project = loadProject(projectRoot);
+  if (!project) {
+    throw new Error(`Project metadata not found: ${projectManifestPath(projectRoot)}`);
+  }
+
+  const now = options.now?.() ?? defaultNow();
+  const sessions = listProjectSessions(projectRoot);
+  const handoffs = listProjectHandoffs(projectRoot);
+  const timelineEvents = readProjectTimelineEvents(projectRoot);
+  const deliverables = summarizeProjectDeliverables(projectRoot);
+
+  const sessionLines = sessions.length > 0
+    ? sessions.map((session) => `- ${session.mode}: ${session.role || session.displayName} (${session.status}, last active ${session.lastAccessed})`)
+    : ["- No project sessions recorded yet."];
+  const handoffLines = handoffs.length > 0
+    ? handoffs.map((handoff) => `- ${handoff.handoffId}: ${handoff.fromMode} -> ${handoff.toMode}${handoff.toSessionId ? ` (${handoff.toSessionId})` : ""}`)
+    : ["- No handoffs recorded yet."];
+  const deliverableLines = deliverables.length > 0
+    ? deliverables.map((deliverable) => `- ${deliverable.path} (${deliverable.kind}${deliverable.size !== undefined ? `, ${deliverable.size} bytes` : ""})`)
+    : ["- No top-level deliverables found outside .pneuma/."];
+
+  const appendedContent = [
+    "",
+    `## Project Evolution - ${now}`,
+    "",
+    "### Sources",
+    "",
+    `- Sessions scanned: ${sessions.length}`,
+    `- Handoffs scanned: ${handoffs.length}`,
+    `- Timeline facts scanned: ${timelineEvents.length}`,
+    `- Deliverables summarized: ${deliverables.length}`,
+    "",
+    "### Session Signals",
+    "",
+    ...sessionLines,
+    "",
+    "### Handoff Signals",
+    "",
+    ...handoffLines,
+    "",
+    "### Deliverable Summary",
+    "",
+    ...deliverableLines,
+    "",
+    "### Project-Level Preference Notes",
+    "",
+    "- Review these project-local signals before adding durable preferences; keep only constraints that should apply to future sessions in this project.",
+    "",
+  ].join("\n");
+
+  const prefsPath = projectPreferencesPath(projectRoot);
+  mkdirSync(projectPneumaDir(projectRoot), { recursive: true });
+  if (!existsSync(prefsPath)) writeFileSync(prefsPath, "# Project Preferences\n\n");
+  writeFileSync(prefsPath, appendedContent, { flag: "a" });
+  appendProjectTimelineEvent(projectRoot, {
+    type: "project.evolved",
+    at: now,
+    sourceSessionCount: sessions.length,
+  });
+
+  return {
+    preferencesPath: prefsPath,
+    sourceSessionCount: sessions.length,
+    handoffCount: handoffs.length,
+    timelineEventCount: timelineEvents.length,
+    deliverableCount: deliverables.length,
+    appendedContent,
+  };
+}
+
 export function loadRecentProjects(homeDir = homedir()): RecentProjectRecord[] {
   try {
     const records = JSON.parse(readFileSync(recentProjectsRegistryPath(homeDir), "utf-8")) as RecentProjectRecord[];
@@ -325,6 +814,25 @@ export function recordRecentProject(projectRoot: string, options: RecordRecentPr
   return record;
 }
 
+function resolveRuntimeHandoff(
+  projectRoot: string,
+  handoffId: string | undefined,
+  session: ProjectSessionManifest,
+): ProjectHandoff | undefined {
+  if (!handoffId) return undefined;
+  const handoff = loadProjectHandoff(projectRoot, handoffId);
+  if (!handoff) {
+    throw new Error(`Project handoff not found: ${handoffId}`);
+  }
+  if (handoff.toSessionId && handoff.toSessionId !== session.sessionId) {
+    throw new Error(`Project handoff "${handoffId}" targets session "${handoff.toSessionId}", not "${session.sessionId}".`);
+  }
+  if (handoff.toMode && handoff.toMode !== session.mode) {
+    throw new Error(`Project handoff "${handoffId}" targets mode "${handoff.toMode}", not "${session.mode}".`);
+  }
+  return handoff;
+}
+
 export function resolveProjectRuntime(options: ResolveProjectRuntimeOptions): ProjectRuntime {
   const project = createProject(options.projectRoot, {
     now: options.now,
@@ -356,11 +864,13 @@ export function resolveProjectRuntime(options: ResolveProjectRuntimeOptions): Pr
       sessionId: session.sessionId,
     });
     recordRecentProject(options.projectRoot, { now: options.now });
+    const handoff = resolveRuntimeHandoff(options.projectRoot, options.handoffId, session);
     return {
       projectRoot: resolve(options.projectRoot),
       workspace: session.sessionWorkspace,
       project,
       session,
+      ...(handoff ? { handoff } : {}),
     };
   }
 
@@ -373,11 +883,13 @@ export function resolveProjectRuntime(options: ResolveProjectRuntimeOptions): Pr
     idFactory: options.sessionIdFactory,
   });
   recordRecentProject(options.projectRoot, { now: options.now });
+  const handoff = resolveRuntimeHandoff(options.projectRoot, options.handoffId, session);
   return {
     projectRoot: resolve(options.projectRoot),
     workspace: session.sessionWorkspace,
     project,
     session,
+    ...(handoff ? { handoff } : {}),
   };
 }
 
@@ -394,6 +906,7 @@ export function buildProjectInstructionContext(
     currentSessionId: runtime.session.sessionId,
     currentMode: runtime.session.mode,
     currentSessionDisplayName: runtime.session.displayName,
+    ...(runtime.handoff ? { handoff: runtime.handoff } : {}),
     peerSessions: sessions
       .filter((session) => session.sessionId !== runtime.session.sessionId)
       .map((session) => ({

--- a/core/project.ts
+++ b/core/project.ts
@@ -1,5 +1,5 @@
 import { existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
-import { basename, join, resolve } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 import { homedir } from "node:os";
 
 export type ProjectBackendType = "claude-code" | "codex";
@@ -68,6 +68,7 @@ export interface ResolveProjectRuntimeOptions {
   displayName: string;
   backendType: ProjectBackendType;
   role?: string;
+  sessionId?: string;
   now?: () => string;
   projectIdFactory?: () => string;
   sessionIdFactory?: () => string;
@@ -111,8 +112,24 @@ export function projectSessionDir(projectRoot: string, sessionId: string): strin
   return join(projectSessionsDir(projectRoot), sessionId);
 }
 
+export function projectSessionManifestPath(projectRoot: string, sessionId: string): string {
+  return join(projectSessionDir(projectRoot, sessionId), "session.json");
+}
+
 export function projectSessionWorkspace(projectRoot: string, sessionId: string): string {
   return join(projectSessionDir(projectRoot, sessionId), "workspace");
+}
+
+export function isProjectSessionWorkspace(workspace: string): boolean {
+  const resolvedWorkspace = resolve(workspace);
+  if (basename(resolvedWorkspace) !== "workspace") return false;
+
+  const sessionDir = dirname(resolvedWorkspace);
+  const sessionsDir = dirname(sessionDir);
+  const pneumaDir = dirname(sessionsDir);
+  if (basename(sessionsDir) !== "sessions" || basename(pneumaDir) !== ".pneuma") return false;
+
+  return existsSync(join(pneumaDir, "project.json")) && existsSync(join(sessionDir, "session.json"));
 }
 
 export function recentProjectsRegistryPath(homeDir = homedir()): string {
@@ -207,7 +224,7 @@ export function createProjectSession(
     sessionWorkspace: workspace,
   };
 
-  writeFileSync(join(dir, "session.json"), JSON.stringify(session, null, 2));
+  writeFileSync(projectSessionManifestPath(projectRoot, sessionId), JSON.stringify(session, null, 2));
   appendProjectTimelineEvent(projectRoot, {
     type: "session.created",
     at: now,
@@ -216,6 +233,22 @@ export function createProjectSession(
     ...(options.role?.trim() ? { role: options.role.trim() } : {}),
   });
   return session;
+}
+
+export function loadProjectSession(projectRoot: string, sessionId: string): ProjectSessionManifest | null {
+  const filePath = projectSessionManifestPath(projectRoot, sessionId);
+  if (!existsSync(filePath)) return null;
+
+  const parsed = JSON.parse(readFileSync(filePath, "utf-8")) as ProjectSessionManifest;
+  if (parsed.schemaVersion !== 1 || !parsed.sessionId || parsed.sessionId !== sessionId) {
+    throw new Error(`Invalid Pneuma project session manifest: ${filePath}`);
+  }
+  return parsed;
+}
+
+export function saveProjectSession(projectRoot: string, session: ProjectSessionManifest): void {
+  mkdirSync(projectSessionDir(projectRoot, session.sessionId), { recursive: true });
+  writeFileSync(projectSessionManifestPath(projectRoot, session.sessionId), JSON.stringify(session, null, 2));
 }
 
 export function listProjectSessions(projectRoot: string): ProjectSessionManifest[] {
@@ -275,6 +308,40 @@ export function resolveProjectRuntime(options: ResolveProjectRuntimeOptions): Pr
     now: options.now,
     idFactory: options.projectIdFactory,
   });
+
+  if (options.sessionId) {
+    const existing = loadProjectSession(options.projectRoot, options.sessionId);
+    if (!existing) {
+      throw new Error(`Project session not found: ${options.sessionId}`);
+    }
+    if (existing.mode !== options.mode) {
+      throw new Error(`Project session "${options.sessionId}" belongs to mode "${existing.mode}", not "${options.mode}".`);
+    }
+    if (existing.backendType !== options.backendType) {
+      throw new Error(`Project session "${options.sessionId}" uses backend "${existing.backendType}", not "${options.backendType}".`);
+    }
+
+    const now = options.now?.() ?? defaultNow();
+    const session: ProjectSessionManifest = {
+      ...existing,
+      status: "active",
+      lastAccessed: now,
+    };
+    saveProjectSession(options.projectRoot, session);
+    appendProjectTimelineEvent(options.projectRoot, {
+      type: "session.resumed",
+      at: now,
+      sessionId: session.sessionId,
+    });
+    recordRecentProject(options.projectRoot, { now: options.now });
+    return {
+      projectRoot: resolve(options.projectRoot),
+      workspace: session.sessionWorkspace,
+      project,
+      session,
+    };
+  }
+
   const session = createProjectSession(options.projectRoot, {
     mode: options.mode,
     displayName: options.displayName,

--- a/core/project.ts
+++ b/core/project.ts
@@ -81,6 +81,28 @@ export interface ProjectRuntime {
   session: ProjectSessionManifest;
 }
 
+export interface ProjectInstructionSessionSummary {
+  sessionId: string;
+  mode: string;
+  displayName: string;
+  role?: string;
+  backendType: ProjectBackendType;
+  status: ProjectSessionManifest["status"];
+  lastAccessed: string;
+}
+
+export interface ProjectInstructionContext {
+  projectId: string;
+  projectName: string;
+  projectRoot: string;
+  description?: string;
+  role?: string;
+  currentSessionId: string;
+  currentMode: string;
+  currentSessionDisplayName: string;
+  peerSessions: ProjectInstructionSessionSummary[];
+}
+
 export type ProjectTimelineEvent =
   | { type: "project.created"; at: string; projectId: string; name: string }
   | { type: "project.updated"; at: string; changes: Record<string, unknown> }
@@ -356,5 +378,32 @@ export function resolveProjectRuntime(options: ResolveProjectRuntimeOptions): Pr
     workspace: session.sessionWorkspace,
     project,
     session,
+  };
+}
+
+export function buildProjectInstructionContext(
+  runtime: ProjectRuntime,
+  sessions: ProjectSessionManifest[] = listProjectSessions(runtime.projectRoot),
+): ProjectInstructionContext {
+  return {
+    projectId: runtime.project.projectId,
+    projectName: runtime.project.name,
+    projectRoot: runtime.projectRoot,
+    ...(runtime.project.description ? { description: runtime.project.description } : {}),
+    ...(runtime.session.role ? { role: runtime.session.role } : {}),
+    currentSessionId: runtime.session.sessionId,
+    currentMode: runtime.session.mode,
+    currentSessionDisplayName: runtime.session.displayName,
+    peerSessions: sessions
+      .filter((session) => session.sessionId !== runtime.session.sessionId)
+      .map((session) => ({
+        sessionId: session.sessionId,
+        mode: session.mode,
+        displayName: session.displayName,
+        ...(session.role ? { role: session.role } : {}),
+        backendType: session.backendType,
+        status: session.status,
+        lastAccessed: session.lastAccessed,
+      })),
   };
 }

--- a/docs/superpowers/plans/2026-04-28-project-layer-foundation.md
+++ b/docs/superpowers/plans/2026-04-28-project-layer-foundation.md
@@ -1,0 +1,1121 @@
+# Project Layer Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the foundation for optional Pneuma projects: project metadata, recent-project registry, project session sandboxes, and CLI/launcher launch plumbing while preserving quick-session behavior.
+
+**Architecture:** Add a focused `core/project.ts` module that owns project manifests, session manifests, timeline events, and recent-project registry files. CLI launch code resolves a project session into a normal `workspace` pointing at `.pneuma/sessions/<session-id>/workspace`, while keeping `projectRoot` as explicit runtime metadata for later context injection and UI work.
+
+**Tech Stack:** Bun, TypeScript, Hono launcher routes, existing `bin/pneuma.ts` CLI flow, existing Bun test suite.
+
+---
+
+## Scope
+
+This plan implements the foundation needed before Launcher overview, editable cross-mode handoffs, project preference injection, quick-session upgrade UI, and project-level evolve. Those features are represented as follow-up board cards because they are independently testable subsystems.
+
+This foundation must ship with one observable guarantee: `pneuma <mode>` still behaves as a quick session, while `pneuma <mode> --project <root> --role <role>` creates or uses a project and stores session state under the project session sandbox.
+
+## File Map
+
+- Create: `core/project.ts`
+  - Project manifest types and read/write helpers.
+  - Project session manifest helpers.
+  - Timeline append helper.
+  - Recent-project registry helpers.
+  - Runtime session path resolver.
+
+- Create: `core/__tests__/project.test.ts`
+  - Unit tests for project creation, project loading, session sandbox resolution, timeline append, registry behavior, and corrupt manifest handling.
+
+- Modify: `bin/pneuma-cli-helpers.ts`
+  - Add `--project` and `--role` parsing.
+  - Extend `ParsedCliArgs`.
+
+- Modify: `bin/__tests__/pneuma-cli-helpers.test.ts`
+  - Assert project and role flags parse without changing quick-session defaults.
+
+- Modify: `bin/pneuma.ts`
+  - Resolve project session runtime before workspace existence checks.
+  - Use the session sandbox as `workspace` for skill install, config, history, watcher, server, and backend cwd.
+  - Record recent project and project session metadata.
+
+- Modify: `server/index.ts`
+  - Add Launcher-mode project APIs.
+  - Accept project launch fields in `/api/launch`.
+  - Spawn child processes with `--project` and `--role` when requested.
+
+- Create: `server/__tests__/project-routes.test.ts`
+  - Route tests for listing projects, creating projects, project path validation, and project launch argument behavior where observable without spawning a real agent.
+
+## Task 1: Project Domain Module
+
+**Files:**
+- Create: `core/project.ts`
+- Create: `core/__tests__/project.test.ts`
+
+- [ ] **Step 1: Write failing tests for project manifest creation**
+
+Create `core/__tests__/project.test.ts` with this first test group:
+
+```ts
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  createProject,
+  loadProject,
+  projectManifestPath,
+  projectPneumaDir,
+} from "../project.js";
+
+describe("project manifest", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = join(tmpdir(), `pneuma-project-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(root, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test("createProject writes project.json and project-preferences.md", () => {
+    const project = createProject(root, {
+      name: "Launch Site",
+      description: "Marketing site for Pneuma",
+      now: () => "2026-04-28T00:00:00.000Z",
+      idFactory: () => "project_123",
+    });
+
+    expect(project.projectId).toBe("project_123");
+    expect(project.name).toBe("Launch Site");
+    expect(project.root).toBe(root);
+    expect(existsSync(projectManifestPath(root))).toBe(true);
+    expect(existsSync(join(projectPneumaDir(root), "project-preferences.md"))).toBe(true);
+
+    const loaded = loadProject(root);
+    expect(loaded?.description).toBe("Marketing site for Pneuma");
+  });
+
+  test("createProject derives a readable name from the directory when name is omitted", () => {
+    const project = createProject(root, {
+      now: () => "2026-04-28T00:00:00.000Z",
+      idFactory: () => "project_derived",
+    });
+
+    expect(project.name).toBe(root.split("/").pop());
+  });
+
+  test("loadProject returns null when project.json is absent", () => {
+    expect(loadProject(root)).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run the focused test and confirm it fails**
+
+Run:
+
+```bash
+bun test core/__tests__/project.test.ts
+```
+
+Expected: FAIL because `core/project.ts` does not exist.
+
+- [ ] **Step 3: Implement project manifest helpers**
+
+Create `core/project.ts` with these exports:
+
+```ts
+import { existsSync, mkdirSync, readFileSync, writeFileSync, readdirSync, statSync } from "node:fs";
+import { basename, join, resolve } from "node:path";
+import { homedir } from "node:os";
+
+export interface ProjectManifest {
+  schemaVersion: 1;
+  projectId: string;
+  name: string;
+  description?: string;
+  createdAt: string;
+  updatedAt: string;
+  root: string;
+  deliverablePaths?: string[];
+  defaultBackendType?: "claude-code" | "codex";
+}
+
+export interface CreateProjectOptions {
+  name?: string;
+  description?: string;
+  now?: () => string;
+  idFactory?: () => string;
+}
+
+export function projectPneumaDir(projectRoot: string): string {
+  return join(resolve(projectRoot), ".pneuma");
+}
+
+export function projectManifestPath(projectRoot: string): string {
+  return join(projectPneumaDir(projectRoot), "project.json");
+}
+
+export function projectPreferencesPath(projectRoot: string): string {
+  return join(projectPneumaDir(projectRoot), "project-preferences.md");
+}
+
+export function projectTimelinePath(projectRoot: string): string {
+  return join(projectPneumaDir(projectRoot), "timeline.jsonl");
+}
+
+export function projectSessionsDir(projectRoot: string): string {
+  return join(projectPneumaDir(projectRoot), "sessions");
+}
+
+function defaultNow(): string {
+  return new Date().toISOString();
+}
+
+function defaultProjectId(): string {
+  return `project_${crypto.randomUUID()}`;
+}
+
+export function loadProject(projectRoot: string): ProjectManifest | null {
+  const filePath = projectManifestPath(projectRoot);
+  if (!existsSync(filePath)) return null;
+  const parsed = JSON.parse(readFileSync(filePath, "utf-8")) as ProjectManifest;
+  if (parsed.schemaVersion !== 1 || !parsed.projectId || !parsed.name) {
+    throw new Error(`Invalid Pneuma project manifest: ${filePath}`);
+  }
+  return { ...parsed, root: resolve(projectRoot) };
+}
+
+export function createProject(projectRoot: string, options: CreateProjectOptions = {}): ProjectManifest {
+  const root = resolve(projectRoot);
+  const existing = loadProject(root);
+  if (existing) return existing;
+
+  const now = options.now?.() ?? defaultNow();
+  const manifest: ProjectManifest = {
+    schemaVersion: 1,
+    projectId: options.idFactory?.() ?? defaultProjectId(),
+    name: options.name?.trim() || basename(root),
+    ...(options.description?.trim() ? { description: options.description.trim() } : {}),
+    createdAt: now,
+    updatedAt: now,
+    root,
+  };
+
+  mkdirSync(projectPneumaDir(root), { recursive: true });
+  mkdirSync(projectSessionsDir(root), { recursive: true });
+  writeFileSync(projectManifestPath(root), JSON.stringify(manifest, null, 2));
+  if (!existsSync(projectPreferencesPath(root))) {
+    writeFileSync(projectPreferencesPath(root), "# Project Preferences\n\n");
+  }
+  appendProjectTimelineEvent(root, {
+    type: "project.created",
+    at: now,
+    projectId: manifest.projectId,
+    name: manifest.name,
+  });
+  return manifest;
+}
+```
+
+Add the timeline helper at the bottom of the same file:
+
+```ts
+export type ProjectTimelineEvent =
+  | { type: "project.created"; at: string; projectId: string; name: string }
+  | { type: "project.updated"; at: string; changes: Record<string, unknown> }
+  | { type: "session.created"; at: string; sessionId: string; mode: string; role?: string }
+  | { type: "session.resumed"; at: string; sessionId: string }
+  | { type: "deliverable.published"; at: string; sessionId: string; paths: string[] };
+
+export function appendProjectTimelineEvent(projectRoot: string, event: ProjectTimelineEvent): void {
+  mkdirSync(projectPneumaDir(projectRoot), { recursive: true });
+  const line = `${JSON.stringify(event)}\n`;
+  const path = projectTimelinePath(projectRoot);
+  writeFileSync(path, line, { flag: "a" });
+}
+```
+
+- [ ] **Step 4: Run the focused test and confirm it passes**
+
+Run:
+
+```bash
+bun test core/__tests__/project.test.ts
+```
+
+Expected: PASS for the manifest test group.
+
+## Task 2: Project Session Sandboxes
+
+**Files:**
+- Modify: `core/project.ts`
+- Modify: `core/__tests__/project.test.ts`
+
+- [ ] **Step 1: Add failing tests for session sandbox creation**
+
+Append these tests to `core/__tests__/project.test.ts`:
+
+```ts
+import {
+  createProjectSession,
+  listProjectSessions,
+  projectSessionDir,
+  projectSessionWorkspace,
+} from "../project.js";
+
+describe("project sessions", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = join(tmpdir(), `pneuma-project-session-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(root, { recursive: true });
+    createProject(root, {
+      name: "Session Project",
+      now: () => "2026-04-28T00:00:00.000Z",
+      idFactory: () => "project_sessions",
+    });
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test("createProjectSession creates session.json, workspace, and scratch", () => {
+    const session = createProjectSession(root, {
+      mode: "webcraft",
+      displayName: "Webcraft",
+      backendType: "claude-code",
+      role: "Build the landing page",
+      now: () => "2026-04-28T01:00:00.000Z",
+      idFactory: () => "webcraft-abc",
+    });
+
+    expect(session.sessionId).toBe("webcraft-abc");
+    expect(session.projectId).toBe("project_sessions");
+    expect(session.sessionWorkspace).toBe(projectSessionWorkspace(root, "webcraft-abc"));
+    expect(existsSync(join(projectSessionDir(root, "webcraft-abc"), "session.json"))).toBe(true);
+    expect(existsSync(projectSessionWorkspace(root, "webcraft-abc"))).toBe(true);
+    expect(existsSync(join(projectSessionDir(root, "webcraft-abc"), "scratch"))).toBe(true);
+  });
+
+  test("listProjectSessions returns sessions sorted by lastAccessed descending", () => {
+    createProjectSession(root, {
+      mode: "doc",
+      displayName: "Doc",
+      backendType: "claude-code",
+      now: () => "2026-04-28T01:00:00.000Z",
+      idFactory: () => "doc-old",
+    });
+    createProjectSession(root, {
+      mode: "webcraft",
+      displayName: "Webcraft",
+      backendType: "codex",
+      now: () => "2026-04-28T02:00:00.000Z",
+      idFactory: () => "web-new",
+    });
+
+    expect(listProjectSessions(root).map((s) => s.sessionId)).toEqual(["web-new", "doc-old"]);
+  });
+});
+```
+
+- [ ] **Step 2: Run the focused test and confirm it fails**
+
+Run:
+
+```bash
+bun test core/__tests__/project.test.ts
+```
+
+Expected: FAIL because session helper exports do not exist.
+
+- [ ] **Step 3: Implement session helpers**
+
+Add these exports to `core/project.ts`:
+
+```ts
+export interface ProjectSessionManifest {
+  schemaVersion: 1;
+  sessionId: string;
+  projectId: string;
+  mode: string;
+  role?: string;
+  displayName: string;
+  backendType: "claude-code" | "codex";
+  status: "active" | "idle" | "archived";
+  createdAt: string;
+  lastAccessed: string;
+  sessionWorkspace: string;
+  deliverablePaths?: string[];
+  sourceQuickSessionId?: string;
+}
+
+export interface CreateProjectSessionOptions {
+  mode: string;
+  displayName: string;
+  backendType: "claude-code" | "codex";
+  role?: string;
+  now?: () => string;
+  idFactory?: () => string;
+}
+
+export function projectSessionDir(projectRoot: string, sessionId: string): string {
+  return join(projectSessionsDir(projectRoot), sessionId);
+}
+
+export function projectSessionWorkspace(projectRoot: string, sessionId: string): string {
+  return join(projectSessionDir(projectRoot, sessionId), "workspace");
+}
+
+function defaultSessionId(mode: string): string {
+  const stamp = new Date().toISOString().replace(/[-:]/g, "").replace(/\.\d{3}Z$/, "Z");
+  return `${mode}-${stamp}-${crypto.randomUUID().slice(0, 8)}`;
+}
+
+export function createProjectSession(
+  projectRoot: string,
+  options: CreateProjectSessionOptions,
+): ProjectSessionManifest {
+  const project = createProject(projectRoot);
+  const now = options.now?.() ?? defaultNow();
+  const sessionId = options.idFactory?.() ?? defaultSessionId(options.mode);
+  const dir = projectSessionDir(projectRoot, sessionId);
+  const workspace = projectSessionWorkspace(projectRoot, sessionId);
+  mkdirSync(workspace, { recursive: true });
+  mkdirSync(join(dir, "scratch"), { recursive: true });
+
+  const session: ProjectSessionManifest = {
+    schemaVersion: 1,
+    sessionId,
+    projectId: project.projectId,
+    mode: options.mode,
+    ...(options.role?.trim() ? { role: options.role.trim() } : {}),
+    displayName: options.displayName,
+    backendType: options.backendType,
+    status: "active",
+    createdAt: now,
+    lastAccessed: now,
+    sessionWorkspace: workspace,
+  };
+
+  writeFileSync(join(dir, "session.json"), JSON.stringify(session, null, 2));
+  appendProjectTimelineEvent(projectRoot, {
+    type: "session.created",
+    at: now,
+    sessionId,
+    mode: options.mode,
+    ...(options.role?.trim() ? { role: options.role.trim() } : {}),
+  });
+  return session;
+}
+
+export function listProjectSessions(projectRoot: string): ProjectSessionManifest[] {
+  const dir = projectSessionsDir(projectRoot);
+  if (!existsSync(dir)) return [];
+  const sessions: ProjectSessionManifest[] = [];
+  for (const entry of readdirSync(dir)) {
+    const filePath = join(dir, entry, "session.json");
+    try {
+      if (!statSync(join(dir, entry)).isDirectory() || !existsSync(filePath)) continue;
+      sessions.push(JSON.parse(readFileSync(filePath, "utf-8")) as ProjectSessionManifest);
+    } catch {
+      continue;
+    }
+  }
+  return sessions.sort((a, b) => b.lastAccessed.localeCompare(a.lastAccessed));
+}
+```
+
+- [ ] **Step 4: Run the focused test and confirm it passes**
+
+Run:
+
+```bash
+bun test core/__tests__/project.test.ts
+```
+
+Expected: PASS for manifest and session helper tests.
+
+## Task 3: Recent Project Registry
+
+**Files:**
+- Modify: `core/project.ts`
+- Modify: `core/__tests__/project.test.ts`
+
+- [ ] **Step 1: Add failing tests for recent-project registry behavior**
+
+Append this test group:
+
+```ts
+import {
+  loadRecentProjects,
+  recordRecentProject,
+  recentProjectsRegistryPath,
+} from "../project.js";
+
+describe("recent project registry", () => {
+  let home: string;
+  let root: string;
+
+  beforeEach(() => {
+    home = join(tmpdir(), `pneuma-project-home-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    root = join(tmpdir(), `pneuma-project-registry-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(home, { recursive: true });
+    mkdirSync(root, { recursive: true });
+    createProject(root, {
+      name: "Registry Project",
+      now: () => "2026-04-28T00:00:00.000Z",
+      idFactory: () => "project_registry",
+    });
+  });
+
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test("recordRecentProject writes ~/.pneuma/projects.json style records", () => {
+    recordRecentProject(root, {
+      homeDir: home,
+      now: () => "2026-04-28T03:00:00.000Z",
+    });
+
+    expect(existsSync(recentProjectsRegistryPath(home))).toBe(true);
+    const records = loadRecentProjects(home);
+    expect(records).toHaveLength(1);
+    expect(records[0]).toMatchObject({
+      projectId: "project_registry",
+      name: "Registry Project",
+      root,
+      lastAccessed: "2026-04-28T03:00:00.000Z",
+    });
+  });
+
+  test("recordRecentProject de-duplicates by projectId and keeps newest first", () => {
+    recordRecentProject(root, { homeDir: home, now: () => "2026-04-28T03:00:00.000Z" });
+    recordRecentProject(root, { homeDir: home, now: () => "2026-04-28T04:00:00.000Z" });
+
+    const records = loadRecentProjects(home);
+    expect(records).toHaveLength(1);
+    expect(records[0].lastAccessed).toBe("2026-04-28T04:00:00.000Z");
+  });
+});
+```
+
+- [ ] **Step 2: Run the focused test and confirm it fails**
+
+Run:
+
+```bash
+bun test core/__tests__/project.test.ts
+```
+
+Expected: FAIL because registry helper exports do not exist.
+
+- [ ] **Step 3: Implement recent-project registry helpers**
+
+Add these exports to `core/project.ts`:
+
+```ts
+export interface RecentProjectRecord {
+  projectId: string;
+  name: string;
+  description?: string;
+  root: string;
+  lastAccessed: string;
+}
+
+export interface RecordRecentProjectOptions {
+  homeDir?: string;
+  now?: () => string;
+  limit?: number;
+}
+
+export function recentProjectsRegistryPath(homeDir = homedir()): string {
+  return join(homeDir, ".pneuma", "projects.json");
+}
+
+export function loadRecentProjects(homeDir = homedir()): RecentProjectRecord[] {
+  const path = recentProjectsRegistryPath(homeDir);
+  try {
+    const records = JSON.parse(readFileSync(path, "utf-8")) as RecentProjectRecord[];
+    return records.filter((record) => existsSync(record.root));
+  } catch {
+    return [];
+  }
+}
+
+export function saveRecentProjects(records: RecentProjectRecord[], homeDir = homedir()): void {
+  const path = recentProjectsRegistryPath(homeDir);
+  mkdirSync(join(homeDir, ".pneuma"), { recursive: true });
+  writeFileSync(path, JSON.stringify(records, null, 2));
+}
+
+export function recordRecentProject(projectRoot: string, options: RecordRecentProjectOptions = {}): RecentProjectRecord {
+  const project = createProject(projectRoot);
+  const home = options.homeDir ?? homedir();
+  const record: RecentProjectRecord = {
+    projectId: project.projectId,
+    name: project.name,
+    ...(project.description ? { description: project.description } : {}),
+    root: resolve(projectRoot),
+    lastAccessed: options.now?.() ?? defaultNow(),
+  };
+  const limit = options.limit ?? 50;
+  const next = [
+    record,
+    ...loadRecentProjects(home).filter((existing) => existing.projectId !== record.projectId),
+  ].slice(0, limit);
+  saveRecentProjects(next, home);
+  return record;
+}
+```
+
+- [ ] **Step 4: Run the focused test and confirm it passes**
+
+Run:
+
+```bash
+bun test core/__tests__/project.test.ts
+```
+
+Expected: PASS.
+
+## Task 4: CLI Argument Parsing
+
+**Files:**
+- Modify: `bin/pneuma-cli-helpers.ts`
+- Modify: `bin/__tests__/pneuma-cli-helpers.test.ts`
+
+- [ ] **Step 1: Add failing parser tests**
+
+Add these tests to `bin/__tests__/pneuma-cli-helpers.test.ts`:
+
+```ts
+test("parseCliArgs parses project and role flags", () => {
+  const parsed = parseCliArgs(
+    [
+      "bun",
+      "bin/pneuma.ts",
+      "webcraft",
+      "--project",
+      "./site",
+      "--role",
+      "Build the home page",
+    ],
+    "/tmp/base",
+  );
+
+  expect(parsed.mode).toBe("webcraft");
+  expect(parsed.projectRoot).toBe("/tmp/base/site");
+  expect(parsed.role).toBe("Build the home page");
+  expect(parsed.workspace).toBe("/tmp/base");
+});
+
+test("parseCliArgs preserves quick-session defaults when project is absent", () => {
+  const parsed = parseCliArgs(["bun", "bin/pneuma.ts", "doc"], "/tmp/workspace");
+
+  expect(parsed.projectRoot).toBe("");
+  expect(parsed.role).toBe("");
+  expect(parsed.workspace).toBe("/tmp/workspace");
+});
+```
+
+- [ ] **Step 2: Run the focused parser test and confirm it fails**
+
+Run:
+
+```bash
+bun test bin/__tests__/pneuma-cli-helpers.test.ts
+```
+
+Expected: FAIL because `projectRoot` and `role` are not on `ParsedCliArgs`.
+
+- [ ] **Step 3: Extend parser types and logic**
+
+Modify `bin/pneuma-cli-helpers.ts`:
+
+```ts
+export interface ParsedCliArgs {
+  mode: string;
+  workspace: string;
+  projectRoot: string;
+  role: string;
+  port: number;
+  backendType: AgentBackendType;
+  showHelp: boolean;
+  showVersion: boolean;
+  noOpen: boolean;
+  debug: boolean;
+  forceDev: boolean;
+  noPrompt: boolean;
+  skipSkill: boolean;
+  replayPackage: string;
+  replaySource: string;
+  sessionName: string;
+  viewing: boolean;
+}
+```
+
+Inside `parseCliArgs` initialize:
+
+```ts
+let projectRoot = "";
+let role = "";
+```
+
+Add flag handling:
+
+```ts
+} else if (arg === "--project" && i + 1 < args.length) {
+  projectRoot = resolve(cwd, args[++i]);
+} else if (arg === "--role" && i + 1 < args.length) {
+  role = args[++i];
+```
+
+Return the new fields:
+
+```ts
+return {
+  mode,
+  workspace: resolve(cwd, workspace),
+  projectRoot,
+  role,
+  port,
+  backendType,
+  showHelp,
+  showVersion,
+  noOpen,
+  debug,
+  forceDev,
+  noPrompt,
+  skipSkill,
+  replayPackage,
+  replaySource,
+  sessionName,
+  viewing,
+};
+```
+
+- [ ] **Step 4: Run parser tests**
+
+Run:
+
+```bash
+bun test bin/__tests__/pneuma-cli-helpers.test.ts
+```
+
+Expected: PASS.
+
+## Task 5: Project Runtime Resolution in CLI
+
+**Files:**
+- Modify: `bin/pneuma.ts`
+- Modify: `core/project.ts`
+- Modify: `core/__tests__/project.test.ts`
+
+- [ ] **Step 1: Add a runtime resolver test**
+
+Append this test to `core/__tests__/project.test.ts`:
+
+```ts
+import { resolveProjectRuntime } from "../project.js";
+
+describe("project runtime", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = join(tmpdir(), `pneuma-project-runtime-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(root, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test("resolveProjectRuntime creates a project session workspace", () => {
+    const runtime = resolveProjectRuntime({
+      projectRoot: root,
+      mode: "webcraft",
+      displayName: "Webcraft",
+      backendType: "claude-code",
+      role: "Build the hero section",
+      now: () => "2026-04-28T05:00:00.000Z",
+      projectIdFactory: () => "project_runtime",
+      sessionIdFactory: () => "web-runtime",
+    });
+
+    expect(runtime.project.projectId).toBe("project_runtime");
+    expect(runtime.session.sessionId).toBe("web-runtime");
+    expect(runtime.workspace).toBe(join(root, ".pneuma", "sessions", "web-runtime", "workspace"));
+    expect(runtime.projectRoot).toBe(root);
+  });
+});
+```
+
+- [ ] **Step 2: Run the focused test and confirm it fails**
+
+Run:
+
+```bash
+bun test core/__tests__/project.test.ts
+```
+
+Expected: FAIL because `resolveProjectRuntime` does not exist.
+
+- [ ] **Step 3: Implement the runtime resolver**
+
+Add this to `core/project.ts`:
+
+```ts
+export interface ResolveProjectRuntimeOptions {
+  projectRoot: string;
+  mode: string;
+  displayName: string;
+  backendType: "claude-code" | "codex";
+  role?: string;
+  now?: () => string;
+  projectIdFactory?: () => string;
+  sessionIdFactory?: () => string;
+}
+
+export interface ProjectRuntime {
+  projectRoot: string;
+  workspace: string;
+  project: ProjectManifest;
+  session: ProjectSessionManifest;
+}
+
+export function resolveProjectRuntime(options: ResolveProjectRuntimeOptions): ProjectRuntime {
+  const project = createProject(options.projectRoot, {
+    now: options.now,
+    idFactory: options.projectIdFactory,
+  });
+  const session = createProjectSession(options.projectRoot, {
+    mode: options.mode,
+    displayName: options.displayName,
+    backendType: options.backendType,
+    role: options.role,
+    now: options.now,
+    idFactory: options.sessionIdFactory,
+  });
+  recordRecentProject(options.projectRoot, { now: options.now });
+  return {
+    projectRoot: resolve(options.projectRoot),
+    workspace: session.sessionWorkspace,
+    project,
+    session,
+  };
+}
+```
+
+- [ ] **Step 4: Wire runtime resolution into `bin/pneuma.ts`**
+
+In `bin/pneuma.ts`, extend parsed args:
+
+```ts
+const { mode, port, backendType, noOpen, debug, forceDev, noPrompt, skipSkill, replaySource, sessionName, viewing, projectRoot, role } = parsedArgs;
+let { workspace, replayPackage } = parsedArgs;
+```
+
+After mode manifest loading and before workspace existence checks, add:
+
+```ts
+let activeProjectRoot = "";
+let projectSessionId = "";
+
+if (projectRoot) {
+  const { resolveProjectRuntime } = await import("../core/project.js");
+  const runtime = resolveProjectRuntime({
+    projectRoot,
+    mode: modeName,
+    displayName: manifest.displayName,
+    backendType,
+    role,
+  });
+  activeProjectRoot = runtime.projectRoot;
+  projectSessionId = runtime.session.sessionId;
+  workspace = runtime.workspace;
+  p.log.info(`Project: ${runtime.project.name} (${activeProjectRoot})`);
+  p.log.info(`Project session: ${projectSessionId}`);
+}
+```
+
+Do not change existing quick-session behavior. All existing call sites for `loadSession(workspace)`, `saveSession(workspace)`, `installSkill`, `startServer({ workspace })`, backend `cwd: workspace`, and `startFileWatcher` should continue using the resolved `workspace` variable.
+
+- [ ] **Step 5: Add help text for project flags**
+
+In the CLI usage block in `bin/pneuma.ts`, add:
+
+```text
+  --project <path>             Launch inside an explicit Pneuma project root
+  --role <text>                Describe this session's role within the project
+```
+
+- [ ] **Step 6: Run foundation tests**
+
+Run:
+
+```bash
+bun test core/__tests__/project.test.ts bin/__tests__/pneuma-cli-helpers.test.ts
+```
+
+Expected: PASS.
+
+## Task 6: Launcher Routes for Project Records
+
+**Files:**
+- Modify: `server/index.ts`
+- Create: `server/__tests__/project-routes.test.ts`
+
+- [ ] **Step 1: Add failing route tests**
+
+Create `server/__tests__/project-routes.test.ts`:
+
+```ts
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { startServer } from "../index.js";
+
+const TEST_PORT = 19891;
+const TEST_WORKSPACE = join(tmpdir(), `pneuma-project-routes-workspace-${Date.now()}`);
+const TEST_PROJECT = join(tmpdir(), `pneuma-project-routes-project-${Date.now()}`);
+
+let server: Awaited<ReturnType<typeof startServer>>;
+
+function api(path: string, init?: RequestInit) {
+  return fetch(`http://localhost:${TEST_PORT}${path}`, init);
+}
+
+describe("project launcher routes", () => {
+  beforeAll(async () => {
+    mkdirSync(TEST_WORKSPACE, { recursive: true });
+    mkdirSync(TEST_PROJECT, { recursive: true });
+    server = await startServer({
+      port: TEST_PORT,
+      workspace: TEST_WORKSPACE,
+      launcherMode: true,
+    });
+  });
+
+  afterAll(() => {
+    server?.stop?.();
+    rmSync(TEST_WORKSPACE, { recursive: true, force: true });
+    rmSync(TEST_PROJECT, { recursive: true, force: true });
+  });
+
+  test("GET /api/projects returns a projects array", async () => {
+    const res = await api("/api/projects");
+    expect(res.status).toBe(200);
+    const body = await res.json() as { projects: unknown[] };
+    expect(Array.isArray(body.projects)).toBe(true);
+  });
+
+  test("POST /api/projects creates an explicit project", async () => {
+    const res = await api("/api/projects", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        root: TEST_PROJECT,
+        name: "Route Project",
+        description: "Created from the launcher API",
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as { project: { name: string; root: string } };
+    expect(body.project.name).toBe("Route Project");
+    expect(body.project.root).toBe(TEST_PROJECT);
+  });
+
+  test("GET /api/projects includes newly created projects", async () => {
+    const res = await api("/api/projects");
+    const body = await res.json() as { projects: Array<{ name: string; root: string }> };
+    expect(body.projects.some((p) => p.name === "Route Project" && p.root === TEST_PROJECT)).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run route tests and confirm failure**
+
+Run:
+
+```bash
+bun test server/__tests__/project-routes.test.ts
+```
+
+Expected: FAIL because `/api/projects` does not exist.
+
+- [ ] **Step 3: Add project routes inside Launcher mode**
+
+In `server/index.ts`, import project helpers:
+
+```ts
+import { createProject, loadRecentProjects, recordRecentProject } from "../core/project.js";
+```
+
+Inside `if (options.launcherMode)`, near the existing `/api/sessions` route, add:
+
+```ts
+app.get("/api/projects", (c) => {
+  const projects = loadRecentProjects();
+  return c.json({ projects });
+});
+
+app.post("/api/projects", async (c) => {
+  try {
+    const body = await c.req.json<{ root?: string; name?: string; description?: string }>();
+    const rawRoot = body.root?.trim();
+    if (!rawRoot) return c.json({ error: "root is required" }, 400);
+    const root = resolve(rawRoot.replace(/^~/, homedir()));
+    mkdirSync(root, { recursive: true });
+    const project = createProject(root, {
+      name: body.name,
+      description: body.description,
+    });
+    recordRecentProject(root);
+    return c.json({ project });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return c.json({ error: message }, 500);
+  }
+});
+```
+
+- [ ] **Step 4: Extend `/api/launch` request body and child args**
+
+In the `/api/launch` route, extend the destructured body:
+
+```ts
+const { specifier, workspace: targetWorkspace, projectRoot, role, initParams, skipSkill, backendType, replayPackage: replayPkg, replaySource, sessionName, viewing } = await c.req.json<{
+  specifier: string;
+  workspace: string;
+  projectRoot?: string;
+  role?: string;
+  initParams?: Record<string, string | number>;
+  skipSkill?: boolean;
+  backendType?: AgentBackendType;
+  replayPackage?: string;
+  replaySource?: string;
+  sessionName?: string;
+  viewing?: boolean;
+}>();
+```
+
+When building child args, use project launch when `projectRoot` is present:
+
+```ts
+const args = projectRoot
+  ? ["bun", pneumaBin, specifier, "--project", resolve(projectRoot.replace(/^~/, homedir())), "--no-prompt", "--no-open"]
+  : ["bun", pneumaBin, specifier, "--workspace", resolvedWorkspace, "--no-prompt", "--no-open"];
+
+if (role?.trim()) args.push("--role", role.trim());
+```
+
+Keep the existing `--backend`, `--skip-skill`, `--viewing`, replay, debug, and dev argument pushes unchanged.
+
+- [ ] **Step 5: Run route tests**
+
+Run:
+
+```bash
+bun test server/__tests__/project-routes.test.ts
+```
+
+Expected: PASS.
+
+## Task 7: Verification and Commit
+
+**Files:**
+- Modify all files touched in Tasks 1-6.
+
+- [ ] **Step 1: Run focused tests**
+
+Run:
+
+```bash
+bun test core/__tests__/project.test.ts bin/__tests__/pneuma-cli-helpers.test.ts server/__tests__/project-routes.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run broader relevant tests**
+
+Run:
+
+```bash
+bun test bin/__tests__/pneuma-cli-helpers.test.ts server/__tests__/security-path-traversal.test.ts server/__tests__/skill-installer.test.ts core/__tests__/project.test.ts server/__tests__/project-routes.test.ts
+```
+
+Expected: PASS. If `security-path-traversal.test.ts` fails because fixed ports are occupied, rerun once after confirming no local Pneuma test server is still active.
+
+- [ ] **Step 3: Run full test suite if the focused set passes**
+
+Run:
+
+```bash
+bun test
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Inspect quick-session behavior by launching help and parser-only paths**
+
+Run:
+
+```bash
+bun bin/pneuma.ts --help
+```
+
+Expected: the command prints usage and includes both `--workspace` and `--project`.
+
+- [ ] **Step 5: Commit the foundation**
+
+```bash
+git add core/project.ts core/__tests__/project.test.ts bin/pneuma-cli-helpers.ts bin/__tests__/pneuma-cli-helpers.test.ts bin/pneuma.ts server/index.ts server/__tests__/project-routes.test.ts
+git commit -m "feat: add project session foundation"
+```
+
+## Follow-Up Board Cards
+
+These are intentionally outside this foundation plan:
+
+1. Launcher Project Overview UI
+   - Recent Projects section.
+   - Project detail screen.
+   - Start/resume project session actions.
+
+2. Project Context and Preferences Injection
+   - Inject project identity, role, and peer session summaries.
+   - Add project preference layer after global preferences.
+   - Make project-over-personal conflict ordering explicit.
+
+3. Cross-Mode Handoff Flow
+   - Generate editable handoff drafts.
+   - Write `.pneuma/handoffs/<handoff-id>.md`.
+   - Resume latest matching mode session or start a new session.
+
+4. Quick Session to Project Upgrade
+   - Seed project from an existing quick session.
+   - Choose or create project root.
+   - Fork session state without destroying the source quick session.
+
+5. Project-Level Evolve
+   - Scan project sessions, handoffs, and timeline.
+   - Write only to `.pneuma/project-preferences.md`.
+
+## Self-Review
+
+- Spec coverage for the foundation is complete: project identity, project session sandbox, recent-project registry, explicit project activation, quick-session preservation, and basic Launcher launch plumbing all map to tasks.
+- Deferred items match independently testable subsystems from the design spec and are listed as follow-up board cards.
+- No task requires changing existing quick-session storage paths.
+- `workspace` continues to mean backend cwd and watcher root; for project sessions it resolves to the session sandbox.
+- The plan avoids hidden cross-session reads and does not introduce project-wide file watching.

--- a/docs/superpowers/specs/2026-04-28-project-layer-design.md
+++ b/docs/superpowers/specs/2026-04-28-project-layer-design.md
@@ -1,0 +1,528 @@
+# Pneuma Project Layer Design
+
+**Date:** 2026-04-28  
+**Status:** Draft, direction approved  
+**Decision:** Project Root / Session Sandbox model
+
+## Overview
+
+Introduce an optional Project layer above Pneuma sessions. A project is a user-owned directory with a persistent identity, multiple isolated sessions, project-scoped preferences, explicit cross-mode handoffs, and a Launcher-level overview.
+
+The design preserves the 2.x quick-session workflow. Users can still run `pneuma <mode>` for a one-off session without creating or understanding projects. A project only exists after the user explicitly creates one or upgrades an existing quick session.
+
+**Core formula:** `ProjectRoot(deliverables) + SessionSandbox(process state) + ExplicitHandoff(cross-mode context)`
+
+## Goals
+
+1. **Optional organization layer** - projects are useful for long-running work, but not required for quick sessions.
+2. **User-owned directory** - project roots are normal directories the user can open in Finder, initialize with git, and push to GitHub.
+3. **Multiple isolated sessions** - a project can host many sessions across one or more modes without session histories bleeding into each other.
+4. **Clean deliverable surface** - final outputs live in the project root or an explicit project-approved location, while agent process files stay inside session sandboxes.
+5. **Explicit cross-mode collaboration** - mode switches transfer reviewed handoff context, not hidden access to another session's private history.
+6. **Project-scoped memory** - project preferences and project evolution exist separately from global user preferences.
+7. **Git-friendly metadata** - Pneuma metadata is visible, centralized, and easy to ignore.
+8. **Recoverable state** - copying a project directory should preserve project identity, sessions, handoffs, and project preferences.
+
+## Non-Goals
+
+- Strong multi-writer consistency. Concurrent writes use last-write-wins semantics.
+- Realtime syncing into already-running sessions. Project preference changes apply on next session start or activation.
+- Automatic migration of existing workspaces into projects.
+- Mode-specific handoff protocols. All modes use the same handoff contract.
+- Hidden session introspection. Sessions do not inspect each other's private history unless the user creates a handoff.
+- Full git workflow management. Projects are git-friendly, but Pneuma does not own commit or push semantics.
+
+## Design Principles
+
+### Project Root / Session Sandbox
+
+The project root is the user's deliverable directory. It should look like the actual product, website, document set, deck, video source, or course material being built.
+
+Each project session gets its own sandbox under `.pneuma/sessions/<session-id>/`. Agent scratch files, private process state, session history, and transient workspace artifacts stay there by default.
+
+```text
+<project-root>/
+  deliverables...
+  .pneuma/
+    project.json
+    project-preferences.md
+    timeline.jsonl
+    sessions/
+      <session-id>/
+        session.json
+        history.json
+        workspace/
+        scratch/
+    handoffs/
+      <handoff-id>.md
+```
+
+This model gives Pneuma two explicit roots:
+
+- `projectRoot` - user-visible deliverables and project metadata.
+- `sessionWorkspace` - agent working area for one session.
+
+### Explicit Publish Boundary
+
+A session does not naturally leak its workspace into the project root. Deliverables reach the project root through explicit writes:
+
+- The user asks for a concrete output path.
+- The mode already has a known deliverable path.
+- The agent performs a project publish action and records it in the project timeline.
+
+This is stricter than the current workspace-only model, but it matches the project promise: opening the project root should show outcomes, not process debris.
+
+### Session Isolation
+
+Sessions in the same project share identity, project preferences, and project-level summaries, but not raw internal histories.
+
+Allowed shared inputs:
+
+- `project.json`
+- `project-preferences.md`
+- project session index metadata
+- user-approved handoffs
+- project timeline facts
+- deliverables in `projectRoot`
+
+Disallowed implicit inputs:
+
+- another session's full `history.json`
+- another session's scratch files
+- another session's private workspace
+- hidden mode-specific state
+
+## Project Metadata
+
+### `.pneuma/project.json`
+
+```ts
+interface ProjectManifest {
+  schemaVersion: 1;
+  projectId: string;
+  name: string;
+  description?: string;
+  createdAt: string;
+  updatedAt: string;
+  root: string;
+  deliverablePaths?: string[];
+  defaultBackendType?: "claude" | "codex";
+}
+```
+
+Rules:
+
+- Creating or activating a project writes this file.
+- Name and description changes are explicit project metadata edits.
+- Metadata edits append to `.pneuma/timeline.jsonl`.
+- `root` is advisory and may be refreshed if the directory is moved.
+
+### Session Index
+
+Each project session has a local session manifest:
+
+```ts
+interface ProjectSessionManifest {
+  schemaVersion: 1;
+  sessionId: string;
+  projectId: string;
+  mode: string;
+  role?: string;
+  displayName: string;
+  backendType: "claude" | "codex";
+  status: "active" | "idle" | "archived";
+  createdAt: string;
+  lastAccessed: string;
+  sessionWorkspace: string;
+  deliverablePaths?: string[];
+  sourceQuickSessionId?: string;
+}
+```
+
+The project overview can derive its session list by scanning `.pneuma/sessions/*/session.json`. A global recent-projects registry may cache this for Launcher performance, but the project directory remains the source of truth.
+
+## Storage Layout
+
+### Project Root
+
+```text
+<project-root>/
+  README.md
+  index.html
+  deck.pptx
+  assets/
+  .pneuma/
+```
+
+The root contains user-recognizable outputs. Pneuma should not fill it with logs, snapshots, temporary prompts, or backend-specific internal files unless the user explicitly wants those as deliverables.
+
+### `.pneuma/`
+
+```text
+.pneuma/
+  project.json
+  project-preferences.md
+  timeline.jsonl
+  sessions/
+    webcraft-20260428-abc123/
+      session.json
+      history.json
+      config.json
+      workspace/
+      scratch/
+      shadow.git/
+      checkpoints.jsonl
+      replay-checkout/
+      resumed-context.xml
+    doc-20260428-def456/
+      ...
+  handoffs/
+    20260428T101500-webcraft-to-doc.md
+```
+
+Existing per-workspace `.pneuma` files move inside the project session sandbox for project sessions. Quick sessions keep the current 2.x layout.
+
+### Git Ignore Recommendation
+
+Project creation should offer or write a local ignore block:
+
+```gitignore
+# Pneuma project metadata and session state
+.pneuma/
+```
+
+This keeps normal project commits clean. Users who want to back up project sessions can opt into tracking `.pneuma/` or copy the project directory outside git.
+
+## Launcher Experience
+
+The Launcher gets two top-level recency sections:
+
+1. **Recent Projects** - persistent workspaces with project identity.
+2. **Recent Sessions** - independent quick sessions.
+
+Opening a project shows:
+
+- Project name, description, root path, created time.
+- Session list with mode, role, backend, activity, and status.
+- Actions to start a new session in any mode.
+- Actions to resume an existing session.
+- Project actions: edit identity, evolve project, open folder, upgrade/export/backup affordances as they become available.
+
+Creating a project is a Launcher-level action. It does not require first starting a session.
+
+## Session Startup
+
+### Quick Session
+
+Existing behavior remains:
+
+```text
+pneuma <mode> --workspace <workspace>
+```
+
+The session uses the current workspace-local `.pneuma/` structure. No project metadata is required.
+
+### New Project Session
+
+Project session startup takes both a project root and a session sandbox:
+
+```text
+pneuma <mode> --project <project-root> --role "Build the landing page"
+```
+
+Resolved runtime context:
+
+```ts
+interface RuntimeSessionContext {
+  mode: string;
+  backendType: "claude" | "codex";
+  project?: {
+    projectId: string;
+    name: string;
+    description?: string;
+    root: string;
+    preferencesPath: string;
+    sessions: ProjectSessionSummary[];
+  };
+  workspace: string;          // sessionWorkspace, not projectRoot
+  projectRoot?: string;       // deliverable root
+  role?: string;
+}
+```
+
+The backend still receives a normal workspace. For project sessions, that workspace is the session sandbox. Project information is injected as explicit context so the agent knows where deliverables belong.
+
+## Agent Context Injection
+
+At session start, Pneuma injects a project section into backend instructions:
+
+```markdown
+### Project Context
+
+Project: <name>
+Root: <project-root>
+Description: <description>
+This session role: <role>
+
+Deliverables should be written to the project root or explicit deliverable paths.
+Scratch work and intermediate files should stay in this session workspace.
+
+Other sessions:
+- <mode> - <role/displayName> - <status> - last active <time>
+```
+
+Project preferences are injected after global preferences and before mode-specific runtime instructions. If project and personal preferences conflict, project preferences win and the agent should briefly state that it is following the project-specific constraint.
+
+## Cross-Mode Handoffs
+
+Mode switching is explicit, reviewable, and non-destructive.
+
+### Flow
+
+1. User chooses "Switch mode" from a project session.
+2. Source session generates a handoff draft:
+   - current goal
+   - key decisions
+   - constraints
+   - relevant deliverables
+   - open questions
+   - recommended next mode action
+3. UI shows the handoff draft.
+4. User can cancel, edit, or confirm.
+5. On confirm, Pneuma writes `.pneuma/handoffs/<handoff-id>.md`.
+6. Target mode either resumes the most recent session for that mode or starts a new session.
+7. Target session receives the handoff as startup context.
+8. Project timeline records the handoff event.
+
+### Handoff File
+
+```markdown
+---
+handoffId: 20260428T101500-webcraft-to-doc
+projectId: ...
+fromSessionId: ...
+toSessionId: ...
+fromMode: webcraft
+toMode: doc
+createdAt: 2026-04-28T10:15:00Z
+---
+
+# Handoff: webcraft to doc
+
+## Goal
+
+## Decisions
+
+## Constraints
+
+## Relevant Files
+
+## Open Questions
+
+## Suggested Next Step
+```
+
+Handoff files are the collaboration boundary. The target session does not read raw source session history unless the user explicitly includes excerpts in the handoff.
+
+## Project Preferences
+
+Pneuma keeps two orthogonal preference layers:
+
+- Personal preferences: `~/.pneuma/preferences/`
+- Project preferences: `<project-root>/.pneuma/project-preferences.md`
+
+Project preferences apply to all sessions in that project only. They are natural-language documents managed by agents and users, with the same "observe carefully, record sparingly" standard as personal preferences.
+
+Conflict rule:
+
+1. Project preference wins over personal preference.
+2. Mode-specific critical constraints still apply unless the project explicitly narrows or overrides them.
+3. The agent should mention the conflict briefly when it affects visible behavior.
+
+Running sessions are not required to hot-reload project preference changes. The updated preferences apply on next start or activation.
+
+## Project Evolution
+
+Project evolution is a project-scoped version of the existing preference analysis flow.
+
+Inputs:
+
+- all project session manifests
+- handoff files
+- project timeline
+- project deliverable summaries
+- user-approved session summaries
+
+Outputs:
+
+- updates to `.pneuma/project-preferences.md`
+- a timeline event describing the evolution run
+
+Project evolution must not write to `~/.pneuma/preferences/`. Its output is local to the project.
+
+## Upgrade From Quick Session
+
+A quick session can be upgraded into a project without destroying the original session.
+
+### Flow
+
+1. User chooses "Create project from this session" or creates a project and selects a seed quick session.
+2. User selects or creates the project root.
+3. Pneuma creates `.pneuma/project.json` in the project root.
+4. Pneuma copies or summarizes the quick session into a new project session sandbox.
+5. Existing deliverables can be copied, moved, or left in place depending on the user's selected root.
+6. The original quick session remains recoverable.
+7. The project timeline records the upgrade.
+
+Upgrade is a fork. It does not convert old workspaces in place unless the user selected that same directory as the project root.
+
+## File Watching
+
+Project sessions default to watching `sessionWorkspace`, not the whole project root.
+
+Mode viewers that need deliverable previews may subscribe to explicit deliverable paths in `projectRoot`. This should be opt-in per mode or per project session, because watching the whole project root would make unrelated deliverable edits flood the session.
+
+Watcher policy:
+
+- Always watch session-owned files.
+- Watch project deliverable paths only when declared.
+- Do not watch `.pneuma/sessions/*` from other sessions.
+- Never infer cross-session collaboration from filesystem changes alone.
+
+## Timeline
+
+`.pneuma/timeline.jsonl` records project-level facts:
+
+```ts
+type ProjectTimelineEvent =
+  | { type: "project.created"; at: string; projectId: string; name: string }
+  | { type: "project.updated"; at: string; changes: Record<string, unknown> }
+  | { type: "session.created"; at: string; sessionId: string; mode: string; role?: string }
+  | { type: "session.resumed"; at: string; sessionId: string }
+  | { type: "handoff.created"; at: string; handoffId: string; fromSessionId: string; toSessionId?: string }
+  | { type: "deliverable.published"; at: string; sessionId: string; paths: string[] }
+  | { type: "project.evolved"; at: string; sourceSessionCount: number };
+```
+
+This is not a full audit log. It is a user-visible collaboration timeline for recovery, explanation, and future analysis.
+
+## Global Registries
+
+Quick sessions continue to use the existing global recent-session registry.
+
+Projects add a separate recent-projects registry:
+
+```text
+~/.pneuma/projects.json
+```
+
+```ts
+interface RecentProjectRecord {
+  projectId: string;
+  name: string;
+  description?: string;
+  root: string;
+  lastAccessed: string;
+}
+```
+
+The registry is a cache for Launcher convenience. If it is missing or stale, Pneuma can rebuild recent project metadata from known roots when the user opens a project.
+
+## Error Handling
+
+- Missing `.pneuma/project.json`: the directory is not a project until the user activates it.
+- Corrupt `project.json`: show a repair prompt; do not silently create a different project identity.
+- Missing session sandbox: mark the session as unavailable in the project overview.
+- Missing handoff file: target session starts without that handoff and records a warning.
+- Moved project directory: refresh the advisory `root` value after user confirmation.
+- Preference parse issues: project preferences are Markdown; unreadable files are skipped with a visible warning.
+
+## Backward Compatibility
+
+2.x quick sessions remain valid. Existing workspaces continue to use:
+
+```text
+<workspace>/.pneuma/session.json
+<workspace>/.pneuma/history.json
+```
+
+Project sessions use:
+
+```text
+<project-root>/.pneuma/sessions/<session-id>/session.json
+<project-root>/.pneuma/sessions/<session-id>/history.json
+```
+
+This avoids a forced migration and keeps old workspace restore semantics intact.
+
+## Implementation Decomposition
+
+This should become several board cards after spec approval:
+
+1. **Project metadata and registry**
+   - create/read/update `project.json`
+   - recent-projects registry
+   - explicit project activation
+
+2. **Project session sandbox runtime**
+   - resolve `projectRoot` and `sessionWorkspace`
+   - write project session manifests
+   - preserve quick-session behavior
+
+3. **Launcher project overview**
+   - Recent Projects section
+   - project detail view
+   - create project and start/resume project session actions
+
+4. **Project context and preferences injection**
+   - inject project identity, role, session summaries, and project preferences
+   - implement project-over-personal conflict ordering
+
+5. **Mode switch handoff**
+   - generate editable handoff drafts
+   - write handoff files
+   - resume latest matching mode session or create a new one
+   - record timeline events
+
+6. **Quick-session upgrade**
+   - seed project from existing session
+   - choose root
+   - fork session state without destroying original session
+
+7. **Project evolution**
+   - scan project sessions and handoffs
+   - update project preferences only
+   - record project evolution timeline event
+
+## Testing Strategy
+
+### Unit Tests
+
+- Project manifest read/write and validation.
+- Recent-project registry update and stale-path handling.
+- Session sandbox path resolution.
+- Preference merge ordering.
+- Handoff file frontmatter parsing.
+
+### Integration Tests
+
+- Create a project from Launcher and start a session.
+- Start two sessions in the same project with different modes.
+- Verify each session writes process files only inside its sandbox.
+- Switch modes and confirm handoff context appears in the target session.
+- Upgrade a quick session into a project and verify the original remains recoverable.
+
+### Regression Tests
+
+- `pneuma <mode>` without project arguments behaves exactly like a quick session.
+- Existing workspace `.pneuma/session.json` restore still works.
+- File watcher does not subscribe to the whole project root by default.
+- Ignoring `.pneuma/` keeps project deliverables git-clean.
+
+## Open Decisions Resolved
+
+- **Directory model:** project root is the deliverable directory; sessions use isolated sandboxes.
+- **Project creation:** explicit only; no automatic project detection.
+- **Cross-session collaboration:** handoff files only; no hidden session-history reads.
+- **Preference conflict:** project preferences override personal preferences.
+- **Upgrade semantics:** fork, not in-place migration.

--- a/docs/superpowers/specs/2026-04-28-project-layer-design.md
+++ b/docs/superpowers/specs/2026-04-28-project-layer-design.md
@@ -1,7 +1,7 @@
 # Pneuma Project Layer Design
 
-**Date:** 2026-04-28  
-**Status:** Draft, direction approved  
+**Date:** 2026-04-28
+**Status:** Draft, direction approved
 **Decision:** Project Root / Session Sandbox model
 
 ## Overview

--- a/server/__tests__/project-routes.test.ts
+++ b/server/__tests__/project-routes.test.ts
@@ -224,7 +224,7 @@ describe("project launcher routes", () => {
         projectRoot: upgradeRoot,
         name: "Route Upgrade",
         displayName: "Doc",
-        copyDeliverables: true,
+        deliverableTransfer: "copy",
       }),
     });
 

--- a/server/__tests__/project-routes.test.ts
+++ b/server/__tests__/project-routes.test.ts
@@ -3,16 +3,20 @@ import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node
 import { join } from "node:path";
 import { homedir, tmpdir } from "node:os";
 import { startServer } from "../index.js";
-import { recentProjectsRegistryPath } from "../../core/project.js";
+import { createProjectSession, recentProjectsRegistryPath } from "../../core/project.js";
 
 const TEST_PORT = 19891;
 const TEST_WORKSPACE = join(tmpdir(), `pneuma-project-routes-workspace-${Date.now()}`);
 const TEST_PROJECT = join(tmpdir(), `pneuma-project-routes-project-${Date.now()}`);
+const TEST_QUICK_WORKSPACE = join(tmpdir(), `pneuma-project-routes-quick-${Date.now()}`);
 const REGISTRY_PATH = recentProjectsRegistryPath(homedir());
+const SESSION_REGISTRY_PATH = join(homedir(), ".pneuma", "sessions.json");
 
 let server: Awaited<ReturnType<typeof startServer>>;
 let registryBackup: string | null = null;
 let hadRegistry = false;
+let sessionRegistryBackup: string | null = null;
+let hadSessionRegistry = false;
 
 function api(path: string, init?: RequestInit) {
   return fetch(`http://localhost:${TEST_PORT}${path}`, init);
@@ -22,8 +26,12 @@ describe("project launcher routes", () => {
   beforeAll(async () => {
     mkdirSync(TEST_WORKSPACE, { recursive: true });
     mkdirSync(TEST_PROJECT, { recursive: true });
+    mkdirSync(TEST_QUICK_WORKSPACE, { recursive: true });
+    mkdirSync(join(homedir(), ".pneuma"), { recursive: true });
     hadRegistry = existsSync(REGISTRY_PATH);
     if (hadRegistry) registryBackup = readFileSync(REGISTRY_PATH, "utf-8");
+    hadSessionRegistry = existsSync(SESSION_REGISTRY_PATH);
+    if (hadSessionRegistry) sessionRegistryBackup = readFileSync(SESSION_REGISTRY_PATH, "utf-8");
 
     server = await startServer({
       port: TEST_PORT,
@@ -36,10 +44,16 @@ describe("project launcher routes", () => {
     server?.stop?.();
     rmSync(TEST_WORKSPACE, { recursive: true, force: true });
     rmSync(TEST_PROJECT, { recursive: true, force: true });
+    rmSync(TEST_QUICK_WORKSPACE, { recursive: true, force: true });
     if (hadRegistry && registryBackup !== null) {
       writeFileSync(REGISTRY_PATH, registryBackup);
     } else {
       rmSync(REGISTRY_PATH, { force: true });
+    }
+    if (hadSessionRegistry && sessionRegistryBackup !== null) {
+      writeFileSync(SESSION_REGISTRY_PATH, sessionRegistryBackup);
+    } else {
+      rmSync(SESSION_REGISTRY_PATH, { force: true });
     }
   });
 
@@ -71,5 +85,102 @@ describe("project launcher routes", () => {
     const res = await api("/api/projects");
     const body = await res.json() as { projects: Array<{ name: string; root: string }> };
     expect(body.projects.some((p) => p.name === "Route Project" && p.root === TEST_PROJECT)).toBe(true);
+  });
+
+  test("GET /api/projects/:projectId returns project identity and sessions", async () => {
+    createProjectSession(TEST_PROJECT, {
+      mode: "webcraft",
+      displayName: "Webcraft",
+      backendType: "codex",
+      role: "Build the home page",
+      now: () => "2026-04-28T08:00:00.000Z",
+      idFactory: () => "web-overview",
+    });
+
+    const listRes = await api("/api/projects");
+    const listBody = await listRes.json() as { projects: Array<{ projectId: string; name: string }> };
+    const record = listBody.projects.find((p) => p.name === "Route Project");
+    expect(record).toBeDefined();
+
+    const res = await api(`/api/projects/${encodeURIComponent(record!.projectId)}`);
+    expect(res.status).toBe(200);
+    const body = await res.json() as {
+      project: { name: string; description?: string; root: string; createdAt: string };
+      sessions: Array<{ sessionId: string; mode: string; role?: string; backendType: string; status: string; lastAccessed: string }>;
+    };
+
+    expect(body.project).toMatchObject({
+      name: "Route Project",
+      description: "Created from the launcher API",
+      root: TEST_PROJECT,
+    });
+    expect(body.project.createdAt).toBeTruthy();
+    expect(body.sessions).toEqual([
+      expect.objectContaining({
+        sessionId: "web-overview",
+        mode: "webcraft",
+        role: "Build the home page",
+        backendType: "codex",
+        status: "active",
+        lastAccessed: "2026-04-28T08:00:00.000Z",
+      }),
+    ]);
+  });
+
+  test("GET /api/sessions filters stale project session registry entries", async () => {
+    const projectSession = createProjectSession(TEST_PROJECT, {
+      mode: "doc",
+      displayName: "Doc",
+      backendType: "codex",
+      now: () => "2026-04-28T09:00:00.000Z",
+      idFactory: () => "doc-stale-registry",
+    });
+
+    writeFileSync(SESSION_REGISTRY_PATH, JSON.stringify([
+      {
+        id: `${projectSession.sessionWorkspace}::doc`,
+        mode: "doc",
+        displayName: "Doc",
+        workspace: projectSession.sessionWorkspace,
+        backendType: "codex",
+        lastAccessed: 2,
+      },
+      {
+        id: `${TEST_QUICK_WORKSPACE}::doc`,
+        mode: "doc",
+        displayName: "Doc",
+        workspace: TEST_QUICK_WORKSPACE,
+        backendType: "codex",
+        lastAccessed: 1,
+      },
+    ]));
+
+    const res = await api("/api/sessions");
+    expect(res.status).toBe(200);
+    const body = await res.json() as { sessions: Array<{ workspace: string }> };
+    expect(body.sessions.map((session) => session.workspace)).toEqual([TEST_QUICK_WORKSPACE]);
+  });
+
+  test("GET /api/processes/children exposes project metadata for launched project sessions", async () => {
+    const pid = 424242;
+    server.childProcesses.set(pid, {
+      proc: {} as never,
+      specifier: "webcraft",
+      workspace: TEST_PROJECT,
+      projectRoot: TEST_PROJECT,
+      projectSessionId: "web-overview",
+      url: "http://localhost:18000",
+      startedAt: 123,
+    });
+
+    const res = await api("/api/processes/children");
+    expect(res.status).toBe(200);
+    const body = await res.json() as { processes: Array<{ pid: number; projectRoot?: string; projectSessionId?: string }> };
+    expect(body.processes.find((process) => process.pid === pid)).toMatchObject({
+      projectRoot: TEST_PROJECT,
+      projectSessionId: "web-overview",
+    });
+
+    server.childProcesses.delete(pid);
   });
 });

--- a/server/__tests__/project-routes.test.ts
+++ b/server/__tests__/project-routes.test.ts
@@ -127,6 +127,135 @@ describe("project launcher routes", () => {
     ]);
   });
 
+  test("project handoff routes draft reviewed context and confirm a target session", async () => {
+    const listRes = await api("/api/projects");
+    const listBody = await listRes.json() as { projects: Array<{ projectId: string; name: string }> };
+    const record = listBody.projects.find((p) => p.name === "Route Project");
+    expect(record).toBeDefined();
+    const beforeRes = await api(`/api/projects/${encodeURIComponent(record!.projectId)}`);
+    const beforeBody = await beforeRes.json() as { sessions: Array<{ sessionId: string }> };
+
+    const draftRes = await api(`/api/projects/${encodeURIComponent(record!.projectId)}/handoffs/draft`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        fromSessionId: "web-overview",
+        toMode: "doc",
+        goal: "Turn the page into a launch brief.",
+      }),
+    });
+    expect(draftRes.status).toBe(200);
+    const draftBody = await draftRes.json() as { handoffId: string; content: string };
+    expect(draftBody.content).toContain("fromSessionId: web-overview");
+    expect(draftBody.content).toContain("toMode: doc");
+    expect(draftBody.content).toContain("Turn the page into a launch brief.");
+
+    const confirmRes = await api(`/api/projects/${encodeURIComponent(record!.projectId)}/handoffs/${encodeURIComponent(draftBody.handoffId)}/confirm`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        content: `${draftBody.content}\nReviewed in Launcher.\n`,
+        toMode: "doc",
+        targetDisplayName: "Doc",
+        backendType: "codex",
+      }),
+    });
+    expect(confirmRes.status).toBe(200);
+    const confirmBody = await confirmRes.json() as { handoff: { toSessionId?: string; content: string }; targetSession: { sessionId: string; mode: string } };
+    expect(confirmBody.targetSession.mode).toBe("doc");
+    expect(confirmBody.handoff.toSessionId).toBe(confirmBody.targetSession.sessionId);
+    expect(confirmBody.handoff.content).toContain("Reviewed in Launcher.");
+  });
+
+  test("handoff confirm rejects edited frontmatter that targets a different mode", async () => {
+    const listRes = await api("/api/projects");
+    const listBody = await listRes.json() as { projects: Array<{ projectId: string; name: string }> };
+    const record = listBody.projects.find((p) => p.name === "Route Project");
+    expect(record).toBeDefined();
+    const beforeRes = await api(`/api/projects/${encodeURIComponent(record!.projectId)}`);
+    const beforeBody = await beforeRes.json() as { sessions: Array<{ sessionId: string }> };
+
+    const draftRes = await api(`/api/projects/${encodeURIComponent(record!.projectId)}/handoffs/draft`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        fromSessionId: "web-overview",
+        toMode: "doc",
+      }),
+    });
+    const draftBody = await draftRes.json() as { handoffId: string; content: string };
+    const mismatchedContent = draftBody.content.replace("toMode: doc", "toMode: webcraft");
+
+    const confirmRes = await api(`/api/projects/${encodeURIComponent(record!.projectId)}/handoffs/${encodeURIComponent(draftBody.handoffId)}/confirm`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        content: mismatchedContent,
+        toMode: "doc",
+        targetDisplayName: "Doc",
+        backendType: "codex",
+        newSession: true,
+      }),
+    });
+
+    expect(confirmRes.status).toBe(400);
+    const afterRes = await api(`/api/projects/${encodeURIComponent(record!.projectId)}`);
+    const afterBody = await afterRes.json() as { sessions: Array<{ sessionId: string }> };
+    expect(afterBody.sessions).toHaveLength(beforeBody.sessions.length);
+  });
+
+  test("POST /api/projects/upgrade-session creates a project from a quick session fork", async () => {
+    mkdirSync(join(TEST_QUICK_WORKSPACE, ".pneuma"), { recursive: true });
+    writeFileSync(join(TEST_QUICK_WORKSPACE, ".pneuma", "session.json"), JSON.stringify({
+      sessionId: "quick-route",
+      mode: "doc",
+      backendType: "codex",
+      createdAt: 123,
+    }, null, 2));
+    writeFileSync(join(TEST_QUICK_WORKSPACE, ".pneuma", "history.json"), JSON.stringify([{ content: "route history" }]));
+    writeFileSync(join(TEST_QUICK_WORKSPACE, "route-brief.md"), "# Route Brief\n");
+
+    const upgradeRoot = join(TEST_PROJECT, "upgraded-route");
+    const res = await api("/api/projects/upgrade-session", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        sourceWorkspace: TEST_QUICK_WORKSPACE,
+        projectRoot: upgradeRoot,
+        name: "Route Upgrade",
+        displayName: "Doc",
+        copyDeliverables: true,
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as { project: { name: string; root: string }; session: { sourceQuickSessionId?: string; sessionWorkspace: string } };
+    expect(body.project).toMatchObject({ name: "Route Upgrade", root: upgradeRoot });
+    expect(body.session.sourceQuickSessionId).toBe("quick-route");
+    expect(readFileSync(join(upgradeRoot, "route-brief.md"), "utf-8")).toBe("# Route Brief\n");
+    expect(readFileSync(join(body.session.sessionWorkspace, ".pneuma", "history.json"), "utf-8")).toContain("route history");
+    expect(existsSync(join(TEST_QUICK_WORKSPACE, ".pneuma", "session.json"))).toBe(true);
+  });
+
+  test("POST /api/projects/:projectId/evolve runs project-scoped evolution", async () => {
+    const listRes = await api("/api/projects");
+    const listBody = await listRes.json() as { projects: Array<{ projectId: string; name: string }> };
+    const record = listBody.projects.find((p) => p.name === "Route Project");
+    expect(record).toBeDefined();
+    writeFileSync(join(TEST_PROJECT, "project-evolve.md"), "# Project Evolve\n");
+
+    const res = await api(`/api/projects/${encodeURIComponent(record!.projectId)}/evolve`, {
+      method: "POST",
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { sourceSessionCount: number; preferencesPath: string };
+
+    expect(body.sourceSessionCount).toBeGreaterThan(0);
+    expect(body.preferencesPath).toBe(join(TEST_PROJECT, ".pneuma", "project-preferences.md"));
+    expect(readFileSync(body.preferencesPath, "utf-8")).toContain("Project Evolution");
+    expect(readFileSync(join(TEST_PROJECT, ".pneuma", "timeline.jsonl"), "utf-8")).toContain("project.evolved");
+  });
+
   test("GET /api/sessions filters stale project session registry entries", async () => {
     const projectSession = createProjectSession(TEST_PROJECT, {
       mode: "doc",

--- a/server/__tests__/project-routes.test.ts
+++ b/server/__tests__/project-routes.test.ts
@@ -1,0 +1,75 @@
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { homedir, tmpdir } from "node:os";
+import { startServer } from "../index.js";
+import { recentProjectsRegistryPath } from "../../core/project.js";
+
+const TEST_PORT = 19891;
+const TEST_WORKSPACE = join(tmpdir(), `pneuma-project-routes-workspace-${Date.now()}`);
+const TEST_PROJECT = join(tmpdir(), `pneuma-project-routes-project-${Date.now()}`);
+const REGISTRY_PATH = recentProjectsRegistryPath(homedir());
+
+let server: Awaited<ReturnType<typeof startServer>>;
+let registryBackup: string | null = null;
+let hadRegistry = false;
+
+function api(path: string, init?: RequestInit) {
+  return fetch(`http://localhost:${TEST_PORT}${path}`, init);
+}
+
+describe("project launcher routes", () => {
+  beforeAll(async () => {
+    mkdirSync(TEST_WORKSPACE, { recursive: true });
+    mkdirSync(TEST_PROJECT, { recursive: true });
+    hadRegistry = existsSync(REGISTRY_PATH);
+    if (hadRegistry) registryBackup = readFileSync(REGISTRY_PATH, "utf-8");
+
+    server = await startServer({
+      port: TEST_PORT,
+      workspace: TEST_WORKSPACE,
+      launcherMode: true,
+    });
+  });
+
+  afterAll(() => {
+    server?.stop?.();
+    rmSync(TEST_WORKSPACE, { recursive: true, force: true });
+    rmSync(TEST_PROJECT, { recursive: true, force: true });
+    if (hadRegistry && registryBackup !== null) {
+      writeFileSync(REGISTRY_PATH, registryBackup);
+    } else {
+      rmSync(REGISTRY_PATH, { force: true });
+    }
+  });
+
+  test("GET /api/projects returns a projects array", async () => {
+    const res = await api("/api/projects");
+    expect(res.status).toBe(200);
+    const body = await res.json() as { projects: unknown[] };
+    expect(Array.isArray(body.projects)).toBe(true);
+  });
+
+  test("POST /api/projects creates an explicit project", async () => {
+    const res = await api("/api/projects", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        root: TEST_PROJECT,
+        name: "Route Project",
+        description: "Created from the launcher API",
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as { project: { name: string; root: string } };
+    expect(body.project.name).toBe("Route Project");
+    expect(body.project.root).toBe(TEST_PROJECT);
+  });
+
+  test("GET /api/projects includes newly created projects", async () => {
+    const res = await api("/api/projects");
+    const body = await res.json() as { projects: Array<{ name: string; root: string }> };
+    expect(body.projects.some((p) => p.name === "Route Project" && p.root === TEST_PROJECT)).toBe(true);
+  });
+});

--- a/server/__tests__/skill-installer.test.ts
+++ b/server/__tests__/skill-installer.test.ts
@@ -420,6 +420,16 @@ describe("installSkill", () => {
         currentSessionId: "codex-1",
         currentMode: "doc",
         currentSessionDisplayName: "Doc",
+        handoff: {
+          handoffId: "handoff-1",
+          projectId: "project_codex",
+          fromSessionId: "web-1",
+          toSessionId: "codex-1",
+          fromMode: "webcraft",
+          toMode: "doc",
+          createdAt: "2026-04-28T04:00:00.000Z",
+          content: "# Handoff\n\nReviewed launch context only.\n",
+        },
         peerSessions: [],
       },
     });
@@ -428,6 +438,8 @@ describe("installSkill", () => {
     expect(content).toContain("<!-- pneuma:project-context:start -->");
     expect(content).toContain("Codex Project");
     expect(content).toContain("Review implementation");
+    expect(content).toContain("### Confirmed Handoff");
+    expect(content).toContain("Reviewed launch context only.");
     expect(existsSync(join(workspace, "CLAUDE.md"))).toBe(false);
   });
 

--- a/server/__tests__/skill-installer.test.ts
+++ b/server/__tests__/skill-installer.test.ts
@@ -8,8 +8,9 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from "node:fs";
 import { join } from "node:path";
-import { applyTemplateParams, installSkill, generateViewerApiSection, installMcpServers, installSkillDependencies } from "../skill-installer.js";
+import { applyTemplateParams, installSkill, generateViewerApiSection, installMcpServers, installSkillDependencies, buildAndInjectPreferences } from "../skill-installer.js";
 import type { SkillConfig, ViewerApiConfig, McpServerConfig, SkillDependency } from "../../core/types/mode-manifest.js";
+import { HookBus } from "../../core/hook-bus.js";
 
 // ── applyTemplateParams (pure) ──────────────────────────────────────────────
 
@@ -357,6 +358,152 @@ describe("installSkill", () => {
     // Also when omitted
     installSkill(workspace, defaultSkillConfig, modeSourceDir);
     expect(existsSync(join(workspace, "AGENTS.md"))).toBe(false);
+  });
+
+  test("injects project context and project preferences into CLAUDE.md", () => {
+    const projectRoot = join(tmpDir, "project-root");
+    mkdirSync(join(projectRoot, ".pneuma"), { recursive: true });
+    writeFileSync(
+      join(projectRoot, ".pneuma", "project-preferences.md"),
+      "# Project Preferences\n\n- Use a quiet editorial tone.\n",
+    );
+
+    installSkill(workspace, defaultSkillConfig, modeSourceDir, undefined, undefined, "claude-code", undefined, {
+      projectContext: {
+        projectId: "project_123",
+        projectName: "Launch Project",
+        projectRoot,
+        description: "Marketing site",
+        role: "Build the intro page",
+        currentSessionId: "web-1",
+        currentMode: "webcraft",
+        currentSessionDisplayName: "Webcraft",
+        peerSessions: [
+          {
+            sessionId: "doc-1",
+            mode: "doc",
+            displayName: "Doc",
+            role: "Draft the copy",
+            backendType: "claude-code",
+            status: "idle",
+            lastAccessed: "2026-04-28T03:00:00.000Z",
+          },
+        ],
+      },
+    });
+
+    const content = readFileSync(join(workspace, "CLAUDE.md"), "utf-8");
+    expect(content).toContain("<!-- pneuma:project-context:start -->");
+    expect(content).toContain("## Project Context");
+    expect(content).toContain("Launch Project");
+    expect(content).toContain(projectRoot);
+    expect(content).toContain("Marketing site");
+    expect(content).toContain("Build the intro page");
+    expect(content).toContain("Doc (`doc`) — role: Draft the copy");
+    expect(content).not.toContain("sessionWorkspace");
+    expect(content).toContain("<!-- pneuma:preferences:start -->");
+    expect(content).toContain("**Project:**");
+    expect(content).toContain("Project preferences override personal preferences when they conflict.");
+    expect(content).toContain("Use a quiet editorial tone.");
+  });
+
+  test("injects project context into AGENTS.md for codex sessions", () => {
+    const projectRoot = join(tmpDir, "codex-project-root");
+    mkdirSync(join(projectRoot, ".pneuma"), { recursive: true });
+
+    installSkill(workspace, defaultSkillConfig, modeSourceDir, undefined, undefined, "codex", undefined, {
+      projectContext: {
+        projectId: "project_codex",
+        projectName: "Codex Project",
+        projectRoot,
+        role: "Review implementation",
+        currentSessionId: "codex-1",
+        currentMode: "doc",
+        currentSessionDisplayName: "Doc",
+        peerSessions: [],
+      },
+    });
+
+    const content = readFileSync(join(workspace, "AGENTS.md"), "utf-8");
+    expect(content).toContain("<!-- pneuma:project-context:start -->");
+    expect(content).toContain("Codex Project");
+    expect(content).toContain("Review implementation");
+    expect(existsSync(join(workspace, "CLAUDE.md"))).toBe(false);
+  });
+
+  test("does not infer project context from workspace files for quick sessions", () => {
+    mkdirSync(join(workspace, ".pneuma"), { recursive: true });
+    writeFileSync(join(workspace, ".pneuma", "project.json"), JSON.stringify({ name: "Should Not Load" }));
+    writeFileSync(join(workspace, ".pneuma", "project-preferences.md"), "- Should not be injected\n");
+    writeFileSync(
+      join(workspace, "CLAUDE.md"),
+      "<!-- pneuma:project-context:start -->\nstale project\n<!-- pneuma:project-context:end -->\n",
+    );
+
+    installSkill(workspace, defaultSkillConfig, modeSourceDir);
+
+    const content = readFileSync(join(workspace, "CLAUDE.md"), "utf-8");
+    expect(content).not.toContain("<!-- pneuma:project-context:start -->");
+    expect(content).not.toContain("Should Not Load");
+    expect(content).not.toContain("Should not be injected");
+  });
+});
+
+describe("buildAndInjectPreferences project layer", () => {
+  let tmpDir: string;
+  let workspace: string;
+  let projectRoot: string;
+
+  beforeEach(() => {
+    tmpDir = join(import.meta.dir, `.tmp-project-prefs-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    workspace = join(tmpDir, "workspace");
+    projectRoot = join(tmpDir, "project-root");
+    mkdirSync(workspace, { recursive: true });
+    mkdirSync(join(projectRoot, ".pneuma"), { recursive: true });
+    writeFileSync(join(workspace, "CLAUDE.md"), "# Project\n");
+    writeFileSync(
+      join(projectRoot, ".pneuma", "project-preferences.md"),
+      "# Project Preferences\n\n- Prefer restrained visual density.\n",
+    );
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("preserves project preferences when plugin preference enrichment runs", async () => {
+    const hookBus = new HookBus();
+    hookBus.on("preferences:build", "test-plugin", async ({ payload }) => ({
+      ...(payload as any),
+      globalCritical: "Always cite assumptions.",
+    }));
+
+    await buildAndInjectPreferences(
+      workspace,
+      "pneuma-webcraft",
+      "claude-code",
+      hookBus,
+      { sessionId: "s1", mode: "webcraft", workspace, backendType: "claude-code" },
+      {
+        projectContext: {
+          projectId: "project_123",
+          projectName: "Launch Project",
+          projectRoot,
+          currentSessionId: "s1",
+          currentMode: "webcraft",
+          currentSessionDisplayName: "Webcraft",
+          peerSessions: [],
+        },
+      },
+    );
+
+    const content = readFileSync(join(workspace, "CLAUDE.md"), "utf-8");
+    expect(content).toContain("<!-- pneuma:project-context:start -->");
+    expect(content).toContain("Launch Project");
+    expect(content).toContain("**Global:**");
+    expect(content).toContain("Always cite assumptions.");
+    expect(content).toContain("**Project:**");
+    expect(content).toContain("Prefer restrained visual density.");
   });
 });
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -236,6 +236,7 @@ export async function startServer(options: ServerOptions) {
           displayName?: string;
           backendType?: AgentBackendType;
           role?: string;
+          deliverableTransfer?: "copy" | "move" | "none";
           copyDeliverables?: boolean;
         }>();
         const sourceWorkspace = body.sourceWorkspace?.trim();
@@ -253,6 +254,9 @@ export async function startServer(options: ServerOptions) {
             displayName: body.displayName,
             backendType: body.backendType === "codex" ? "codex" : body.backendType === "claude-code" ? "claude-code" : undefined,
             role: body.role,
+            deliverableTransfer: body.deliverableTransfer === "copy" || body.deliverableTransfer === "move" || body.deliverableTransfer === "none"
+              ? body.deliverableTransfer
+              : undefined,
             copyDeliverables: body.copyDeliverables,
           },
         );

--- a/server/index.ts
+++ b/server/index.ts
@@ -31,6 +31,7 @@ import { createProxyMiddleware, mergeProxyConfig, type ProxyConfigRef } from "./
 import type { ProxyRoute } from "../core/types/mode-manifest.js";
 import { startProxyWatcher, registerSelfWrite, registerSelfDelete } from "./file-watcher.js";
 import { mountNativeRoutes } from "./native-bridge.js";
+import { createProject, loadRecentProjects, recordRecentProject } from "../core/project.js";
 
 const DEFAULT_PORT = 17007;
 
@@ -172,6 +173,31 @@ export async function startServer(options: ServerOptions) {
         return { ...desc, available: avail?.available ?? false, reason: avail?.reason };
       });
       return c.json({ backends, defaultBackendType: getDefaultBackendType() });
+    });
+
+    app.get("/api/projects", (c) => {
+      const projects = loadRecentProjects();
+      return c.json({ projects });
+    });
+
+    app.post("/api/projects", async (c) => {
+      try {
+        const body = await c.req.json<{ root?: string; name?: string; description?: string }>();
+        const rawRoot = body.root?.trim();
+        if (!rawRoot) return c.json({ error: "root is required" }, 400);
+
+        const root = resolve(rawRoot.replace(/^~/, homedir()));
+        mkdirSync(root, { recursive: true });
+        const project = createProject(root, {
+          name: body.name,
+          description: body.description,
+        });
+        recordRecentProject(root);
+        return c.json({ project });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return c.json({ error: message }, 500);
+      }
     });
 
     // Install a mode from a remote source (url tar.gz or github:user/repo).
@@ -597,9 +623,11 @@ export async function startServer(options: ServerOptions) {
     });
 
     app.post("/api/launch", async (c) => {
-      const { specifier, workspace: targetWorkspace, initParams, skipSkill, backendType, replayPackage: replayPkg, replaySource, sessionName, viewing } = await c.req.json<{
+      const { specifier, workspace: targetWorkspace, projectRoot: launchProjectRoot, role, initParams, skipSkill, backendType, replayPackage: replayPkg, replaySource, sessionName, viewing } = await c.req.json<{
         specifier: string;
-        workspace: string;
+        workspace?: string;
+        projectRoot?: string;
+        role?: string;
         initParams?: Record<string, string | number>;
         skipSkill?: boolean;
         backendType?: AgentBackendType;
@@ -610,13 +638,21 @@ export async function startServer(options: ServerOptions) {
       }>();
 
       try {
-        const resolvedWorkspace = resolve(targetWorkspace.replace(/^~/, homedir()));
+        const resolvedProjectRoot = launchProjectRoot
+          ? resolve(launchProjectRoot.replace(/^~/, homedir()))
+          : "";
+        const resolvedWorkspace = targetWorkspace
+          ? resolve(targetWorkspace.replace(/^~/, homedir()))
+          : resolvedProjectRoot || homedir();
 
-        // 1. Create workspace dir
-        mkdirSync(resolvedWorkspace, { recursive: true });
+        // 1. Create workspace/project dir
+        mkdirSync(resolvedProjectRoot || resolvedWorkspace, { recursive: true });
 
-        // 2. Save initParams to .pneuma/config.json if provided
-        if (initParams && Object.keys(initParams).length > 0) {
+        // 2. Save initParams to .pneuma/config.json if provided.
+        // Project sessions create their sandbox in the child process, so
+        // project init-param persistence is handled after project session
+        // routing grows a stable session selector.
+        if (!resolvedProjectRoot && initParams && Object.keys(initParams).length > 0) {
           const pneumaDir = join(resolvedWorkspace, ".pneuma");
           mkdirSync(pneumaDir, { recursive: true });
           writeFileSync(join(pneumaDir, "config.json"), JSON.stringify(initParams, null, 2));
@@ -625,8 +661,11 @@ export async function startServer(options: ServerOptions) {
         // 3. Spawn pneuma process
         const projectRoot = options.projectRoot || resolve(dirname(import.meta.path), "..");
         const pneumaBin = join(projectRoot, "bin", "pneuma.ts");
-        const args = ["bun", pneumaBin, specifier, "--workspace", resolvedWorkspace, "--no-prompt", "--no-open"];
+        const args = resolvedProjectRoot
+          ? ["bun", pneumaBin, specifier, "--project", resolvedProjectRoot, "--no-prompt", "--no-open"]
+          : ["bun", pneumaBin, specifier, "--workspace", resolvedWorkspace, "--no-prompt", "--no-open"];
         args.push("--backend", backendType || getDefaultBackendType());
+        if (role?.trim()) args.push("--role", role.trim());
         if (skipSkill) args.push("--skip-skill");
         if (viewing) args.push("--viewing");
         if (replayPkg) args.push("--replay", replayPkg);
@@ -692,7 +731,7 @@ export async function startServer(options: ServerOptions) {
         childProcesses.set(pid, {
           proc: child,
           specifier,
-          workspace: resolvedWorkspace,
+          workspace: resolvedProjectRoot || resolvedWorkspace,
           url: readyUrl,
           startedAt: Date.now(),
         });
@@ -702,7 +741,7 @@ export async function startServer(options: ServerOptions) {
           childProcesses.delete(pid);
         });
 
-        return c.json({ url: readyUrl, workspace: resolvedWorkspace, mode: specifier });
+        return c.json({ url: readyUrl, workspace: resolvedProjectRoot || resolvedWorkspace, mode: specifier });
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         return c.json({ error: message }, 500);

--- a/server/index.ts
+++ b/server/index.ts
@@ -31,7 +31,7 @@ import { createProxyMiddleware, mergeProxyConfig, type ProxyConfigRef } from "./
 import type { ProxyRoute } from "../core/types/mode-manifest.js";
 import { startProxyWatcher, registerSelfWrite, registerSelfDelete } from "./file-watcher.js";
 import { mountNativeRoutes } from "./native-bridge.js";
-import { createProject, loadRecentProjects, recordRecentProject } from "../core/project.js";
+import { createProject, isProjectSessionWorkspace, listProjectSessions, loadProject, loadRecentProjects, recordRecentProject } from "../core/project.js";
 
 const DEFAULT_PORT = 17007;
 
@@ -91,6 +91,8 @@ export async function startServer(options: ServerOptions) {
       proc: ReturnType<typeof Bun.spawn>;
       specifier: string;
       workspace: string;
+      projectRoot?: string;
+      projectSessionId?: string;
       url: string;
       startedAt: number;
     }>();
@@ -178,6 +180,28 @@ export async function startServer(options: ServerOptions) {
     app.get("/api/projects", (c) => {
       const projects = loadRecentProjects();
       return c.json({ projects });
+    });
+
+    app.get("/api/projects/:projectId", (c) => {
+      const projectId = c.req.param("projectId");
+      const record = loadRecentProjects().find((project) => project.projectId === projectId);
+      if (!record) return c.json({ error: "Project not found" }, 404);
+
+      const project = loadProject(record.root);
+      if (!project) return c.json({ error: "Project metadata not found" }, 404);
+
+      const sessions = listProjectSessions(record.root).map((session) => ({
+        sessionId: session.sessionId,
+        mode: session.mode,
+        displayName: session.displayName,
+        ...(session.role ? { role: session.role } : {}),
+        backendType: session.backendType,
+        status: session.status,
+        createdAt: session.createdAt,
+        lastAccessed: session.lastAccessed,
+      }));
+
+      return c.json({ project, sessions });
     });
 
     app.post("/api/projects", async (c) => {
@@ -336,8 +360,9 @@ export async function startServer(options: ServerOptions) {
         ...session,
         backendType: session.backendType || getDefaultBackendType(),
       }));
-      // Filter out sessions whose workspace no longer exists
-      sessions = sessions.filter((s) => existsSync(s.workspace));
+      // Filter out sessions whose workspace no longer exists or belongs to a
+      // project sandbox. Project sessions are surfaced from the project view.
+      sessions = sessions.filter((s) => existsSync(s.workspace) && !isProjectSessionWorkspace(s.workspace));
       // Sort by lastAccessed descending
       sessions.sort((a, b) => b.lastAccessed - a.lastAccessed);
       // Check for thumbnails
@@ -367,7 +392,9 @@ export async function startServer(options: ServerOptions) {
       try {
         const raw = readFileSync(registryPath, "utf-8");
         const sessions = JSON.parse(raw) as Array<{ workspace: string }>;
-        knownWorkspaces = sessions.map((s) => resolve(s.workspace));
+        knownWorkspaces = sessions
+          .filter((s) => existsSync(s.workspace) && !isProjectSessionWorkspace(s.workspace))
+          .map((s) => resolve(s.workspace));
       } catch { /* no registry yet */ }
       const resolvedWorkspace = resolve(workspace);
       if (!knownWorkspaces.includes(resolvedWorkspace)) {
@@ -623,10 +650,11 @@ export async function startServer(options: ServerOptions) {
     });
 
     app.post("/api/launch", async (c) => {
-      const { specifier, workspace: targetWorkspace, projectRoot: launchProjectRoot, role, initParams, skipSkill, backendType, replayPackage: replayPkg, replaySource, sessionName, viewing } = await c.req.json<{
+      const { specifier, workspace: targetWorkspace, projectRoot: launchProjectRoot, projectSessionId, role, initParams, skipSkill, backendType, replayPackage: replayPkg, replaySource, sessionName, viewing } = await c.req.json<{
         specifier: string;
         workspace?: string;
         projectRoot?: string;
+        projectSessionId?: string;
         role?: string;
         initParams?: Record<string, string | number>;
         skipSkill?: boolean;
@@ -665,6 +693,7 @@ export async function startServer(options: ServerOptions) {
           ? ["bun", pneumaBin, specifier, "--project", resolvedProjectRoot, "--no-prompt", "--no-open"]
           : ["bun", pneumaBin, specifier, "--workspace", resolvedWorkspace, "--no-prompt", "--no-open"];
         args.push("--backend", backendType || getDefaultBackendType());
+        if (projectSessionId?.trim()) args.push("--project-session", projectSessionId.trim());
         if (role?.trim()) args.push("--role", role.trim());
         if (skipSkill) args.push("--skip-skill");
         if (viewing) args.push("--viewing");
@@ -732,6 +761,8 @@ export async function startServer(options: ServerOptions) {
           proc: child,
           specifier,
           workspace: resolvedProjectRoot || resolvedWorkspace,
+          ...(resolvedProjectRoot ? { projectRoot: resolvedProjectRoot } : {}),
+          ...(resolvedProjectRoot && projectSessionId?.trim() ? { projectSessionId: projectSessionId.trim() } : {}),
           url: readyUrl,
           startedAt: Date.now(),
         });
@@ -754,6 +785,8 @@ export async function startServer(options: ServerOptions) {
         pid,
         specifier: info.specifier,
         workspace: info.workspace,
+        ...(info.projectRoot ? { projectRoot: info.projectRoot } : {}),
+        ...(info.projectSessionId ? { projectSessionId: info.projectSessionId } : {}),
         url: info.url,
         startedAt: info.startedAt,
       }));

--- a/server/index.ts
+++ b/server/index.ts
@@ -31,7 +31,7 @@ import { createProxyMiddleware, mergeProxyConfig, type ProxyConfigRef } from "./
 import type { ProxyRoute } from "../core/types/mode-manifest.js";
 import { startProxyWatcher, registerSelfWrite, registerSelfDelete } from "./file-watcher.js";
 import { mountNativeRoutes } from "./native-bridge.js";
-import { createProject, isProjectSessionWorkspace, listProjectSessions, loadProject, loadRecentProjects, recordRecentProject } from "../core/project.js";
+import { createProject, isProjectSessionWorkspace, listProjectSessions, loadProject, loadRecentProjects, recordRecentProject, type ProjectInstructionContext } from "../core/project.js";
 
 const DEFAULT_PORT = 17007;
 
@@ -57,6 +57,7 @@ export interface ServerOptions {
   editingSupported?: boolean; // Mode supports editing ↔ viewing toggle
   backendType?: string; // Backend type for correct instructions file selection (claude-code | codex)
   refreshStrategy?: "auto" | "manual"; // Viewer refresh strategy (default: "auto")
+  projectInstructionContext?: ProjectInstructionContext; // Explicit project context for agent instructions
 }
 
 export async function startServer(options: ServerOptions) {
@@ -1231,7 +1232,9 @@ export async function startServer(options: ServerOptions) {
   {
     const { buildAndInjectPreferences } = await import("./skill-installer.js");
     const installName = `pneuma-${options.modeName ?? ""}`;
-    await buildAndInjectPreferences(workspace, installName, options.backendType ?? "claude-code", hookBus, sessionInfo);
+    await buildAndInjectPreferences(workspace, installName, options.backendType ?? "claude-code", hookBus, sessionInfo, {
+      projectContext: options.projectInstructionContext,
+    });
   }
 
   // Mount plugin routes

--- a/server/index.ts
+++ b/server/index.ts
@@ -31,7 +31,7 @@ import { createProxyMiddleware, mergeProxyConfig, type ProxyConfigRef } from "./
 import type { ProxyRoute } from "../core/types/mode-manifest.js";
 import { startProxyWatcher, registerSelfWrite, registerSelfDelete } from "./file-watcher.js";
 import { mountNativeRoutes } from "./native-bridge.js";
-import { createProject, isProjectSessionWorkspace, listProjectSessions, loadProject, loadRecentProjects, recordRecentProject, type ProjectInstructionContext } from "../core/project.js";
+import { confirmProjectHandoff, createProject, createProjectHandoffDraft, createProjectSession, isProjectSessionWorkspace, listProjectSessions, loadProject, loadRecentProjects, parseProjectHandoffContent, recordRecentProject, runProjectEvolution, upgradeQuickSessionToProject, type ProjectInstructionContext } from "../core/project.js";
 
 const DEFAULT_PORT = 17007;
 
@@ -219,6 +219,133 @@ export async function startServer(options: ServerOptions) {
         });
         recordRecentProject(root);
         return c.json({ project });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return c.json({ error: message }, 500);
+      }
+    });
+
+    app.post("/api/projects/upgrade-session", async (c) => {
+      try {
+        const body = await c.req.json<{
+          sourceWorkspace?: string;
+          projectRoot?: string;
+          name?: string;
+          description?: string;
+          mode?: string;
+          displayName?: string;
+          backendType?: AgentBackendType;
+          role?: string;
+          copyDeliverables?: boolean;
+        }>();
+        const sourceWorkspace = body.sourceWorkspace?.trim();
+        const projectRoot = body.projectRoot?.trim();
+        if (!sourceWorkspace) return c.json({ error: "sourceWorkspace is required" }, 400);
+        if (!projectRoot) return c.json({ error: "projectRoot is required" }, 400);
+
+        const result = upgradeQuickSessionToProject(
+          resolve(sourceWorkspace.replace(/^~/, homedir())),
+          resolve(projectRoot.replace(/^~/, homedir())),
+          {
+            name: body.name,
+            description: body.description,
+            mode: body.mode,
+            displayName: body.displayName,
+            backendType: body.backendType === "codex" ? "codex" : body.backendType === "claude-code" ? "claude-code" : undefined,
+            role: body.role,
+            copyDeliverables: body.copyDeliverables,
+          },
+        );
+        return c.json(result);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return c.json({ error: message }, 500);
+      }
+    });
+
+    app.post("/api/projects/:projectId/handoffs/draft", async (c) => {
+      try {
+        const projectId = c.req.param("projectId");
+        const record = loadRecentProjects().find((project) => project.projectId === projectId);
+        if (!record) return c.json({ error: "Project not found" }, 404);
+
+        const body = await c.req.json<{ fromSessionId?: string; toMode?: string; goal?: string }>();
+        const fromSessionId = body.fromSessionId?.trim();
+        const toMode = body.toMode?.trim();
+        if (!fromSessionId) return c.json({ error: "fromSessionId is required" }, 400);
+        if (!toMode) return c.json({ error: "toMode is required" }, 400);
+
+        const draft = createProjectHandoffDraft(record.root, {
+          fromSessionId,
+          toMode,
+          goal: body.goal,
+        });
+        return c.json(draft);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return c.json({ error: message }, 500);
+      }
+    });
+
+    app.post("/api/projects/:projectId/handoffs/:handoffId/confirm", async (c) => {
+      try {
+        const projectId = c.req.param("projectId");
+        const handoffId = c.req.param("handoffId");
+        const record = loadRecentProjects().find((project) => project.projectId === projectId);
+        if (!record) return c.json({ error: "Project not found" }, 404);
+
+        const body = await c.req.json<{
+          content?: string;
+          toMode?: string;
+          targetDisplayName?: string;
+          backendType?: AgentBackendType;
+          role?: string;
+          newSession?: boolean;
+        }>();
+        const content = body.content?.trimEnd();
+        const toMode = body.toMode?.trim();
+        if (!content) return c.json({ error: "content is required" }, 400);
+        if (!toMode) return c.json({ error: "toMode is required" }, 400);
+
+        const editedHandoff = parseProjectHandoffContent(content);
+        if (editedHandoff.toMode && editedHandoff.toMode !== toMode) {
+          return c.json({ error: `Handoff targets mode "${editedHandoff.toMode}", not "${toMode}".` }, 400);
+        }
+
+        const backendType = body.backendType || getDefaultBackendType();
+        const existingTarget = body.newSession
+          ? undefined
+          : listProjectSessions(record.root).find((session) => (
+              session.mode === toMode && session.backendType === backendType
+            ));
+        const targetSession = existingTarget || createProjectSession(record.root, {
+          mode: toMode,
+          displayName: body.targetDisplayName?.trim() || toMode,
+          backendType,
+          role: body.role,
+        });
+        const handoff = confirmProjectHandoff(record.root, {
+          handoffId,
+          content,
+          toSessionId: targetSession.sessionId,
+          toMode,
+        });
+
+        return c.json({ handoff, targetSession });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return c.json({ error: message }, 500);
+      }
+    });
+
+    app.post("/api/projects/:projectId/evolve", (c) => {
+      try {
+        const projectId = c.req.param("projectId");
+        const record = loadRecentProjects().find((project) => project.projectId === projectId);
+        if (!record) return c.json({ error: "Project not found" }, 404);
+
+        const result = runProjectEvolution(record.root);
+        return c.json(result);
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         return c.json({ error: message }, 500);
@@ -651,11 +778,12 @@ export async function startServer(options: ServerOptions) {
     });
 
     app.post("/api/launch", async (c) => {
-      const { specifier, workspace: targetWorkspace, projectRoot: launchProjectRoot, projectSessionId, role, initParams, skipSkill, backendType, replayPackage: replayPkg, replaySource, sessionName, viewing } = await c.req.json<{
+      const { specifier, workspace: targetWorkspace, projectRoot: launchProjectRoot, projectSessionId, handoffId, role, initParams, skipSkill, backendType, replayPackage: replayPkg, replaySource, sessionName, viewing } = await c.req.json<{
         specifier: string;
         workspace?: string;
         projectRoot?: string;
         projectSessionId?: string;
+        handoffId?: string;
         role?: string;
         initParams?: Record<string, string | number>;
         skipSkill?: boolean;
@@ -695,6 +823,7 @@ export async function startServer(options: ServerOptions) {
           : ["bun", pneumaBin, specifier, "--workspace", resolvedWorkspace, "--no-prompt", "--no-open"];
         args.push("--backend", backendType || getDefaultBackendType());
         if (projectSessionId?.trim()) args.push("--project-session", projectSessionId.trim());
+        if (handoffId?.trim()) args.push("--handoff", handoffId.trim());
         if (role?.trim()) args.push("--role", role.trim());
         if (skipSkill) args.push("--skip-skill");
         if (viewing) args.push("--viewing");

--- a/server/skill-installer.ts
+++ b/server/skill-installer.ts
@@ -10,6 +10,7 @@ import { mkdirSync, existsSync, readFileSync, writeFileSync, cpSync, readdirSync
 import { join, dirname, extname } from "node:path";
 import { homedir } from "node:os";
 import type { SkillConfig, ViewerApiConfig, McpServerConfig, SkillDependency } from "../core/types/mode-manifest.js";
+import { projectPreferencesPath, type ProjectInstructionContext } from "../core/project.js";
 
 /** Return the workspace-relative skills directory for a given backend. */
 function skillsDir(backendType?: string): string {
@@ -29,6 +30,12 @@ const SKILLS_MARKER_START = "<!-- pneuma:skills:start -->";
 const SKILLS_MARKER_END = "<!-- pneuma:skills:end -->";
 const PREFS_MARKER_START = "<!-- pneuma:preferences:start -->";
 const PREFS_MARKER_END = "<!-- pneuma:preferences:end -->";
+const PROJECT_CONTEXT_MARKER_START = "<!-- pneuma:project-context:start -->";
+const PROJECT_CONTEXT_MARKER_END = "<!-- pneuma:project-context:end -->";
+
+export interface InstallSkillOptions {
+  projectContext?: ProjectInstructionContext;
+}
 
 /**
  * Extract critical preferences from a preference file.
@@ -46,6 +53,86 @@ export function extractPreferenceCritical(filePath: string): string | null {
   } catch {
     return null;
   }
+}
+
+function removeMarkedSection(content: string, markerStart: string, markerEnd: string): string {
+  const start = content.indexOf(markerStart);
+  const end = content.indexOf(markerEnd);
+  if (start === -1 || end === -1) return content;
+  return content.substring(0, start) + content.substring(end + markerEnd.length);
+}
+
+function upsertMarkedSection(
+  content: string,
+  markerStart: string,
+  markerEnd: string,
+  section: string,
+): string {
+  const start = content.indexOf(markerStart);
+  const end = content.indexOf(markerEnd);
+  if (start !== -1 && end !== -1) {
+    return content.substring(0, start) + section + content.substring(end + markerEnd.length);
+  }
+  if (content.length > 0 && !content.endsWith("\n")) content += "\n";
+  return content + "\n" + section + "\n";
+}
+
+function readProjectPreferences(projectContext?: ProjectInstructionContext): string | null {
+  if (!projectContext) return null;
+  try {
+    const raw = readFileSync(projectPreferencesPath(projectContext.projectRoot), "utf-8");
+    const withoutTitle = raw.replace(/^# Project Preferences\s*/i, "").trim();
+    return withoutTitle || null;
+  } catch {
+    return null;
+  }
+}
+
+function injectProjectContextSection(
+  content: string,
+  projectContext?: ProjectInstructionContext,
+): string {
+  if (!projectContext) {
+    return removeMarkedSection(content, PROJECT_CONTEXT_MARKER_START, PROJECT_CONTEXT_MARKER_END);
+  }
+
+  const lines = [
+    "## Project Context",
+    "",
+    "This session is running inside an explicit Pneuma project.",
+    "",
+    `- Project: ${projectContext.projectName}`,
+    `- Project root: ${projectContext.projectRoot}`,
+  ];
+  if (projectContext.description) lines.push(`- Description: ${projectContext.description}`);
+  lines.push(`- Current session: ${projectContext.currentSessionDisplayName} (\`${projectContext.currentMode}\`)`);
+  if (projectContext.currentSessionId) lines.push(`- Current session id: ${projectContext.currentSessionId}`);
+  if (projectContext.role) lines.push(`- Role: ${projectContext.role}`);
+
+  lines.push("", "### Other Project Sessions");
+  if (projectContext.peerSessions.length === 0) {
+    lines.push("", "No other project sessions recorded yet.");
+  } else {
+    lines.push("");
+    for (const session of projectContext.peerSessions) {
+      const parts = [
+        `${session.displayName} (\`${session.mode}\`)`,
+        session.role ? `role: ${session.role}` : "role: unspecified",
+        `backend: ${session.backendType}`,
+        `status: ${session.status}`,
+        `last active: ${session.lastAccessed}`,
+      ];
+      lines.push(`- ${parts.join(" — ")}`);
+    }
+  }
+
+  lines.push(
+    "",
+    "Project context is shared project metadata only. Do not inspect another session's raw history, scratch files, or workspace unless the user provides an explicit handoff.",
+  );
+
+  const section = `${PROJECT_CONTEXT_MARKER_START}\n${lines.join("\n")}\n${PROJECT_CONTEXT_MARKER_END}`;
+  return upsertMarkedSection(content, PROJECT_CONTEXT_MARKER_START, PROJECT_CONTEXT_MARKER_END, section);
 }
 
 export interface PreferencesBuildPayload {
@@ -68,6 +155,7 @@ function injectPreferencesSection(
   installName: string,
   globalCritical?: string | null,
   modeCritical?: string | null,
+  projectContext?: ProjectInstructionContext,
 ): string {
   const prefModeName = installName.replace(/^pneuma-/, "");
 
@@ -78,31 +166,29 @@ function injectPreferencesSection(
   const mc = modeCritical !== undefined
     ? modeCritical
     : extractPreferenceCritical(join(homedir(), ".pneuma", "preferences", `mode-${prefModeName}.md`));
+  const pc = readProjectPreferences(projectContext);
 
-  if (gc || mc) {
+  if (gc || pc || mc) {
     const prefsLines: string[] = ["### User Preferences (Critical)", ""];
     if (gc) {
       prefsLines.push("**Global:**", gc, "");
+    }
+    if (pc) {
+      prefsLines.push(
+        "**Project:**",
+        "Project preferences override personal preferences when they conflict.",
+        pc,
+        "",
+      );
     }
     if (mc) {
       prefsLines.push(`**${prefModeName} Mode:**`, mc);
     }
     const prefsSection = `${PREFS_MARKER_START}\n${prefsLines.join("\n")}\n${PREFS_MARKER_END}`;
-    const pStart = content.indexOf(PREFS_MARKER_START);
-    const pEnd = content.indexOf(PREFS_MARKER_END);
-    if (pStart !== -1 && pEnd !== -1) {
-      content = content.substring(0, pStart) + prefsSection + content.substring(pEnd + PREFS_MARKER_END.length);
-    } else {
-      if (content.length > 0 && !content.endsWith("\n")) content += "\n";
-      content += "\n" + prefsSection + "\n";
-    }
+    content = upsertMarkedSection(content, PREFS_MARKER_START, PREFS_MARKER_END, prefsSection);
   } else {
     // Remove stale preferences section
-    const pStart = content.indexOf(PREFS_MARKER_START);
-    const pEnd = content.indexOf(PREFS_MARKER_END);
-    if (pStart !== -1 && pEnd !== -1) {
-      content = content.substring(0, pStart) + content.substring(pEnd + PREFS_MARKER_END.length);
-    }
+    content = removeMarkedSection(content, PREFS_MARKER_START, PREFS_MARKER_END);
   }
 
   return content;
@@ -127,6 +213,7 @@ export async function buildAndInjectPreferences(
   backendType: string,
   hookBus: import("../core/hook-bus.js").HookBus,
   sessionInfo: import("../core/types/plugin.js").SessionInfo,
+  options: InstallSkillOptions = {},
 ): Promise<void> {
   const instrFile = backendType === "codex" ? "AGENTS.md" : "CLAUDE.md";
   const instructionsPath = join(workspace, instrFile);
@@ -151,13 +238,21 @@ export async function buildAndInjectPreferences(
     modeName: prefModeName,
   } satisfies PreferencesBuildPayload, sessionInfo);
 
-  // Only rewrite if plugins actually changed something
-  if (enriched.globalCritical === globalCritical && enriched.modeCritical === modeCritical) {
+  let nextContent = injectProjectContextSection(content, options.projectContext);
+  nextContent = injectPreferencesSection(
+    nextContent,
+    installName,
+    enriched.globalCritical,
+    enriched.modeCritical,
+    options.projectContext,
+  );
+
+  // Only rewrite if plugins or the project preference layer changed something
+  if (nextContent === content) {
     return;
   }
 
-  content = injectPreferencesSection(content, installName, enriched.globalCritical, enriched.modeCritical);
-  writeFileSync(instructionsPath, content, "utf-8");
+  writeFileSync(instructionsPath, nextContent, "utf-8");
   console.log(`[skill-installer] Enriched preferences in ${instructionsPath}`);
 }
 
@@ -654,6 +749,7 @@ export function installSkill(
   viewerApi?: ViewerApiConfig,
   backendType?: string,
   proxyConfig?: Record<string, import("../core/types/mode-manifest.js").ProxyRoute>,
+  options: InstallSkillOptions = {},
 ): void {
   // 1. Copy skill to the backend-appropriate skills directory
   const skillSource = join(modeSourceDir, skillConfig.sourceDir);
@@ -824,8 +920,11 @@ export function installSkill(
     }
   }
 
-  // 2d. Inject/update preferences critical section
-  content = injectPreferencesSection(content, skillConfig.installName);
+  // 2d. Inject/update explicit project context section
+  content = injectProjectContextSection(content, options.projectContext);
+
+  // 2e. Inject/update preferences critical section
+  content = injectPreferencesSection(content, skillConfig.installName, undefined, undefined, options.projectContext);
 
   // Write instructions file
   mkdirSync(dirname(primaryInstructionsPath), { recursive: true });

--- a/server/skill-installer.ts
+++ b/server/skill-installer.ts
@@ -126,6 +126,21 @@ function injectProjectContextSection(
     }
   }
 
+  if (projectContext.handoff) {
+    lines.push(
+      "",
+      "### Confirmed Handoff",
+      "",
+      `- Handoff id: ${projectContext.handoff.handoffId}`,
+      `- From: ${projectContext.handoff.fromMode} (${projectContext.handoff.fromSessionId})`,
+      `- To: ${projectContext.handoff.toMode}${projectContext.handoff.toSessionId ? ` (${projectContext.handoff.toSessionId})` : ""}`,
+      "",
+      "Use this user-reviewed handoff as the collaboration boundary. Do not inspect the source session's raw history, scratch files, or workspace unless the user explicitly provides them.",
+      "",
+      projectContext.handoff.content.trim(),
+    );
+  }
+
   lines.push(
     "",
     "Project context is shared project metadata only. Do not inspect another session's raw history, scratch files, or workspace unless the user provides an explicit handoff.",

--- a/src/components/Launcher.tsx
+++ b/src/components/Launcher.tsx
@@ -3349,7 +3349,7 @@ function CreateProjectDialog({
   const [description, setDescription] = useState("");
   const [root, setRoot] = useState(defaultRoot);
   const [seedSessionId, setSeedSessionId] = useState("");
-  const [copyDeliverables, setCopyDeliverables] = useState(true);
+  const [deliverableTransfer, setDeliverableTransfer] = useState<"copy" | "move" | "none">("copy");
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState("");
   const seedSession = sessions.find((session) => session.id === seedSessionId);
@@ -3368,7 +3368,7 @@ function CreateProjectDialog({
           mode: seedSession.mode,
           displayName: seedSession.displayName,
           backendType: seedSession.backendType,
-          copyDeliverables,
+          deliverableTransfer,
           ...(name.trim() ? { name: name.trim() } : {}),
           ...(description.trim() ? { description: description.trim() } : {}),
         } : {
@@ -3438,15 +3438,18 @@ function CreateProjectDialog({
                 ))}
               </select>
               {seedSession && (
-                <label className="flex items-center gap-2 text-xs text-cc-muted/70">
-                  <input
-                    type="checkbox"
-                    checked={copyDeliverables}
-                    onChange={(e) => setCopyDeliverables(e.target.checked)}
-                    className="accent-cc-primary"
-                  />
-                  Copy deliverables
-                </label>
+                <div>
+                  <label className="block text-xs text-cc-muted/70 mb-1">Deliverables</label>
+                  <select
+                    value={deliverableTransfer}
+                    onChange={(e) => setDeliverableTransfer(e.target.value as "copy" | "move" | "none")}
+                    className="w-full px-3 py-2 bg-cc-input-bg border border-cc-border rounded-lg text-cc-fg text-sm focus:outline-none focus:border-cc-primary/50"
+                  >
+                    <option value="copy">Copy to project root</option>
+                    <option value="move">Move to project root</option>
+                    <option value="none">Leave in quick session</option>
+                  </select>
+                </div>
               )}
             </div>
           )}

--- a/src/components/Launcher.tsx
+++ b/src/components/Launcher.tsx
@@ -3334,10 +3334,12 @@ function ProjectCard({
 
 function CreateProjectDialog({
   homeDir,
+  sessions,
   onClose,
   onCreated,
 }: {
   homeDir: string;
+  sessions: RecentSession[];
   onClose: () => void;
   onCreated: (project: RecentProject) => void;
 }) {
@@ -3346,18 +3348,30 @@ function CreateProjectDialog({
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
   const [root, setRoot] = useState(defaultRoot);
+  const [seedSessionId, setSeedSessionId] = useState("");
+  const [copyDeliverables, setCopyDeliverables] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState("");
+  const seedSession = sessions.find((session) => session.id === seedSessionId);
 
   const submit = async () => {
     if (!root.trim() || saving) return;
     setSaving(true);
     setError("");
     try {
-      const res = await fetch(`${getApiBase()}/api/projects`, {
+      const res = await fetch(`${getApiBase()}${seedSession ? "/api/projects/upgrade-session" : "/api/projects"}`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
+        body: JSON.stringify(seedSession ? {
+          sourceWorkspace: seedSession.workspace,
+          projectRoot: root.trim(),
+          mode: seedSession.mode,
+          displayName: seedSession.displayName,
+          backendType: seedSession.backendType,
+          copyDeliverables,
+          ...(name.trim() ? { name: name.trim() } : {}),
+          ...(description.trim() ? { description: description.trim() } : {}),
+        } : {
           root: root.trim(),
           ...(name.trim() ? { name: name.trim() } : {}),
           ...(description.trim() ? { description: description.trim() } : {}),
@@ -3408,6 +3422,34 @@ function CreateProjectDialog({
               className="w-full px-3 py-2 bg-cc-input-bg border border-cc-border rounded-lg text-cc-fg text-sm font-mono focus:outline-none focus:border-cc-primary/50"
             />
           </div>
+          {sessions.length > 0 && (
+            <div className="space-y-2">
+              <label className="block text-xs text-cc-muted/70">Seed session</label>
+              <select
+                value={seedSessionId}
+                onChange={(e) => setSeedSessionId(e.target.value)}
+                className="w-full px-3 py-2 bg-cc-input-bg border border-cc-border rounded-lg text-cc-fg text-sm focus:outline-none focus:border-cc-primary/50"
+              >
+                <option value="">None</option>
+                {sessions.map((session) => (
+                  <option key={session.id} value={session.id}>
+                    {(session.sessionName || session.displayName)} - {shortenPath(session.workspace, homeDir)}
+                  </option>
+                ))}
+              </select>
+              {seedSession && (
+                <label className="flex items-center gap-2 text-xs text-cc-muted/70">
+                  <input
+                    type="checkbox"
+                    checked={copyDeliverables}
+                    onChange={(e) => setCopyDeliverables(e.target.checked)}
+                    className="accent-cc-primary"
+                  />
+                  Copy deliverables
+                </label>
+              )}
+            </div>
+          )}
           {error && <div className="text-xs text-cc-error">{error}</div>}
         </div>
         <div className="p-6 pt-0 flex justify-end gap-3">
@@ -3432,6 +3474,7 @@ function ProjectOverview({
   onClose,
   onResume,
   onStartNew,
+  onLaunchHandoff,
 }: {
   data: ProjectOverviewData;
   modes: AnyMode[];
@@ -3441,9 +3484,98 @@ function ProjectOverview({
   onClose: () => void;
   onResume: (session: ProjectOverviewSession) => void;
   onStartNew: (mode: AnyMode) => void;
+  onLaunchHandoff: (targetSpecifier: string, targetSession: ProjectOverviewSession, handoffId: string) => void;
 }) {
   const project = data.project;
   const launchableModes = modes.filter((m) => m.name !== "evolve");
+  const [handoffSource, setHandoffSource] = useState<ProjectOverviewSession | null>(null);
+  const [handoffTarget, setHandoffTarget] = useState<AnyMode | null>(null);
+  const [handoffId, setHandoffId] = useState("");
+  const [handoffContent, setHandoffContent] = useState("");
+  const [handoffLoading, setHandoffLoading] = useState(false);
+  const [handoffSaving, setHandoffSaving] = useState(false);
+  const [handoffNewSession, setHandoffNewSession] = useState(false);
+  const [handoffError, setHandoffError] = useState("");
+  const [evolving, setEvolving] = useState(false);
+  const [evolveMessage, setEvolveMessage] = useState("");
+
+  const loadHandoffDraft = useCallback(async (source: ProjectOverviewSession, target: AnyMode) => {
+    setHandoffLoading(true);
+    setHandoffError("");
+    try {
+      const res = await fetch(`${getApiBase()}/api/projects/${encodeURIComponent(project.projectId)}/handoffs/draft`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          fromSessionId: source.sessionId,
+          toMode: target.name,
+          goal: source.role,
+        }),
+      });
+      const payload = await res.json();
+      if (!res.ok) throw new Error(payload.error || "Failed to create handoff draft");
+      setHandoffId(payload.handoffId);
+      setHandoffContent(payload.content);
+    } catch (err) {
+      setHandoffError(err instanceof Error ? err.message : "Failed to create handoff draft");
+    } finally {
+      setHandoffLoading(false);
+    }
+  }, [project.projectId]);
+
+  const openHandoff = useCallback((source: ProjectOverviewSession) => {
+    const target = launchableModes.find((mode) => mode.name !== source.mode) || launchableModes[0] || null;
+    setHandoffSource(source);
+    setHandoffTarget(target);
+    setHandoffId("");
+    setHandoffContent("");
+    setHandoffNewSession(false);
+    if (target) void loadHandoffDraft(source, target);
+  }, [launchableModes, loadHandoffDraft]);
+
+  const confirmHandoff = useCallback(async () => {
+    if (!handoffSource || !handoffTarget || !handoffId || handoffSaving) return;
+    setHandoffSaving(true);
+    setHandoffError("");
+    try {
+      const res = await fetch(`${getApiBase()}/api/projects/${encodeURIComponent(project.projectId)}/handoffs/${encodeURIComponent(handoffId)}/confirm`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          content: handoffContent,
+          toMode: handoffTarget.name,
+          targetDisplayName: handoffTarget.displayName,
+          backendType: defaultBackendType,
+          newSession: handoffNewSession,
+        }),
+      });
+      const payload = await res.json();
+      if (!res.ok) throw new Error(payload.error || "Failed to confirm handoff");
+      onLaunchHandoff(handoffTarget.specifier, payload.targetSession as ProjectOverviewSession, handoffId);
+    } catch (err) {
+      setHandoffError(err instanceof Error ? err.message : "Failed to confirm handoff");
+    } finally {
+      setHandoffSaving(false);
+    }
+  }, [defaultBackendType, handoffContent, handoffId, handoffNewSession, handoffSaving, handoffSource, handoffTarget, onLaunchHandoff, project.projectId]);
+
+  const runProjectEvolve = useCallback(async () => {
+    if (evolving) return;
+    setEvolving(true);
+    setEvolveMessage("");
+    try {
+      const res = await fetch(`${getApiBase()}/api/projects/${encodeURIComponent(project.projectId)}/evolve`, {
+        method: "POST",
+      });
+      const payload = await res.json();
+      if (!res.ok) throw new Error(payload.error || "Project evolve failed");
+      setEvolveMessage(`Updated project preferences from ${payload.sourceSessionCount} session${payload.sourceSessionCount === 1 ? "" : "s"}.`);
+    } catch (err) {
+      setEvolveMessage(err instanceof Error ? err.message : "Project evolve failed");
+    } finally {
+      setEvolving(false);
+    }
+  }, [evolving, project.projectId]);
 
   return (
     <div className="fixed inset-0 bg-black/30 backdrop-blur-[2px] flex items-center justify-center z-50 font-body py-12" style={{ animation: "overlayFadeIn 0.2s ease-out" }}>
@@ -3456,12 +3588,22 @@ function ProjectOverview({
               <span className="font-mono truncate max-w-[520px]">{shortenPath(project.root, homeDir)}</span>
               <span>Created {formatIsoDate(project.createdAt)}</span>
             </div>
+            {evolveMessage && <div className="mt-2 text-xs text-cc-muted/65">{evolveMessage}</div>}
           </div>
-          <button onClick={onClose} className="p-2 text-cc-muted/60 hover:text-cc-fg transition-colors cursor-pointer" title="Close">
-            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-            </svg>
-          </button>
+          <div className="flex items-center gap-2 shrink-0">
+            <button
+              onClick={runProjectEvolve}
+              disabled={evolving}
+              className="px-3 py-1.5 text-xs rounded-lg border border-cc-border/60 text-cc-muted hover:text-cc-fg hover:border-cc-primary/40 disabled:opacity-50 transition-colors cursor-pointer"
+            >
+              {evolving ? "Evolving..." : "Evolve"}
+            </button>
+            <button onClick={onClose} className="p-2 text-cc-muted/60 hover:text-cc-fg transition-colors cursor-pointer" title="Close">
+              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
         </div>
         <div className="p-6 overflow-y-auto grid grid-cols-1 lg:grid-cols-[1fr_320px] gap-6">
           <section>
@@ -3490,6 +3632,12 @@ function ProjectOverview({
                     <PrimaryButton size="sm" onClick={() => onResume(session)}>
                       Resume
                     </PrimaryButton>
+                    <button
+                      onClick={() => openHandoff(session)}
+                      className="px-3 py-1.5 text-xs rounded-lg border border-cc-border/60 text-cc-muted hover:text-cc-fg hover:border-cc-primary/40 transition-colors cursor-pointer"
+                    >
+                      Switch
+                    </button>
                   </div>
                 ))}
               </div>
@@ -3516,6 +3664,66 @@ function ProjectOverview({
           </aside>
         </div>
       </div>
+      {handoffSource && handoffTarget && (
+        <div className="fixed inset-0 bg-black/35 flex items-center justify-center z-[60] px-4">
+          <div className="launcher-card-elevated bg-cc-surface border border-cc-border/50 rounded-2xl overflow-hidden w-full max-w-3xl max-h-[86vh] flex flex-col">
+            <div className="p-5 border-b border-cc-border/40 flex items-start justify-between gap-4">
+              <div>
+                <div className="text-sm font-medium text-cc-fg">Mode Handoff</div>
+                <div className="text-xs text-cc-muted/60 mt-1">{handoffSource.displayName} to {handoffTarget.displayName}</div>
+              </div>
+              <button onClick={() => setHandoffSource(null)} className="p-2 text-cc-muted/60 hover:text-cc-fg transition-colors cursor-pointer" title="Close">
+                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
+            <div className="p-5 space-y-4 overflow-y-auto">
+              <div className="flex items-center gap-3">
+                <label className="text-xs text-cc-muted/70 shrink-0">Target mode</label>
+                <select
+                  value={handoffTarget.specifier}
+                  onChange={(event) => {
+                    const next = launchableModes.find((mode) => mode.specifier === event.target.value) || handoffTarget;
+                    setHandoffTarget(next);
+                    void loadHandoffDraft(handoffSource, next);
+                  }}
+                  className="px-3 py-2 bg-cc-input-bg border border-cc-border rounded-lg text-cc-fg text-sm focus:outline-none focus:border-cc-primary/50"
+                >
+                  {launchableModes.map((mode) => (
+                    <option key={`${mode.source}:${mode.specifier}`} value={mode.specifier}>{mode.displayName}</option>
+                  ))}
+                </select>
+                <label className="ml-auto flex items-center gap-2 text-xs text-cc-muted/70">
+                  <input
+                    type="checkbox"
+                    checked={handoffNewSession}
+                    onChange={(event) => setHandoffNewSession(event.target.checked)}
+                    className="accent-cc-primary"
+                  />
+                  New session
+                </label>
+              </div>
+              <textarea
+                value={handoffLoading ? "Loading..." : handoffContent}
+                onChange={(event) => setHandoffContent(event.target.value)}
+                disabled={handoffLoading}
+                rows={18}
+                className="w-full min-h-[360px] px-3 py-2 bg-cc-input-bg border border-cc-border rounded-lg text-cc-fg text-xs font-mono focus:outline-none focus:border-cc-primary/50 resize-none"
+              />
+              {handoffError && <div className="text-xs text-cc-error">{handoffError}</div>}
+            </div>
+            <div className="p-5 pt-0 flex justify-end gap-3">
+              <button onClick={() => setHandoffSource(null)} className="px-4 py-2 text-sm rounded-lg border border-cc-border/50 text-cc-muted hover:text-cc-fg transition-colors cursor-pointer">
+                Cancel
+              </button>
+              <PrimaryButton onClick={confirmHandoff} disabled={handoffLoading || handoffSaving || !handoffContent.trim()}>
+                {handoffSaving ? "Switching..." : "Confirm"}
+              </PrimaryButton>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }
@@ -3809,6 +4017,7 @@ export default function Launcher() {
     mode: string,
     backendType: BackendType,
     projectSessionId?: string,
+    handoffId?: string,
   ) => {
     try {
       const res = await fetch(`${getApiBase()}/api/launch`, {
@@ -3819,6 +4028,7 @@ export default function Launcher() {
           projectRoot,
           backendType,
           ...(projectSessionId ? { projectSessionId } : {}),
+          ...(handoffId ? { handoffId } : {}),
         }),
       });
       const data = await res.json();
@@ -4306,6 +4516,7 @@ export default function Launcher() {
       {showCreateProject && (
         <CreateProjectDialog
           homeDir={homeDir}
+          sessions={sessions}
           onClose={() => setShowCreateProject(false)}
           onCreated={(project) => {
             setShowCreateProject(false);
@@ -4330,6 +4541,10 @@ export default function Launcher() {
           onStartNew={(mode) => {
             setProjectOverview(null);
             launchProjectSession(projectOverview.project.root, mode.specifier, defaultBackendType);
+          }}
+          onLaunchHandoff={(targetSpecifier, targetSession, handoffId) => {
+            setProjectOverview(null);
+            launchProjectSession(projectOverview.project.root, targetSpecifier, targetSession.backendType, targetSession.sessionId, handoffId);
           }}
         />
       )}

--- a/src/components/Launcher.tsx
+++ b/src/components/Launcher.tsx
@@ -3,6 +3,7 @@ import { getApiBase } from "../utils/api.js";
 import { motion, AnimatePresence, LayoutGroup } from "framer-motion";
 import SpotlightCard from "./reactbits/SpotlightCard";
 import Galaxy from "./reactbits/Galaxy";
+import { buildContinueItems } from "./launcher-helpers";
 import type { InitParam } from "../../core/types/mode-manifest.js";
 
 type BackendType = "claude-code" | "codex";
@@ -80,10 +81,43 @@ interface RecentSession {
   layout?: "editor" | "app";
 }
 
+interface RecentProject {
+  projectId: string;
+  name: string;
+  description?: string;
+  root: string;
+  lastAccessed: string | number;
+}
+
+interface ProjectOverviewSession {
+  sessionId: string;
+  mode: string;
+  displayName: string;
+  role?: string;
+  backendType: BackendType;
+  status: "active" | "idle" | "archived";
+  createdAt: string | number;
+  lastAccessed: string | number;
+}
+
+interface ProjectOverviewData {
+  project: {
+    projectId: string;
+    name: string;
+    description?: string;
+    root: string;
+    createdAt: string | number;
+    updatedAt: string | number;
+  };
+  sessions: ProjectOverviewSession[];
+}
+
 interface ChildProcess {
   pid: number;
   specifier: string;
   workspace: string;
+  projectRoot?: string;
+  projectSessionId?: string;
   url: string;
   startedAt: number;
 }
@@ -362,6 +396,28 @@ function timeAgo(timestamp: number): string {
   const days = Math.floor(hours / 24);
   if (days < 30) return `${days}d ago`;
   return `${Math.floor(days / 30)}mo ago`;
+}
+
+function timestampFromDateLike(value: string | number): number {
+  if (typeof value === "number") return value;
+  return Date.parse(value);
+}
+
+function timeAgoIso(value: string | number): string {
+  const timestamp = timestampFromDateLike(value);
+  return Number.isFinite(timestamp) ? timeAgo(timestamp) : "";
+}
+
+function formatIsoDate(value: string | number): string {
+  const timestamp = timestampFromDateLike(value);
+  if (!Number.isFinite(timestamp)) return String(value);
+  return new Intl.DateTimeFormat(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(timestamp);
 }
 
 function runningDuration(startedAt: number): string {
@@ -3246,6 +3302,224 @@ function ImportDialog({
   );
 }
 
+function ProjectCard({
+  project,
+  homeDir,
+  onOpen,
+}: {
+  project: RecentProject;
+  homeDir: string;
+  onOpen: () => void;
+}) {
+  return (
+    <button
+      onClick={onOpen}
+      className="group text-left rounded-lg border border-cc-border bg-cc-bg-secondary hover:border-cc-primary/40 transition-all p-4 cursor-pointer min-h-[116px] flex flex-col"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="text-sm font-medium text-cc-fg truncate">{project.name}</div>
+          {project.description && (
+            <div className="text-xs text-cc-muted/70 line-clamp-2 mt-1">{project.description}</div>
+          )}
+        </div>
+        <span className="text-[10px] text-cc-muted/40 shrink-0">{timeAgoIso(project.lastAccessed)}</span>
+      </div>
+      <div className="mt-auto pt-3 text-[10px] text-cc-muted/50 font-mono truncate">
+        {shortenPath(project.root, homeDir)}
+      </div>
+    </button>
+  );
+}
+
+function CreateProjectDialog({
+  homeDir,
+  onClose,
+  onCreated,
+}: {
+  homeDir: string;
+  onClose: () => void;
+  onCreated: (project: RecentProject) => void;
+}) {
+  const stamp = new Date().toISOString().slice(0, 10).replace(/-/g, "");
+  const defaultRoot = homeDir ? `${homeDir}/pneuma-projects/project-${stamp}` : `~/pneuma-projects/project-${stamp}`;
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [root, setRoot] = useState(defaultRoot);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+
+  const submit = async () => {
+    if (!root.trim() || saving) return;
+    setSaving(true);
+    setError("");
+    try {
+      const res = await fetch(`${getApiBase()}/api/projects`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          root: root.trim(),
+          ...(name.trim() ? { name: name.trim() } : {}),
+          ...(description.trim() ? { description: description.trim() } : {}),
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "Failed to create project");
+      onCreated(data.project as RecentProject);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to create project");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/30 backdrop-blur-[2px] flex items-center justify-center z-50 font-body py-12" style={{ animation: "overlayFadeIn 0.2s ease-out" }}>
+      <div className="launcher-card-elevated bg-cc-surface border border-cc-border/50 rounded-2xl overflow-hidden w-full max-w-lg mx-4">
+        <div className="p-6 border-b border-cc-border/40">
+          <h2 className="text-lg font-medium text-cc-fg">Create Project</h2>
+          <p className="text-xs text-cc-muted/60 mt-1">Choose a real folder that you can open, git init, or push later.</p>
+        </div>
+        <div className="p-6 space-y-4">
+          <div>
+            <label className="block text-xs text-cc-muted/70 mb-1">Name</label>
+            <input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Project name"
+              className="w-full px-3 py-2 bg-cc-input-bg border border-cc-border rounded-lg text-cc-fg text-sm focus:outline-none focus:border-cc-primary/50"
+            />
+          </div>
+          <div>
+            <label className="block text-xs text-cc-muted/70 mb-1">Description</label>
+            <textarea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              rows={3}
+              placeholder="Optional"
+              className="w-full px-3 py-2 bg-cc-input-bg border border-cc-border rounded-lg text-cc-fg text-sm focus:outline-none focus:border-cc-primary/50 resize-none"
+            />
+          </div>
+          <div>
+            <label className="block text-xs text-cc-muted/70 mb-1">Root folder</label>
+            <input
+              value={root}
+              onChange={(e) => setRoot(e.target.value)}
+              className="w-full px-3 py-2 bg-cc-input-bg border border-cc-border rounded-lg text-cc-fg text-sm font-mono focus:outline-none focus:border-cc-primary/50"
+            />
+          </div>
+          {error && <div className="text-xs text-cc-error">{error}</div>}
+        </div>
+        <div className="p-6 pt-0 flex justify-end gap-3">
+          <button onClick={onClose} className="px-4 py-2 text-sm rounded-lg border border-cc-border/50 text-cc-muted hover:text-cc-fg transition-colors cursor-pointer">
+            Cancel
+          </button>
+          <PrimaryButton onClick={submit} disabled={saving || !root.trim()}>
+            {saving ? "Creating..." : "Create"}
+          </PrimaryButton>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ProjectOverview({
+  data,
+  modes,
+  homeDir,
+  iconMap,
+  defaultBackendType,
+  onClose,
+  onResume,
+  onStartNew,
+}: {
+  data: ProjectOverviewData;
+  modes: AnyMode[];
+  homeDir: string;
+  iconMap: Record<string, string>;
+  defaultBackendType: BackendType;
+  onClose: () => void;
+  onResume: (session: ProjectOverviewSession) => void;
+  onStartNew: (mode: AnyMode) => void;
+}) {
+  const project = data.project;
+  const launchableModes = modes.filter((m) => m.name !== "evolve");
+
+  return (
+    <div className="fixed inset-0 bg-black/30 backdrop-blur-[2px] flex items-center justify-center z-50 font-body py-12" style={{ animation: "overlayFadeIn 0.2s ease-out" }}>
+      <div className="launcher-card-elevated bg-cc-surface border border-cc-border/50 rounded-2xl overflow-hidden w-full max-w-5xl mx-4 flex flex-col max-h-full">
+        <div className="p-6 border-b border-cc-border/40 flex items-start justify-between gap-6">
+          <div className="min-w-0">
+            <div className="text-lg font-medium text-cc-fg truncate">{project.name}</div>
+            {project.description && <p className="text-sm text-cc-muted/70 mt-1">{project.description}</p>}
+            <div className="mt-3 flex flex-wrap gap-x-4 gap-y-1 text-[11px] text-cc-muted/55">
+              <span className="font-mono truncate max-w-[520px]">{shortenPath(project.root, homeDir)}</span>
+              <span>Created {formatIsoDate(project.createdAt)}</span>
+            </div>
+          </div>
+          <button onClick={onClose} className="p-2 text-cc-muted/60 hover:text-cc-fg transition-colors cursor-pointer" title="Close">
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+        <div className="p-6 overflow-y-auto grid grid-cols-1 lg:grid-cols-[1fr_320px] gap-6">
+          <section>
+            <div className="flex items-baseline justify-between mb-3">
+              <h3 className="text-sm font-medium text-cc-fg/75">Project Sessions</h3>
+              <span className="text-xs text-cc-muted/45">{data.sessions.length}</span>
+            </div>
+            {data.sessions.length === 0 ? (
+              <div className="rounded-lg border border-cc-border/50 bg-cc-bg-secondary p-5 text-sm text-cc-muted/65">
+                No sessions yet.
+              </div>
+            ) : (
+              <div className="space-y-2">
+                {data.sessions.map((session) => (
+                  <div key={session.sessionId} className="rounded-lg border border-cc-border/50 bg-cc-bg-secondary p-3 flex items-center gap-3">
+                    {iconMap[session.mode] && <img src={iconMap[session.mode]} alt="" className="w-8 h-8 rounded" />}
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2 min-w-0">
+                        <span className="text-sm font-medium text-cc-fg truncate">{session.displayName}</span>
+                        <span className="text-[10px] px-1.5 py-0.5 rounded bg-cc-surface text-cc-muted/65">{session.status}</span>
+                      </div>
+                      <div className="text-xs text-cc-muted/60 truncate">
+                        {session.role || "No role set"} · {session.mode} · {backendLabel(session.backendType)} · {timeAgoIso(session.lastAccessed)}
+                      </div>
+                    </div>
+                    <PrimaryButton size="sm" onClick={() => onResume(session)}>
+                      Resume
+                    </PrimaryButton>
+                  </div>
+                ))}
+              </div>
+            )}
+          </section>
+
+          <aside>
+            <h3 className="text-sm font-medium text-cc-fg/75 mb-3">New Session</h3>
+            <div className="space-y-2 max-h-[420px] overflow-y-auto pr-1">
+              {launchableModes.map((mode) => (
+                <button
+                  key={`${mode.source}:${mode.specifier}`}
+                  onClick={() => onStartNew(mode)}
+                  className="w-full rounded-lg border border-cc-border/50 bg-cc-bg-secondary hover:border-cc-primary/40 transition-colors p-3 flex items-center gap-3 text-left cursor-pointer"
+                >
+                  {mode.icon && <img src={mode.icon} alt="" className="w-7 h-7 rounded" />}
+                  <div className="min-w-0">
+                    <div className="text-sm text-cc-fg truncate">{mode.displayName}</div>
+                    <div className="text-[10px] text-cc-muted/50 truncate">{backendLabel(defaultBackendType)}</div>
+                  </div>
+                </button>
+              ))}
+            </div>
+          </aside>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 // ── Main Launcher ────────────────────────────────────────────────────────
 
 export default function Launcher() {
@@ -3256,12 +3530,15 @@ export default function Launcher() {
   const [builtins, setBuiltins] = useState<BuiltinMode[]>([]);
   const [published, setPublished] = useState<PublishedMode[]>([]);
   const [local, setLocal] = useState<LocalMode[]>([]);
+  const [projects, setProjects] = useState<RecentProject[]>([]);
   const [sessions, setSessions] = useState<RecentSession[]>([]);
   const [running, setRunning] = useState<ChildProcess[]>([]);
   const [homeDir, setHomeDir] = useState("");
   const [loading, setLoading] = useState(true);
   const [showGallery, setShowGallery] = useState(false);
   const [showAllSessions, setShowAllSessions] = useState(false);
+  const [showCreateProject, setShowCreateProject] = useState(false);
+  const [projectOverview, setProjectOverview] = useState<ProjectOverviewData | null>(null);
   const [showSettings, setShowSettings] = useState(false);
   const [showImportDialog, setShowImportDialog] = useState(() => {
     const params = new URLSearchParams(window.location.search);
@@ -3313,7 +3590,7 @@ export default function Launcher() {
   const lastLaunchTarget = useRef(launchTarget);
   if (launchTarget) lastLaunchTarget.current = launchTarget;
 
-  const hasOverlay = showGallery || showAllSessions || launchTarget !== null;
+  const hasOverlay = showGallery || showAllSessions || launchTarget !== null || showCreateProject || projectOverview !== null;
 
   // Lock body scroll when any overlay is open
   useEffect(() => {
@@ -3328,14 +3605,16 @@ export default function Launcher() {
     if (!hasOverlay) return;
     const handler = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
-        if (launchTarget) setLaunchTarget(null);
+        if (projectOverview) setProjectOverview(null);
+        else if (showCreateProject) setShowCreateProject(false);
+        else if (launchTarget) setLaunchTarget(null);
         else if (showGallery) setShowGallery(false);
         else if (showAllSessions) setShowAllSessions(false);
       }
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
-  }, [hasOverlay, launchTarget, showGallery, showAllSessions]);
+  }, [hasOverlay, launchTarget, projectOverview, showCreateProject, showGallery, showAllSessions]);
 
   const refreshModes = useCallback(() => {
     fetch(`${getApiBase()}/api/registry`)
@@ -3358,6 +3637,13 @@ export default function Launcher() {
       .catch(() => { });
   }, []);
 
+  const refreshProjects = useCallback(() => {
+    fetch(`${getApiBase()}/api/projects`)
+      .then((r) => r.json())
+      .then((data) => setProjects(data.projects || []))
+      .catch(() => { });
+  }, []);
+
   const refreshRunning = useCallback(() => {
     fetch(`${getApiBase()}/api/processes/children`)
       .then((r) => r.json())
@@ -3369,10 +3655,11 @@ export default function Launcher() {
     Promise.all([
       fetch(`${getApiBase()}/api/backends`).then((r) => r.json()),
       fetch(`${getApiBase()}/api/registry`).then((r) => r.json()),
+      fetch(`${getApiBase()}/api/projects`).then((r) => r.json()),
       fetch(`${getApiBase()}/api/sessions`).then((r) => r.json()),
       fetch(`${getApiBase()}/api/processes/children`).then((r) => r.json()),
     ])
-      .then(([backendData, registryData, sessionsData, runningData]) => {
+      .then(([backendData, registryData, projectsData, sessionsData, runningData]) => {
         setBackendOptions(backendData.backends || []);
         if (backendData.defaultBackendType) {
           setDefaultBackendType(backendData.defaultBackendType);
@@ -3380,6 +3667,7 @@ export default function Launcher() {
         setBuiltins(registryData.builtins || []);
         setPublished(registryData.published || []);
         setLocal(registryData.local || []);
+        setProjects(projectsData.projects || []);
         setSessions(sessionsData.sessions || []);
         if (sessionsData.homeDir) setHomeDir(sessionsData.homeDir);
         setRunning(runningData.processes || []);
@@ -3392,9 +3680,10 @@ export default function Launcher() {
     const interval = setInterval(() => {
       refreshRunning();
       refreshSessions();
+      refreshProjects();
     }, 3000);
     return () => clearInterval(interval);
-  }, [refreshRunning, refreshSessions]);
+  }, [refreshRunning, refreshSessions, refreshProjects]);
 
   // Refresh sessions + running when tab regains focus (picks up new thumbnails)
   useEffect(() => {
@@ -3402,11 +3691,12 @@ export default function Launcher() {
       if (document.visibilityState === "visible") {
         refreshSessions();
         refreshRunning();
+        refreshProjects();
       }
     };
     document.addEventListener("visibilitychange", handleVisibility);
     return () => document.removeEventListener("visibilitychange", handleVisibility);
-  }, [refreshSessions, refreshRunning]);
+  }, [refreshSessions, refreshRunning, refreshProjects]);
 
   const deleteLocalMode = useCallback(async (name: string) => {
     try {
@@ -3505,6 +3795,42 @@ export default function Launcher() {
     } catch { }
   }, [refreshSessions, refreshRunning]);
 
+  const openProject = useCallback(async (projectId: string) => {
+    try {
+      const res = await fetch(`${getApiBase()}/api/projects/${encodeURIComponent(projectId)}`);
+      if (!res.ok) return;
+      const data = await res.json();
+      setProjectOverview(data as ProjectOverviewData);
+    } catch { }
+  }, []);
+
+  const launchProjectSession = useCallback(async (
+    projectRoot: string,
+    mode: string,
+    backendType: BackendType,
+    projectSessionId?: string,
+  ) => {
+    try {
+      const res = await fetch(`${getApiBase()}/api/launch`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          specifier: mode,
+          projectRoot,
+          backendType,
+          ...(projectSessionId ? { projectSessionId } : {}),
+        }),
+      });
+      const data = await res.json();
+      if (data.url) {
+        refreshProjects();
+        refreshSessions();
+        refreshRunning();
+        setTimeout(() => window.open(data.url, "_blank"), 400);
+      }
+    } catch { }
+  }, [refreshProjects, refreshSessions, refreshRunning]);
+
   // Build icon lookup
   const iconMap = React.useMemo(() => {
     const map: Record<string, string> = {};
@@ -3517,32 +3843,9 @@ export default function Launcher() {
 
   // Separate app sessions (layout=app, not editing) from regular sessions
   const appSessions = sessions.filter((s) => s.layout === "app" && s.editing === false);
-  const appWorkspaces = new Set(appSessions.map((s) => s.workspace));
 
   // Merge sessions + running for the "Continue" section (max 3 on homepage)
-  const runningWorkspaces = new Set(running.map((r) => r.workspace));
-  const allContinueItems = [
-    // Running processes first (exclude app sessions)
-    ...running
-      .filter((proc) => !appWorkspaces.has(proc.workspace))
-      .map((proc) => ({
-        type: "running" as const,
-        key: proc.workspace,
-        process: proc,
-        session: sessions.find((s) => s.workspace === proc.workspace),
-        modeName: proc.specifier.split("/").pop() || proc.specifier,
-      })),
-    // Then recent sessions (not currently running, not app sessions)
-    ...sessions
-      .filter((s) => !runningWorkspaces.has(s.workspace) && !appWorkspaces.has(s.workspace))
-      .map((s) => ({
-        type: "recent" as const,
-        key: s.workspace,
-        session: s,
-        process: undefined as ChildProcess | undefined,
-        modeName: s.mode,
-      })),
-  ];
+  const allContinueItems = buildContinueItems<RecentSession, ChildProcess>(sessions, running);
   const continueItems = allContinueItems.slice(0, 3);
 
   // Featured mode — random builtin with showcase, picked once on first data load
@@ -3652,7 +3955,7 @@ export default function Launcher() {
             </a>
           </div>
           <button
-            onClick={() => { setShowGallery(false); setShowAllSessions(false); setLaunchTarget(null); }}
+            onClick={() => { setShowGallery(false); setShowAllSessions(false); setLaunchTarget(null); setShowCreateProject(false); setProjectOverview(null); }}
             className={`p-2 text-cc-muted/50 hover:text-cc-fg transition-all duration-300 ease-out cursor-pointer ${
               hasOverlay ? "opacity-100 translate-x-0 scale-100" : "opacity-0 translate-x-3 scale-75 pointer-events-none"
             }`}
@@ -3687,6 +3990,42 @@ export default function Launcher() {
               onExplore={() => setShowGallery(true)}
             />
           )}
+
+          {/* Recent Projects */}
+          <section
+            className="mb-10 pt-8 border-t border-cc-border"
+            style={{ animation: "launcherFadeIn 0.5s cubic-bezier(0.16, 1, 0.3, 1) 0.08s both" }}
+          >
+            <div className="flex items-baseline justify-between mb-5">
+              <h2 className="text-sm font-medium text-cc-fg/70 tracking-wide">Recent Projects</h2>
+              <button
+                onClick={() => setShowCreateProject(true)}
+                className="text-xs text-cc-muted/50 hover:text-cc-primary transition-colors cursor-pointer"
+              >
+                Create Project
+              </button>
+            </div>
+            {projects.length > 0 ? (
+              <div className="grid gap-3" style={{ gridTemplateColumns: "repeat(auto-fill, minmax(220px, 1fr))" }}>
+                {projects.slice(0, 6).map((project) => (
+                  <ProjectCard
+                    key={project.projectId}
+                    project={project}
+                    homeDir={homeDir}
+                    onOpen={() => openProject(project.projectId)}
+                  />
+                ))}
+              </div>
+            ) : (
+              <div className="rounded-lg border border-cc-border/50 bg-cc-bg-secondary p-5 flex items-center justify-between gap-4">
+                <div>
+                  <div className="text-sm text-cc-fg/80">No projects yet</div>
+                  <div className="text-xs text-cc-muted/55 mt-1">Projects keep related sessions under one real folder.</div>
+                </div>
+                <PrimaryButton size="sm" onClick={() => setShowCreateProject(true)}>Create</PrimaryButton>
+              </div>
+            )}
+          </section>
 
           {/* My Apps — app-layout sessions in use mode */}
           {appSessions.length > 0 && (
@@ -3738,7 +4077,7 @@ export default function Launcher() {
               style={{ animation: "launcherFadeIn 0.5s cubic-bezier(0.16, 1, 0.3, 1) 0.15s both" }}
             >
               <div className="flex items-baseline justify-between mb-5">
-                <h2 className="text-sm font-medium text-cc-fg/70 tracking-wide">Continue</h2>
+                <h2 className="text-sm font-medium text-cc-fg/70 tracking-wide">Recent Sessions</h2>
                 <div className="flex items-center gap-3">
                   <button
                     onClick={() => setShowImportDialog(true)}
@@ -3961,6 +4300,37 @@ export default function Launcher() {
           homeDir={homeDir}
           onClose={() => setLaunchTarget(null)}
           closing={launchAnim.closing}
+        />
+      )}
+
+      {showCreateProject && (
+        <CreateProjectDialog
+          homeDir={homeDir}
+          onClose={() => setShowCreateProject(false)}
+          onCreated={(project) => {
+            setShowCreateProject(false);
+            refreshProjects();
+            openProject(project.projectId);
+          }}
+        />
+      )}
+
+      {projectOverview && (
+        <ProjectOverview
+          data={projectOverview}
+          modes={allModes}
+          homeDir={homeDir}
+          iconMap={iconMap}
+          defaultBackendType={defaultBackendType}
+          onClose={() => setProjectOverview(null)}
+          onResume={(session) => {
+            setProjectOverview(null);
+            launchProjectSession(projectOverview.project.root, session.mode, session.backendType, session.sessionId);
+          }}
+          onStartNew={(mode) => {
+            setProjectOverview(null);
+            launchProjectSession(projectOverview.project.root, mode.specifier, defaultBackendType);
+          }}
         />
       )}
 

--- a/src/components/__tests__/launcher-helpers.test.ts
+++ b/src/components/__tests__/launcher-helpers.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test";
+import { buildContinueItems } from "../launcher-helpers";
+
+describe("buildContinueItems", () => {
+  test("excludes running project processes from global recent sessions", () => {
+    const items = buildContinueItems(
+      [
+        { workspace: "/tmp/quick", mode: "doc" },
+      ],
+      [
+        { pid: 1, specifier: "webcraft", workspace: "/tmp/project", projectRoot: "/tmp/project" },
+        { pid: 2, specifier: "doc", workspace: "/tmp/quick" },
+      ],
+    );
+
+    expect(items.map((item) => item.key)).toEqual(["running:2"]);
+  });
+});

--- a/src/components/launcher-helpers.ts
+++ b/src/components/launcher-helpers.ts
@@ -1,0 +1,55 @@
+export interface ContinueSessionLike {
+  workspace: string;
+  mode: string;
+  layout?: "editor" | "app";
+  editing?: boolean;
+}
+
+export interface ContinueProcessLike {
+  pid?: number;
+  specifier: string;
+  workspace: string;
+  projectRoot?: string;
+}
+
+export interface ContinueItem<S extends ContinueSessionLike, P extends ContinueProcessLike> {
+  type: "running" | "recent";
+  key: string;
+  session?: S;
+  process?: P;
+  modeName: string;
+}
+
+export function buildContinueItems<S extends ContinueSessionLike, P extends ContinueProcessLike>(
+  sessions: S[],
+  running: P[],
+): Array<ContinueItem<S, P>> {
+  const appWorkspaces = new Set(
+    sessions
+      .filter((session) => session.layout === "app" && session.editing === false)
+      .map((session) => session.workspace),
+  );
+  const independentRunning = running.filter((process) => !process.projectRoot);
+  const runningWorkspaces = new Set(independentRunning.map((process) => process.workspace));
+
+  return [
+    ...independentRunning
+      .filter((process) => !appWorkspaces.has(process.workspace))
+      .map((process) => ({
+        type: "running" as const,
+        key: process.pid ? `running:${process.pid}` : `running:${process.workspace}:${process.specifier}`,
+        process,
+        session: sessions.find((session) => session.workspace === process.workspace),
+        modeName: process.specifier.split("/").pop() || process.specifier,
+      })),
+    ...sessions
+      .filter((session) => !runningWorkspaces.has(session.workspace) && !appWorkspaces.has(session.workspace))
+      .map((session) => ({
+        type: "recent" as const,
+        key: session.workspace,
+        session,
+        process: undefined,
+        modeName: session.mode,
+      })),
+  ];
+}


### PR DESCRIPTION
## Automated Verification

- [x] `bun test` - pass (772 pass, 0 fail, 2015 expect calls)
- [x] `git diff --check` - pass
- [x] `bun run build` - pass; Vite still reports the existing local Node 22.11.0 warning and existing chunk-size / dynamic-import warnings

## Human Verification TODO

- [ ] Open Launcher on this branch and confirm project creation, seed-session upgrade, project overview, mode switch handoff dialog, and project evolve all work end-to-end.
- [ ] Launch a target session from a confirmed handoff and confirm the generated agent context includes the Confirmed Handoff section.

## Retro Notes

- Refs #81, #82, #83, #84, #85, #86. This PR intentionally consolidates the Project Layer cards into one branch for product review.
- Treat handoff draft frontmatter as untrusted input; confirm validates the edited target mode before creating the target session.
- Quick-session upgrade needs a deliverable collision preflight so fork semantics do not overwrite files already present in the chosen project root.
