### PR TITLE
feat: scene-setting CLAUDE.md + SKILL.md-centric mode migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ web/.deploy.env
 
 # Git worktrees
 .worktrees/
+
+# Per-mode build artifacts (e.g. modes/slide/.build/)
+.build/

--- a/bin/pneuma.ts
+++ b/bin/pneuma.ts
@@ -754,6 +754,7 @@ async function handleEvolveCommand(args: string[]) {
     workspace,
     skillConfig: manifest.skill,
     modeSourceDir: targetModeSourceDir,
+    displayName: manifest.displayName,
   });
 
   // 3b. Install evolve skill (so agent has dashboard context in SKILL.md)
@@ -765,6 +766,7 @@ async function handleEvolveCommand(args: string[]) {
     modeSourceDir: evolveModeSourceDir,
     params: {},
     viewerApi: evolveManifest.viewerApi,
+    displayName: evolveManifest.displayName,
   });
 
   // 4. Determine dev vs production mode
@@ -1629,6 +1631,7 @@ Options:
       viewerApi: manifest.viewerApi,
       backendType,
       proxyConfig: manifest.proxy,
+      displayName: manifest.displayName,
     });
     // Record installed skill version for update detection
     const skillVersionPath = join(stateDir, "skill-version.json");
@@ -2016,6 +2019,7 @@ Options:
         viewerApi: manifest.viewerApi,
         backendType,
         proxyConfig: manifest.proxy,
+        displayName: manifest.displayName,
       });
 
       // Record installed skill version
@@ -2260,6 +2264,7 @@ Options:
           viewerApi: manifest.viewerApi,
           backendType: sessionBackendType,
           proxyConfig: manifest.proxy,
+          displayName: manifest.displayName,
         });
         const skillVersionPath = join(stateDir, "skill-version.json");
         writeFileSync(skillVersionPath, JSON.stringify({ mode: modeName, version: manifest.version }));
@@ -2422,6 +2427,7 @@ Options:
             viewerApi: manifest.viewerApi,
             backendType: sessionBackendType,
             proxyConfig: manifest.proxy,
+            displayName: manifest.displayName,
           });
 
           backend = createBackend(sessionBackendType, actualPort);

--- a/core/types/mode-manifest.ts
+++ b/core/types/mode-manifest.ts
@@ -59,8 +59,26 @@ export interface SkillConfig {
   sourceDir: string;
   /** Directory name under .claude/skills/ (e.g. "pneuma-doc") */
   installName: string;
-  /** Content snippet injected into CLAUDE.md (excluding marker comments) */
-  claudeMdSection: string;
+  /**
+   * Short scene-setting paragraph (1–3 sentences) for the `pneuma:start` block
+   * in CLAUDE.md / AGENTS.md. Describes what the user and the agent are doing
+   * together in this mode — not a system prompt or rule list. The installer
+   * wraps it in a templated header that already names the mode, runtime shell,
+   * and backend; the scene paragraph adds the human-shaped context.
+   *
+   * Mode-specific architecture, file conventions, and workflows do NOT belong
+   * here — they live in the mode's SKILL.md and load via progressive disclosure.
+   *
+   * If omitted, the installer falls back to a generic scene built from
+   * displayName + description.
+   */
+  mdScene?: string;
+  /**
+   * @deprecated Use `mdScene` for the scene paragraph and put the rest in
+   * the mode's `SKILL.md`. Retained as optional during migration; treated as
+   * an additional source of scene text if `mdScene` is missing.
+   */
+  claudeMdSection?: string;
   /**
    * Environment variable file mapping — automatically generates .env during skill installation.
    * key: environment variable name (e.g. "OPENROUTER_API_KEY")
@@ -181,8 +199,12 @@ export interface ViewerApiConfig {
     label: string;
     description?: string;
   }>;
-  /** Locator cards — clickable navigation targets in agent messages.
-   *  When set, instructions for `<viewer-locator>` tags are injected into CLAUDE.md. */
+  /**
+   * @deprecated Mode-specific locator-card guidance now lives in the mode's
+   * `SKILL.md` (loaded via progressive disclosure), not in CLAUDE.md.
+   * The slim Viewer API teaser only mentions that the channel exists.
+   * Retained as optional during migration — currently unused by the installer.
+   */
   locatorDescription?: string;
   /** Scaffold — workspace initialization/reset capability. Requires user confirmation in browser. */
   scaffold?: {

--- a/core/types/mode-manifest.ts
+++ b/core/types/mode-manifest.ts
@@ -199,13 +199,6 @@ export interface ViewerApiConfig {
     label: string;
     description?: string;
   }>;
-  /**
-   * @deprecated Mode-specific locator-card guidance now lives in the mode's
-   * `SKILL.md` (loaded via progressive disclosure), not in CLAUDE.md.
-   * The slim Viewer API teaser only mentions that the channel exists.
-   * Retained as optional during migration — currently unused by the installer.
-   */
-  locatorDescription?: string;
   /** Scaffold — workspace initialization/reset capability. Requires user confirmation in browser. */
   scaffold?: {
     description: string;

--- a/core/types/viewer-contract.ts
+++ b/core/types/viewer-contract.ts
@@ -279,7 +279,4 @@ export interface ViewerContract {
 
   /** Capture current viewport screenshot (optional, dynamically injected by PreviewComponent after mount) */
   captureViewport?: () => Promise<{ data: string; media_type: string } | null>;
-
-  /** Locator format description — injected into CLAUDE.md to guide the agent in generating <viewer-locator> tags */
-  locatorDescription?: string;
 }

--- a/modes/_shared/skills/pneuma-preferences/SKILL.md
+++ b/modes/_shared/skills/pneuma-preferences/SKILL.md
@@ -32,6 +32,8 @@ Preferences are not instructions. They're your understanding of who this user is
 
 Files are created by you as needed. An absent file means no profile exists yet — not an error.
 
+**Project sessions** carry a parallel set of preference files at `<projectRoot>/.pneuma/preferences/` — same schema, but scoped to one project. Those belong to the `pneuma-project` skill, not this one. When a project preference contradicts a personal one, follow the project's and tell the user once with a brief reason — the full conflict policy lives in `pneuma-project` (read it if you're in a project and the situation comes up).
+
 ## Three-Layer Model
 
 Preferences organize into three layers, each requiring different levels of evidence:

--- a/modes/clipcraft/manifest.ts
+++ b/modes/clipcraft/manifest.ts
@@ -28,13 +28,7 @@ const clipcraftManifest: ModeManifest = {
       OPENROUTER_API_KEY: "openrouterApiKey",
       FAL_KEY: "falApiKey",
     },
-    claudeMdSection: `## Pneuma ClipCraft Mode
-
-You are running inside **Pneuma**, a co-creation workspace. This is **ClipCraft Mode** — AI-orchestrated video production on \`@pneuma-craft\`.
-
-Your domain knowledge lives in the \`pneuma-clipcraft\` skill. Read \`.claude/skills/pneuma-clipcraft/SKILL.md\` at session start; reference \`references/craft.md\` before creative decisions, \`references/project-json.md\` when editing \`project.json\`, \`references/workflows.md\` when the user asks for a generation task, \`references/reference-directives.md\` for the seedance multi-reference directive language, \`references/character-consistency.md\` when a specific human character appears, and \`references/filter-retries.md\` when seedance rejects with a 422.
-
-The \`scripts/\` directory holds six generator CLIs: \`generate_image.mjs\` (shared, GPT-Image-2 default — legible text, multi-layer composition, complex UI mockups, precise mask edits); \`edit_image.mjs\` (shared, Gemini vision for annotation-driven edits); \`generate-video.mjs\` (seedance 2.0 with veo3.1 fallback); \`generate-tts.mjs\`; \`generate-bgm.mjs\`; \`make-character-sheet.mjs\` (recovery tool for the image-side content filter). GPT-Image-2's strength at rendering text, preserving layout across multiple references, and holding an aesthetic direction makes the video-side pipeline much more controlled — first/last frames, title cards, text overlays, character sheets, and complex single-frame compositions all hold up now in ways that used to require heavy post-processing.`,
+    mdScene: `You and the user are producing an AI-generated video together inside Pneuma's ClipCraft workspace. The user watches an exploded 3D timeline of tracks, clips, and assets — every asset you generate and every edit you make to \`project.json\` re-hydrates the composition live, so they can hear the new TTS take or see the new shot land on the timeline as soon as it's ready. You orchestrate the work by running the bundled generation scripts and editing \`project.json\`; the viewer plays the result back as the file changes.`,
   },
 
   viewer: {
@@ -83,8 +77,6 @@ The \`scripts/\` directory holds six generator CLIs: \`generate_image.mjs\` (sha
           "Export the project as an MP4. Handled directly in the viewer — clicking this button runs @pneuma-craft/video's ExportEngine against the live composition and downloads the finished file. No agent involvement.",
       },
     ],
-    locatorDescription:
-      'After creating or editing assets, clips, or moving the playhead, embed <viewer-locator> cards so the user can jump straight to the change. Emit one card per distinct thing you changed (a newly generated asset, a clip you just placed, a time beat you built around) — not one per response. Data shapes: navigate to an asset in the library via `data=\'{"assetId":"asset-<semantic-id>"}\'`; navigate to a clip on the timeline (auto-selects the clip and seeks the playhead to its start) via `data=\'{"clipId":"clip-<semantic-id>"}\'`; seek the playhead to a time in seconds via `data=\'{"time":3.5}\'`; focus a track via `data=\'{"trackId":"track-<semantic-id>"}\'`. Use short concrete labels like "新的 VO 开场" or "panda clip on Main" — the user will see these cards in chat and click to navigate.',
   },
 
   agent: {

--- a/modes/clipcraft/skill/SKILL.md
+++ b/modes/clipcraft/skill/SKILL.md
@@ -18,6 +18,107 @@ ClipCraft is built for **AIGC workflows**: assets are generated, not
 uploaded. You orchestrate image / video / TTS / BGM generation by
 running bundled scripts, then record the lineage in `project.json`.
 
+## Working with the viewer
+
+The viewer is the exploded 3D timeline rendering of `project.json`.
+It is the user's source of truth for what's currently selected, what
+the playhead is on, and what they're pointing at. Four channels link
+the three actors (you, the user, the viewer):
+
+### Reading what the user sees
+
+Every user message arrives wrapped in `<viewer-context>` and (if the
+user just clicked / dragged / seeked) `<user-actions>`. Read them
+before you act. Typical clipcraft payloads:
+
+- `<viewer-context>` — `selectedClipId`, `selectedAssetId`,
+  `selectedTrackId`, `playheadTime` (seconds), `composition.duration`,
+  the active asset's metadata. Use this to disambiguate a vague
+  request like "try another take" — there's almost always a clip
+  selected that tells you which one.
+- `<user-actions>` — recent UI events: `playhead:seek`
+  (`{time}`), `clip:select` (`{clipId, trackId}`),
+  `asset:select` (`{assetId}`), `clip:drag` (`{clipId, startTime,
+  trackId}`), `track:toggle-mute`, `track:toggle-visible`. Treat
+  these as hints, not commands — the user usually expects you to
+  read them and act, not echo them back.
+
+If both are absent (cold start, command-button click), inspect
+`project.json` directly and ask if intent is ambiguous.
+
+### Locator cards
+
+After creating or editing assets, clips, or moving the playhead,
+embed `<viewer-locator>` cards so the user can jump straight to the
+change. Emit one card per distinct thing you changed — a newly
+generated asset, a clip you just placed, a time beat you built
+around — not one per response. The user sees these as clickable
+chips in chat. Use short concrete labels — "新的 VO 开场",
+"panda clip on Main", "3.5s — punchline beat" — not generic ones
+like "see asset".
+
+Four `data` shapes for clipcraft:
+
+```html
+<!-- assetId — scrolls the asset library to the asset and flashes it. -->
+<viewer-locator data='{"assetId":"asset-vo-tagline"}'>新的 VO 开场</viewer-locator>
+
+<!-- clipId — selects the clip on the timeline AND seeks the playhead
+     to its startTime, so the user lands on the frame you mean. -->
+<viewer-locator data='{"clipId":"clip-shot1-spark"}'>panda clip on Main</viewer-locator>
+
+<!-- time — seeks the playhead only (no selection change). Use for
+     pure "go look at this beat" pointers. -->
+<viewer-locator data='{"time":3.5}'>3.5s — punchline beat</viewer-locator>
+
+<!-- trackId — scrolls and flashes a track header. Use when the
+     change is track-level (mute/solo, reordered, new track). -->
+<viewer-locator data='{"trackId":"track-narration"}'>narration track</viewer-locator>
+```
+
+### Viewer commands (user → agent)
+
+The viewer toolbar exposes six command buttons. Clicks arrive as
+short natural-language messages in chat — they're hints about what
+the user wants next, usually with a clip or scene pre-selected, not
+rigid tool calls. Read `<viewer-context>` to figure out the target,
+then run the matching workflow. If intent is ambiguous (e.g. a vague
+"generate video"), confirm before spending money on `veo3.1`.
+
+| Command | Typical handling |
+|---|---|
+| Generate image | New image asset for the current selection — read context for scene/clip |
+| Generate video | New video clip; confirm before veo3.1 if vague |
+| Try another take | Variant of the selected clip's asset; register as a derived asset (provenance edge) so the variant switcher shows both options |
+| Add narration | TTS for the selected subtitle clip (or the whole caption track); match audio clip timing to subtitle clip timing |
+| Add BGM | Ask for mood/style if not given; generate, register, place on a new or existing audio track |
+| Export video | Handled in the viewer — runs `@pneuma-craft/video` ExportEngine. **No agent involvement.** |
+
+### Agent → viewer actions (HTTP)
+
+When you need to *drive* the viewer (not just respond), POST to
+`$PNEUMA_API/api/viewer/action`. Reach for this when the user asks
+"show me the part where..." and you want the playhead to land
+there before you explain, or when you've just registered an asset
+and want it pre-selected for the next take.
+
+```bash
+# Seek the playhead to a specific second.
+curl -s -X POST "$PNEUMA_API/api/viewer/action" \
+  -H 'content-type: application/json' \
+  -d '{"action":"playhead:seek","payload":{"time":4.2}}'
+
+# Select a clip on the timeline (also seeks to its start).
+curl -s -X POST "$PNEUMA_API/api/viewer/action" \
+  -H 'content-type: application/json' \
+  -d '{"action":"clip:select","payload":{"clipId":"clip-shot1-spark"}}'
+```
+
+Prefer `<viewer-locator>` cards when the user benefits from a
+clickable hand-off. Use HTTP actions when *you* need the viewer
+state to change before the next step (e.g. taking a screenshot via
+`/api/native/screenshot`).
+
 ## When to reach for which reference
 
 This SKILL.md is the map. Drill into the references when the
@@ -353,47 +454,6 @@ prompt words (no "CG render" / "virtual character" — they degrade
 output quality), and always include `--no-audio` (seedance's
 output-audio filter rejects these generations at the second gate).
 Full recipe and honest-limits disclosures in the reference doc.
-
-## Viewer commands
-
-The viewer exposes a row of command buttons (Generate image,
-Generate video, Try another take, Add narration, Add BGM, Export
-video). Clicks arrive as short natural-language messages in the
-chat — they're hints about what the user wants next, usually with a
-clip or scene pre-selected, not rigid tool calls.
-
-Interpret them conversationally: read the viewer context to see
-what's currently selected, then execute the matching workflow. If
-the intent is ambiguous (for example a vague "generate video"),
-confirm with the user before spending money on veo3.1.
-
-## Locator cards
-
-After creating or editing assets, clips, or moving the playhead,
-embed `<viewer-locator>` cards so the user can jump straight to the
-change. Emit one card per distinct thing you changed — a newly
-generated asset, a clip you just placed, a time beat you built
-around — not one per response. The user sees these as clickable
-chips in chat.
-
-Four `data` shapes, pick the one that matches what you changed:
-
-```html
-<!-- An asset in the library -->
-<viewer-locator data='{"assetId":"asset-<semantic-id>"}'>新的 VO 开场</viewer-locator>
-
-<!-- A clip on the timeline (auto-selects + seeks to its start) -->
-<viewer-locator data='{"clipId":"clip-<semantic-id>"}'>panda clip on Main</viewer-locator>
-
-<!-- Seek the playhead to a time in seconds -->
-<viewer-locator data='{"time":3.5}'>3.5s — punchline beat</viewer-locator>
-
-<!-- Focus a track -->
-<viewer-locator data='{"trackId":"track-<semantic-id>"}'>narration track</viewer-locator>
-```
-
-Use short concrete labels — "新的 VO 开场", "panda clip on Main",
-"3.5s — punchline beat" — not generic ones like "see asset".
 
 ## Gotchas
 

--- a/modes/clipcraft/skill/SKILL.md
+++ b/modes/clipcraft/skill/SKILL.md
@@ -18,6 +18,28 @@ ClipCraft is built for **AIGC workflows**: assets are generated, not
 uploaded. You orchestrate image / video / TTS / BGM generation by
 running bundled scripts, then record the lineage in `project.json`.
 
+## When to reach for which reference
+
+This SKILL.md is the map. Drill into the references when the
+situation matches:
+
+- `references/craft.md` — before any creative decision (open brief,
+  generated clip feels close-but-wrong, picking music, deciding what
+  to cut). It's principles, not procedures.
+- `references/project-json.md` — before editing `project.json`. The
+  user usually doesn't know the schema; you have to.
+- `references/workflows.md` — when the user asks for a generation
+  task. Pattern-match the closest end-to-end example, then adapt.
+- `references/reference-directives.md` — when more than one visual
+  intent needs to be pinned down for a seedance generation (multi-ref
+  @-addressing, role vocabulary).
+- `references/character-consistency.md` — when a specific human
+  character appears, especially photorealistic, especially across
+  multiple shots.
+- `references/filter-retries.md` — when seedance rejects with a 422.
+  Decision tree for the two distinct content-filter signatures.
+- `references/asset-ids.md` — id naming and stability rules.
+
 ## Domain vocabulary (2-minute version)
 
 - **Asset** — an addressable piece of media. Has `id`, `type`, `uri`,
@@ -344,6 +366,34 @@ Interpret them conversationally: read the viewer context to see
 what's currently selected, then execute the matching workflow. If
 the intent is ambiguous (for example a vague "generate video"),
 confirm with the user before spending money on veo3.1.
+
+## Locator cards
+
+After creating or editing assets, clips, or moving the playhead,
+embed `<viewer-locator>` cards so the user can jump straight to the
+change. Emit one card per distinct thing you changed — a newly
+generated asset, a clip you just placed, a time beat you built
+around — not one per response. The user sees these as clickable
+chips in chat.
+
+Four `data` shapes, pick the one that matches what you changed:
+
+```html
+<!-- An asset in the library -->
+<viewer-locator data='{"assetId":"asset-<semantic-id>"}'>新的 VO 开场</viewer-locator>
+
+<!-- A clip on the timeline (auto-selects + seeks to its start) -->
+<viewer-locator data='{"clipId":"clip-<semantic-id>"}'>panda clip on Main</viewer-locator>
+
+<!-- Seek the playhead to a time in seconds -->
+<viewer-locator data='{"time":3.5}'>3.5s — punchline beat</viewer-locator>
+
+<!-- Focus a track -->
+<viewer-locator data='{"trackId":"track-<semantic-id>"}'>narration track</viewer-locator>
+```
+
+Use short concrete labels — "新的 VO 开场", "panda clip on Main",
+"3.5s — punchline beat" — not generic ones like "see asset".
 
 ## Gotchas
 

--- a/modes/clipcraft/viewer/ClipCraftPreview.tsx
+++ b/modes/clipcraft/viewer/ClipCraftPreview.tsx
@@ -185,7 +185,7 @@ function SyncedBody({
   // ── Locator navigation ──────────────────────────────────────────────
   //
   // Agent-emitted <viewer-locator> cards arrive as `navigateRequest`.
-  // Data shapes (documented in pneuma-mode.ts as locatorDescription):
+  // Data shapes (documented in the pneuma-clipcraft skill's viewer-protocol section):
   //   { clipId }   — select the clip + seek playhead to clip.startTime,
   //                  then scroll/flash the DOM element.
   //   { assetId }  — scroll/flash the asset tile or row.

--- a/modes/diagram/manifest.ts
+++ b/modes/diagram/manifest.ts
@@ -10,16 +10,7 @@ const diagramManifest: ModeManifest = {
   skill: {
     sourceDir: "skill",
     installName: "pneuma-diagram",
-    claudeMdSection: `## Pneuma Diagram Mode
-
-You are running inside **Pneuma**, a co-creation environment. The user sees a live preview of draw.io diagrams you create.
-
-### How it works
-- You write \`.drawio\` files (draw.io XML format) — the preview updates in real-time as you write
-- The user can select elements on the diagram and chat about them
-- Use descriptive cell IDs (e.g. "user-box", "arrow-1-2") for stable references
-- Always include \`adaptiveColors="auto"\` on mxGraphModel for dark mode support
-- See the skill reference files for complete XML and style documentation`,
+    mdScene: `You and the user are diagramming together inside Pneuma. The user watches a live draw.io canvas as you author \`.drawio\` XML — every Edit or Write streams into the preview, and they can click elements on the canvas to chat about them. You shape the diagram by writing files; the canvas re-renders as the XML changes.`,
   },
 
   viewer: {
@@ -42,7 +33,6 @@ You are running inside **Pneuma**, a co-creation environment. The user sees a li
       ordered: false,
       hasActiveFile: true,
     },
-    locatorDescription: `After creating diagrams, embed a locator card so the user can navigate to it:\n\`\`\`pneuma-locator\ndata='{"file":"architecture.drawio"}'\n\`\`\``,
     scaffold: {
       description: "Reset the active diagram to empty state",
       params: {},

--- a/modes/diagram/skill/SKILL.md
+++ b/modes/diagram/skill/SKILL.md
@@ -10,16 +10,24 @@ description: >
 
 # Pneuma Diagram Mode
 
-You create and edit draw.io diagrams. The user sees a live preview that updates as you write `.drawio` files. Changes appear in real time during streaming — no confirmation needed.
+You create and edit draw.io diagrams. The user sees a live preview that updates as you write `.drawio` files. Changes appear in real time during streaming — no confirmation needed. The user can also click elements on the canvas to select them and chat about specific shapes or edges, so descriptive, stable cell IDs (e.g. `user-box`, `edge-api-db`) make those references far easier to reason about.
 
 ## File Rules
 
 - **Multi-page support.** A single `.drawio` file can contain multiple `<diagram>` pages — the viewer shows tabs to switch between them. Use multiple pages for related diagrams on the same topic (e.g., overview + detail views). Each `<diagram>` must have a unique `id` and descriptive `name`.
-- After creating a diagram, embed a locator card so the user can navigate to it:
-  ```pneuma-locator
-  data='{"file":"architecture.drawio"}'
-  ```
 - When modifying an existing diagram, always `Read` the file first to preserve existing cell IDs and structure.
+
+## Locator cards
+
+After creating or substantially updating a diagram, embed a locator card so the user can jump to it from the chat:
+
+````
+```pneuma-locator
+data='{"file":"architecture.drawio"}'
+```
+````
+
+The `data` field is a JSON object — `file` is the workspace-relative path to the `.drawio` file. The viewer renders the card as a clickable chip that opens the diagram in the preview pane.
 
 ## .drawio XML Structure
 

--- a/modes/diagram/skill/SKILL.md
+++ b/modes/diagram/skill/SKILL.md
@@ -10,24 +10,60 @@ description: >
 
 # Pneuma Diagram Mode
 
-You create and edit draw.io diagrams. The user sees a live preview that updates as you write `.drawio` files. Changes appear in real time during streaming — no confirmation needed. The user can also click elements on the canvas to select them and chat about specific shapes or edges, so descriptive, stable cell IDs (e.g. `user-box`, `edge-api-db`) make those references far easier to reason about.
+You create and edit draw.io diagrams. The user sees a live preview that updates as you write `.drawio` files. Changes appear in real time during streaming — no confirmation needed.
+
+## Working with the viewer
+
+The diagram canvas is the live surface where you and the user meet. Files (`.drawio` XML) are the source of truth; the viewer renders them and exposes a few channels for the user to point at things and for you to drive the canvas. Use these channels — don't ask the user to describe what they're looking at.
+
+### Reading what the user sees
+
+Before you respond, scan the latest user turn for two viewer-emitted blocks:
+
+- `<viewer-context>` — current canvas state. Carries the active `.drawio` file (workspace-relative path) and, when the user clicked a shape or edge to chat about it, the selected element (cell `id`, `value`, and style summary). Trust this over your own assumptions about what's open.
+- `<user-actions>` — discrete events since the last turn (file switches, page changes, element selections). These are the breadcrumbs of what the user just did on the canvas.
+
+If the user says "this box" or "that arrow" without further context, it almost always refers to the selected element from `<viewer-context>` — `Read` that file and locate the cell by `id` before editing.
+
+### Locator cards
+
+After creating or substantially updating a diagram, embed a locator card so the user can jump to it from the chat. The viewer renders the card as a clickable chip that opens the diagram in the preview pane.
+
+Diagram locator `data` keys:
+
+| Key | Required | Meaning |
+|-----|----------|---------|
+| `file` | yes | Workspace-relative path to a `.drawio` file |
+
+Real example:
+
+```html
+<viewer-locator label="Open architecture.drawio" data='{"file":"architecture.drawio"}' />
+```
+
+For a multi-page diagram, one card opens the whole file; the user uses the viewer's page tabs to switch between `<diagram>` pages.
+
+### Viewer actions
+
+The viewer exposes one agent-callable action via `POST $PNEUMA_API/api/viewer/action`:
+
+- **`scaffold`** — Reset the active diagram to empty state. `clearPatterns: ["(active file)"]`. No params.
+
+Use it when the user asks for a clean slate on the current diagram (e.g. "start over", "clear this diagram"). The action wipes the `.drawio` file's content; you then write a fresh `<mxfile>` skeleton.
+
+```bash
+curl -X POST "$PNEUMA_API/api/viewer/action" \
+  -H "Content-Type: application/json" \
+  -d '{"action":"scaffold","params":{}}'
+```
+
+After scaffold, write the new diagram with `Write` — don't expect the canvas to do anything until you save the file.
 
 ## File Rules
 
 - **Multi-page support.** A single `.drawio` file can contain multiple `<diagram>` pages — the viewer shows tabs to switch between them. Use multiple pages for related diagrams on the same topic (e.g., overview + detail views). Each `<diagram>` must have a unique `id` and descriptive `name`.
+- **Descriptive, stable cell IDs** (e.g. `user-box`, `edge-api-db`) — the user can click elements on the canvas, and selections come back via `<viewer-context>` keyed by `id`. Random ids like `cell-1` make those references hard to reason about.
 - When modifying an existing diagram, always `Read` the file first to preserve existing cell IDs and structure.
-
-## Locator cards
-
-After creating or substantially updating a diagram, embed a locator card so the user can jump to it from the chat:
-
-````
-```pneuma-locator
-data='{"file":"architecture.drawio"}'
-```
-````
-
-The `data` field is a JSON object — `file` is the workspace-relative path to the `.drawio` file. The viewer renders the card as a clickable chip that opens the diagram in the preview pane.
 
 ## .drawio XML Structure
 

--- a/modes/doc/manifest.ts
+++ b/modes/doc/manifest.ts
@@ -15,20 +15,7 @@ const docManifest: ModeManifest = {
   skill: {
     sourceDir: "skill",
     installName: "pneuma-doc",
-    claudeMdSection: `## Pneuma Doc Mode
-
-You are running inside **Pneuma**, a co-creation workspace where you and the user build content together — you edit files, the user sees live results in a browser preview panel.
-
-This is **Doc Mode**: markdown document editing with real-time preview.
-
-For editing conventions, context format, and workspace constraints, consult the \`pneuma-doc\` skill.
-
-### Core Rules
-- Edit markdown files directly using Edit or Write tools — the user sees updates in real-time
-- Make focused, incremental edits; preserve existing structure unless asked to reorganize
-- One document per file — separate topics keep the workspace navigable
-- Do not modify \`.claude/\` directory — managed by runtime, edits get overwritten
-- Do not ask for confirmation on simple edits — just do them`,
+    mdScene: `You and the user are writing markdown together inside Pneuma. The user watches a live preview panel as you edit — every Edit or Write you do appears immediately, so they can react and redirect mid-stroke. You shape the document by writing files; the panel re-renders the rendered markdown as files change.`,
   },
 
   viewer: {
@@ -46,7 +33,6 @@ For editing conventions, context format, and workspace constraints, consult the 
 
   viewerApi: {
     workspace: { type: "all", multiFile: true, ordered: false, hasActiveFile: false },
-    locatorDescription: 'After creating or editing documents, embed locator cards so the user can jump to them. Navigate to file: `data=\'{"file":"notes.md"}\'`.',
     scaffold: {
       description: "Initialize workspace with empty markdown files. Clears only the currently viewed files.",
       params: {

--- a/modes/doc/skill/SKILL.md
+++ b/modes/doc/skill/SKILL.md
@@ -49,3 +49,13 @@ Use this to resolve references like "this section", "here", etc.
 - Do not modify `.claude/` directory contents — managed by the runtime, your edits would be overwritten on next session
 - Do not run long-running background processes
 - Do not ask for confirmation before simple edits — just do them. The user sees your edits live and can course-correct immediately
+
+## Locator cards
+
+After creating or editing documents, embed a `<viewer-locator>` card at the end of your reply so the user can jump straight to what changed:
+
+```
+<viewer-locator label="Open notes.md" data='{"file":"notes.md"}' />
+```
+
+The `file` field is the path relative to the workspace root.

--- a/modes/doc/skill/SKILL.md
+++ b/modes/doc/skill/SKILL.md
@@ -19,6 +19,68 @@ You are working in Pneuma Doc Mode — a WYSIWYG markdown editing environment wh
 3. **Preserve structure**: Don't reorganize content unless explicitly asked
 4. **Quality markdown**: Use proper GFM conventions consistently
 
+## Working with the viewer
+
+The user watches a live markdown preview while you edit. Treat the viewer as a shared surface: read what they're looking at, drop them locator cards back to the result, and reach for the scaffold action only when they want a clean slate.
+
+### Reading what the user sees
+
+Each user message may be preceded by a `<viewer-context>` block describing the panel state, and a `<user-actions>` block describing what they just clicked. Use these to resolve deictic phrases like "this section", "here", "that heading".
+
+Example context:
+
+```
+<viewer-context>
+[Context: file "README.md"]
+[User selected: heading (level 2) "Installation"]
+</viewer-context>
+```
+
+When you see the above and the user says "tighten this section up", they mean the `## Installation` heading and the prose underneath it in `README.md`. Edit that file directly — don't ask which one.
+
+If no `<viewer-context>` is attached, the user hasn't selected anything specific; default to the most recently edited file or ask only when the request is genuinely ambiguous.
+
+### Locator cards
+
+After creating or editing a document, post a `<viewer-locator>` card at the end of your reply so the user can jump straight to the result. The `data` payload uses one key: `file`, the path relative to the workspace root.
+
+Examples:
+
+```
+<viewer-locator label="Open notes.md" data='{"file":"notes.md"}' />
+```
+
+```
+<viewer-locator label="See the rewritten Installation section" data='{"file":"README.md"}' />
+```
+
+One card per file you touched is plenty. Use a label that names what the user will find when they click — "Open the new draft" beats "View file".
+
+### Viewer actions
+
+The viewer exposes one agent-invocable action: `scaffold`. Call it with a POST to `$PNEUMA_API/api/viewer/action`:
+
+```bash
+curl -X POST "$PNEUMA_API/api/viewer/action" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "actionId": "scaffold",
+    "params": {
+      "files": "[{\"name\":\"intro.md\",\"heading\":\"Introduction\"},{\"name\":\"methods.md\",\"heading\":\"Methods\"},{\"name\":\"results.md\",\"heading\":\"Results\"}]"
+    }
+  }'
+```
+
+The browser will surface a confirmation prompt before the scaffold runs.
+
+### Scaffold
+
+`scaffold` initializes the workspace with empty markdown files. It clears only the currently viewed files, then writes one file per entry in `files`.
+
+- **`files`** (optional): a JSON-encoded array of `{ name, heading? }`. `name` is the filename (with or without `.md`); `heading` becomes the H1 inside the new file.
+
+Use scaffold only when the user explicitly asks to start fresh — "wipe these and start over", "set up an outline with these chapters", "blank workspace with three files for X / Y / Z". For everyday additions, just `Write` a new `.md` file directly. Scaffold requires user confirmation in the browser, so don't fire it speculatively.
+
 ## File Convention
 
 - The workspace contains markdown files (`.md`)
@@ -33,29 +95,9 @@ You are working in Pneuma Doc Mode — a WYSIWYG markdown editing environment wh
 - Make focused, incremental edits — the user sees changes live, so each edit should leave the document in a valid state
 - Preserve existing content structure unless asked to reorganize — the user chose that structure deliberately
 
-## Context Format
-
-When the user sends a message, they are asking you to edit the markdown content in the workspace. Respond by making the requested edits directly — do not just describe what you would do.
-
-Context may include:
-- `[Context: file "README.md"]` — which file the user is viewing
-- `[User selected: heading (level 2) "Installation"]` — which element they clicked
-
-Use this to resolve references like "this section", "here", etc.
-
 ## Constraints
 
 - Do not create non-markdown files unless explicitly asked
 - Do not modify `.claude/` directory contents — managed by the runtime, your edits would be overwritten on next session
 - Do not run long-running background processes
 - Do not ask for confirmation before simple edits — just do them. The user sees your edits live and can course-correct immediately
-
-## Locator cards
-
-After creating or editing documents, embed a `<viewer-locator>` card at the end of your reply so the user can jump straight to what changed:
-
-```
-<viewer-locator label="Open notes.md" data='{"file":"notes.md"}' />
-```
-
-The `file` field is the path relative to the workspace root.

--- a/modes/draw/manifest.ts
+++ b/modes/draw/manifest.ts
@@ -17,19 +17,7 @@ const drawManifest: ModeManifest = {
   skill: {
     sourceDir: "skill",
     installName: "pneuma-draw",
-    claudeMdSection: `## Pneuma Draw Mode
-
-You are running inside **Pneuma**, a co-creation workspace where you and the user build content together — you edit files, the user sees live results in a browser preview panel.
-
-This is **Draw Mode**: Excalidraw diagramming with real-time canvas preview.
-
-For Excalidraw JSON format, element types, color palette, and diagram recipes, consult the \`pneuma-draw\` skill. You need it to produce correct .excalidraw files.
-
-### Core Rules
-- Edit .excalidraw JSON files directly — the user sees updates in real-time on the canvas
-- Ensure bidirectional binding: arrows reference shapes AND shapes reference arrows (otherwise connections break on canvas interaction)
-- Use unique element IDs and random seeds — changing existing IDs causes visual flicker
-- Do not ask for confirmation on simple edits — just do them`,
+    mdScene: `You and the user are sketching diagrams together on an Excalidraw canvas inside Pneuma. The user watches the whiteboard live as you edit \`.excalidraw\` JSON files — shapes, arrows, and labels appear and rearrange in real time, and they can pan, zoom, or grab elements directly. You shape the drawing by writing files; the canvas re-renders as files change.`,
   },
 
   viewer: {
@@ -47,7 +35,6 @@ For Excalidraw JSON format, element types, color palette, and diagram recipes, c
 
   viewerApi: {
     workspace: { type: "all", multiFile: true, ordered: false, hasActiveFile: true },
-    locatorDescription: 'After creating drawings, embed locator cards so the user can switch to them. Navigate to file: `data=\'{"file":"architecture.excalidraw"}\'`.',
     scaffold: {
       description: "Reset the active canvas to empty state. Only affects the currently viewed file.",
       params: {},

--- a/modes/draw/skill/SKILL.md
+++ b/modes/draw/skill/SKILL.md
@@ -16,6 +16,23 @@ You are an expert at creating and editing Excalidraw diagrams. The user sees you
 
 This mode uses [Excalidraw](https://excalidraw.com) — an open-source, MIT-licensed virtual whiteboard by the Excalidraw team.
 
+## Core Rules
+
+- Edit `.excalidraw` JSON files directly — the user sees updates in real-time on the canvas.
+- Ensure **bidirectional binding** on every connection: arrows reference shapes AND shapes reference arrows. If only one side is set, the connection breaks the moment the user drags or resizes.
+- Generate unique element `id`s and random `seed`s. Changing the IDs or seeds of existing elements causes visible flicker on the canvas.
+- Don't ask for confirmation on simple edits — just do them.
+
+## Locator cards
+
+After creating drawings, embed locator cards so the user can switch to them. Navigate to a file with:
+
+```html
+<viewer-locator data='{"file":"architecture.excalidraw"}'>Architecture diagram</viewer-locator>
+```
+
+The `data` field is a JSON object; `file` is the workspace-relative path to the `.excalidraw` file.
+
 ## File Format
 
 Excalidraw files use `.excalidraw` extension and are JSON:

--- a/modes/draw/skill/SKILL.md
+++ b/modes/draw/skill/SKILL.md
@@ -16,22 +16,48 @@ You are an expert at creating and editing Excalidraw diagrams. The user sees you
 
 This mode uses [Excalidraw](https://excalidraw.com) — an open-source, MIT-licensed virtual whiteboard by the Excalidraw team.
 
+## Working with the viewer
+
+The draw viewer is an Excalidraw canvas. It renders one `.excalidraw` JSON file at a time and streams what the user sees and does back into the conversation. Four channels matter for this mode:
+
+### Reading what the user sees
+
+Each user turn arrives wrapped with a `<viewer-context>` block describing the current canvas state. For draw, it carries:
+
+- The active `.excalidraw` file path (the canvas only renders one file at a time).
+- The Excalidraw scene state — element ids, types, positions, and which elements are currently selected.
+- A `<user-actions>` sub-block listing direct manipulations the user performed since the last turn — drag, resize, move, or delete on individual shapes/arrows/text.
+
+Read it before you edit. If the user dragged `start-node` 200px to the right, your next edit should preserve that new position rather than snap it back to the old layout.
+
+### Locator cards
+
+After creating or substantially updating a diagram, embed a `<viewer-locator>` card so the user can jump to it with one click. The `data` attribute is a JSON object; the only key draw understands is `file` (workspace-relative path to the `.excalidraw` file).
+
+```html
+<viewer-locator data='{"file":"architecture.excalidraw"}'>Architecture diagram</viewer-locator>
+```
+
+For multi-file work (e.g. a system overview plus per-service detail diagrams), emit one card per file so the user can navigate between them.
+
+### Viewer actions
+
+The viewer exposes one agent-callable action — `scaffold` — which resets the **currently viewed** `.excalidraw` file to an empty canvas. Use it when the user asks for a fresh start on the active diagram; do not use it to clear other files.
+
+```bash
+curl -X POST "$PNEUMA_API/api/viewer/action" \
+  -H "Content-Type: application/json" \
+  -d '{"action":"scaffold","params":{}}'
+```
+
+After scaffold, write your new elements into the active file as a normal edit — the canvas re-renders from the JSON you produce.
+
 ## Core Rules
 
 - Edit `.excalidraw` JSON files directly — the user sees updates in real-time on the canvas.
 - Ensure **bidirectional binding** on every connection: arrows reference shapes AND shapes reference arrows. If only one side is set, the connection breaks the moment the user drags or resizes.
 - Generate unique element `id`s and random `seed`s. Changing the IDs or seeds of existing elements causes visible flicker on the canvas.
 - Don't ask for confirmation on simple edits — just do them.
-
-## Locator cards
-
-After creating drawings, embed locator cards so the user can switch to them. Navigate to a file with:
-
-```html
-<viewer-locator data='{"file":"architecture.excalidraw"}'>Architecture diagram</viewer-locator>
-```
-
-The `data` field is a JSON object; `file` is the workspace-relative path to the `.excalidraw` file.
 
 ## File Format
 

--- a/modes/evolve/manifest.ts
+++ b/modes/evolve/manifest.ts
@@ -17,17 +17,7 @@ const evolveManifest: ModeManifest = {
   skill: {
     sourceDir: "skill",
     installName: "pneuma-evolve",
-    claudeMdSection: `## Pneuma Skill Evolution
-
-You are the Skill Evolution Agent. Your job is to analyze conversation history and propose skill augmentations.
-
-For the full evolution process, data access scripts, proposal format, and interaction protocol, consult the \`pneuma-evolve\` skill. Do not start analysis without loading it first.
-
-### Core Rules
-- Brief the user and wait for confirmation before analyzing
-- Do NOT modify skill files directly — write proposals only
-- Every proposed change must cite specific user quotes as evidence
-- When in doubt, propose nothing — an empty proposal is better than noise`,
+    mdScene: `You and the user are sitting together with a transcript of past sessions, mining what the user actually prefers. The user watches an Evolution Dashboard while you read through history scripts and write proposal files; each proposal you save appears there for them to inspect, apply, fork, or discard. The work is reflective — you are reading the past, not producing a new artifact in real time.`,
   },
 
   viewer: {

--- a/modes/evolve/skill/SKILL.md
+++ b/modes/evolve/skill/SKILL.md
@@ -2,6 +2,38 @@
 
 You are the Skill Evolution Agent for Pneuma. Your mission is to analyze a user's interaction history and write structured proposal files that evolve workspace skill files — both **augmenting** with learned preferences and **pruning** instructions that are no longer load-bearing.
 
+## Working with the viewer
+
+The user sees an **Evolution Dashboard** (left panel). Unlike co-creation modes, there is no live canvas — your work surfaces as proposal files that the dashboard auto-polls and renders. This section consolidates everything you need to know about that surface.
+
+### Reading what the user sees
+
+The user's last message arrives wrapped with two channels you should consume on every turn:
+
+- `<viewer-context>` — a snapshot of dashboard state. For evolve this includes: the target mode being evolved, the workspace path, the active evolution directive, data-source statistics, the proposal currently being inspected (id + path), and the diff/section the user is viewing within it. Read this before responding so your follow-ups reference what's actually open in front of them — e.g., "I see you're on proposal #3, change 2 — here's the additional evidence you asked about."
+- `<user-actions>` — discrete user events since your last turn. In evolve, the relevant action types are clicks on **Apply to Workspace**, **Fork as Custom Mode**, **Discard**, and **Rollback** (along with proposal-open / proposal-close navigation). Treat these as ground truth: if the user just discarded a proposal, do not re-pitch it; if they applied one, your next analysis should treat those changes as committed.
+
+### Locator cards
+
+Locators aren't surfaced in evolve — proposals **are** the navigation surface. The dashboard renders the proposal list as the primary index, and the user navigates by clicking proposals directly. Don't emit `<viewer-locator>` cards in chat; instead, reference proposals by id or filename ("see `.pneuma/evolution/proposals/2026-04-30-tone.json`"), and the user will open them from the dashboard list.
+
+### Viewer actions
+
+Evolve's viewer is effectively **read-only from the agent's side**. The dashboard exposes Apply / Fork / Discard / Rollback to the user, but there is no `POST $PNEUMA_API/api/viewer/action` endpoint you should call to drive it. Your only write surface is the filesystem: you write proposal JSON files; the dashboard reads them. Likewise, no native desktop APIs (`$PNEUMA_API/api/native/*`) are part of the evolve workflow.
+
+If you need to communicate with the user, do it in chat — don't try to push UI state from the agent side.
+
+### Workflow integration
+
+Concretely, the loop is:
+
+1. You write a proposal to `.pneuma/evolution/proposals/<slug>.json` using `Write`.
+2. The server's chokidar watcher picks the file up; the dashboard's auto-poll (every ~3 seconds) refreshes the proposal list and the new entry appears.
+3. The user opens it, scans evidence + confidence ratings, and clicks **Apply** (mutates workspace skill files in place), **Fork** (clones into a new custom mode), **Discard** (removes the proposal), or **Rollback** (reverts a previously applied proposal using the snapshot in `.pneuma/evolution/backups/`).
+4. The next turn's `<viewer-context>` and `<user-actions>` reflect that decision; adjust accordingly (don't re-propose a Discarded change without new evidence; treat Applied changes as the new baseline when reading SKILL.md).
+
+Because the dashboard polls, **the file is the message**. A summary in chat is helpful, but the proposal must stand on its own — assume the user reads it inside the dashboard, not in the chat transcript.
+
 ## Evolution Process
 
 The evolution follows this flow:
@@ -21,20 +53,6 @@ Always start with the briefing. The user may want to:
 - Adjust the evolution direction entirely
 
 Do NOT skip the briefing and jump straight into analysis.
-
-## Dashboard Context
-
-The user sees an Evolution Dashboard on the left panel with:
-- **Settings**: target mode, workspace path, evolution directive, data source statistics
-- **Proposals**: auto-polling list of proposals you write (refreshes every 3 seconds)
-- **Actions**: Apply to Workspace, Fork as Custom Mode, Discard, Rollback
-
-## How Proposals Work
-
-1. You write proposal JSON files to `.pneuma/evolution/proposals/`
-2. The dashboard picks them up automatically
-3. The user reviews evidence and content in the dashboard
-4. The user clicks Apply (modifies workspace skill) or Fork (creates a new custom mode)
 
 ## Data Access Scripts
 

--- a/modes/gridboard/manifest.ts
+++ b/modes/gridboard/manifest.ts
@@ -15,27 +15,7 @@ const gridboardManifest: ModeManifest = {
   skill: {
     sourceDir: "skill",
     installName: "pneuma-gridboard",
-    claudeMdSection: `## Pneuma GridBoard Mode
-
-You are running inside **Pneuma**, a co-creation workspace where you and the user build dashboards together — you edit files, the user sees live results in a browser preview panel.
-
-This is **GridBoard Mode**: an interactive dashboard builder with a draggable tile grid.
-
-For tile component patterns, layout rules, and theming conventions, consult the \`pneuma-gridboard\` skill.
-
-### Architecture
-- \`board.json\` — Board layout config: tile positions, sizes, and metadata
-- \`theme.css\` — Shared CSS theme via custom properties (colors, fonts, spacing)
-- \`tiles/<id>/Tile.tsx\` — Individual tile React components (one directory per tile)
-
-### Core Rules
-- Always use \`defineTile()\` helper to register tile components — do not export bare components
-- Use CSS custom properties from \`theme.css\` for all colors, fonts, and spacing — no hardcoded values
-- Keep \`board.json\` in sync after every structural change (add/move/resize/remove tiles)
-- Size tiles appropriately for their content: charts need more space than stat cards
-- Adapt tile content on resize — tiles should look good at both small and large sizes
-- Board canvas: {{boardWidth}}×{{boardHeight}}px, grid: {{columns}} columns × {{rows}} rows
-- Do not ask for confirmation on simple edits — just do them`,
+    mdScene: `You and the user are building a personal dashboard together inside Pneuma. The user watches a draggable tile grid in the preview panel as you create and edit tiles — every file change re-renders live, and they can drag, resize, or open the gallery while you work. You shape the board by writing tile components and keeping board.json in sync; the canvas reflects the result instantly.`,
   },
 
   layout: "app",
@@ -161,7 +141,6 @@ The user just opened the workspace. You are ready to assist with dashboard creat
         description: "Scaffold a new tile component and register it in board.json",
       },
     ],
-    locatorDescription: "After creating or editing tiles, embed locator cards so the user can jump to them. Navigate by tile ID: `data='{\"tileId\":\"revenue-chart\"}'`. Open the gallery: `data='{\"action\":\"open-gallery\"}'`.",
   },
 
   init: {

--- a/modes/gridboard/pneuma-mode.ts
+++ b/modes/gridboard/pneuma-mode.ts
@@ -168,8 +168,6 @@ const gridboardMode: ModeDefinition = {
     },
 
     updateStrategy: "full-reload",
-
-    locatorDescription: gridboardManifest.viewerApi?.locatorDescription,
   },
 };
 

--- a/modes/gridboard/skill/SKILL.md
+++ b/modes/gridboard/skill/SKILL.md
@@ -11,7 +11,9 @@ description: >
 
 # Pneuma GridBoard Mode — Dashboard Building Skill
 
-You are working in Pneuma GridBoard Mode — a live dashboard editor where the user views your edits in real-time in a browser preview panel. You create and manage tiles on a draggable grid canvas.
+GridBoard is a live dashboard editor: you create and manage tiles on a draggable grid canvas, and the user views every file edit in real-time through the preview panel.
+
+**Board canvas:** {{boardWidth}}×{{boardHeight}}px, grid: {{columns}} columns × {{rows}} rows.
 
 ## Core Principles
 
@@ -294,6 +296,20 @@ What does NOT count: bigger fonts, more padding, same elements rearranged.
 2. If the tile's size requirements changed, update `minSize`/`maxSize` in the definition
 3. If position or size on the board changed, update `board.json`
 4. Never modify `.claude/` or `.pneuma/` — managed by the runtime
+
+---
+
+## Locator cards
+
+After creating or editing tiles, embed `<viewer-locator>` cards in chat so the user can jump straight to the result. Navigate by tile ID, or open the gallery to browse available tile types.
+
+```html
+<!-- Jump to a specific tile -->
+<viewer-locator action="navigate-to" data='{"tileId":"revenue-chart"}' label="Revenue Chart" />
+
+<!-- Open the tile gallery -->
+<viewer-locator action="open-gallery" data='{}' label="Browse tiles" />
+```
 
 ## External API Access (Proxy)
 

--- a/modes/gridboard/skill/SKILL.md
+++ b/modes/gridboard/skill/SKILL.md
@@ -15,6 +15,74 @@ GridBoard is a live dashboard editor: you create and manage tiles on a draggable
 
 **Board canvas:** {{boardWidth}}×{{boardHeight}}px, grid: {{columns}} columns × {{rows}} rows.
 
+---
+
+## Working with the viewer
+
+The GridBoard viewer is a live tile-grid canvas the user watches while you edit. Pneuma exposes a small set of channels that flow between the viewer, you (the agent), and the user. Treat them as your primary I/O — the user is rarely in the chat alone, they're dragging, resizing, and clicking inside the board.
+
+### Reading what the user sees
+
+The runtime injects a `<viewer-context>` block into your turn whenever the user has something focused. For GridBoard it carries the active board snapshot, current layout state, and the selected tile (if any). When the user drags or resizes a tile, opens the gallery, or shifts the layout, those movements arrive as `<user-actions>` — operations the user just performed in the viewer that you should treat as ground truth, even if they contradict your last edit.
+
+**Always reconcile `<viewer-context>` and `<user-actions>` before continuing.** If the user resized `revenue-chart` from 2×2 to 4×3, that new size is the source of truth — do not "fix" it back to your earlier choice. Update `board.json` and the tile's internal breakpoints to match.
+
+### Locator cards
+
+After creating or editing tiles, embed `<viewer-locator>` cards in chat so the user can jump straight to the result with one click. The card's `data` attribute is a JSON object the viewer interprets:
+
+- `{"tileId":"<id>"}` — focuses and highlights the tile on the board (uses the `navigate-to` action under the hood)
+- `{"action":"open-gallery"}` — opens the tile-type gallery for browsing available templates
+
+Real examples:
+
+```html
+<!-- Jump to a specific tile you just edited -->
+<viewer-locator label="Open revenue chart tile" data='{"tileId":"revenue-chart"}' />
+
+<!-- Open the gallery so the user can browse what else is available -->
+<viewer-locator label="Open the gallery" data='{"action":"open-gallery"}' />
+```
+
+Emit a locator card whenever you change something the user benefits from looking at — a new tile, a redesigned tier, a fresh gallery entry. One card per concrete destination; do not spam.
+
+### Viewer actions (agent → viewer)
+
+You can drive the viewer programmatically by `POST $PNEUMA_API/api/viewer/action` with a JSON body `{"id":"<action-id>","params":{...}}`. The action set for GridBoard (declared in the manifest) is:
+
+| Action | Params | Use it when |
+|---|---|---|
+| `navigate-to` | `{ tileId }` | You want to focus the user's eye on a tile after editing it |
+| `open-gallery` | `{}` | The user asked what else is available, or you want to suggest templates |
+| `lock-tile` | `{ tileId }` | About to edit a tile's component — show a "modifying" overlay so the user doesn't drag it mid-edit |
+| `unlock-tile` | `{ tileId }` | Done editing — remove the overlay |
+| `capture-tile` | `{ tileId }` | You need a screenshot of one tile (e.g. to verify a render) |
+| `capture-board` | `{}` | You need a screenshot of the whole board (layout review) |
+
+`lock-tile` / `unlock-tile` should bracket multi-edit tile work so the user sees the in-progress state without grabbing a half-edited component. `capture-tile` and `capture-board` return an image you can inspect — use them when a visual check would beat reading code.
+
+Example — focus a tile after a render rewrite:
+
+```bash
+curl -s -X POST "$PNEUMA_API/api/viewer/action" \
+  -H "Content-Type: application/json" \
+  -d '{"id":"navigate-to","params":{"tileId":"revenue-chart"}}'
+```
+
+Example — screenshot the whole board to review layout:
+
+```bash
+curl -s -X POST "$PNEUMA_API/api/viewer/action" \
+  -H "Content-Type: application/json" \
+  -d '{"id":"capture-board","params":{}}'
+```
+
+### Scaffold (commands)
+
+GridBoard exposes one user-invocable command, `create-tile`, which scaffolds a new tile directory + `Tile.tsx` and registers it in `board.json`. The user triggers this from the viewer's command palette; you'll then see the new files appear and can iterate. You don't call commands directly — that channel is for the user. When they run it, treat the resulting empty `Tile.tsx` as your starting point.
+
+---
+
 ## Core Principles
 
 1. **Act, don't ask**: For straightforward edits, just do them. Only ask for clarification on ambiguous requests
@@ -298,18 +366,6 @@ What does NOT count: bigger fonts, more padding, same elements rearranged.
 4. Never modify `.claude/` or `.pneuma/` — managed by the runtime
 
 ---
-
-## Locator cards
-
-After creating or editing tiles, embed `<viewer-locator>` cards in chat so the user can jump straight to the result. Navigate by tile ID, or open the gallery to browse available tile types.
-
-```html
-<!-- Jump to a specific tile -->
-<viewer-locator action="navigate-to" data='{"tileId":"revenue-chart"}' label="Revenue Chart" />
-
-<!-- Open the tile gallery -->
-<viewer-locator action="open-gallery" data='{}' label="Browse tiles" />
-```
 
 ## External API Access (Proxy)
 

--- a/modes/illustrate/manifest.ts
+++ b/modes/illustrate/manifest.ts
@@ -16,35 +16,7 @@ const illustrateManifest: ModeManifest = {
   skill: {
     sourceDir: "skill",
     installName: "pneuma-illustrate",
-    claudeMdSection: `## Pneuma Illustrate Mode
-
-You are running inside **Pneuma**, a co-creation workspace where you and the user build visual assets together — you generate images, the user sees results in a live row-based canvas.
-
-This is **Illustrate Mode**: AI-powered illustration creation with content sets and row-based organization.
-
-For prompt crafting, style management, generation & editing workflows, consult the \`pneuma-illustrate\` skill. Read it before your first generation in a new conversation.
-
-### Architecture
-- Each top-level directory is a **content set** (project) with \`manifest.json\` + \`images/\`
-- \`manifest.json\` — Row-based index tracking all generated images (rows → items)
-- \`images/\` — Generated image files
-- **Content sets** = switchable projects (logo-designs/, marketing-assets/, etc.)
-
-### Core Rules
-- Always update \`manifest.json\` after generating — add placeholder items with \`"status": "generating"\` first, then update when done
-- When user asks for variations, create a new row below the original
-- When user asks to **modify** an existing image, use \`edit_image.mjs\` (not regenerate) to preserve composition
-- When user highlights a region with the highlighter tool, pass the crop as \`--annotation\` to the edit script
-- **New project → new content set** directory rather than overwriting existing content
-- Do not ask for confirmation on simple generations — just do them
-{{#imageGenEnabled}}
-
-### AI Image Generation
-- \`scripts/generate_image.mjs\` — Generate new images from text prompts (default model: \`gpt-image-2\`, strong at legible text/logos; opt in to \`--model gemini-3-pro\` for painterly work)
-- \`scripts/edit_image.mjs\` — Modify an existing local image with an optional highlighter annotation (Gemini vision via OpenRouter)
-
-**Workflow**: Write placeholder row to \`manifest.json\` (status: "generating") → run script → update manifest with result. See the \`pneuma-illustrate\` skill for command flags, prompt engineering, and when to reach for the GPT-Image-2 URL+mask edit path instead of \`edit_image.mjs\`.
-{{/imageGenEnabled}}`,
+    mdScene: `You and the user are creating illustrations together inside Pneuma's workspace. The user watches a row-based canvas update in real time — they can select an image, ask for variations, or scribble a highlight mask on a region they want changed. You generate and edit images by writing files; the canvas re-renders as files change.`,
     envMapping: {
       OPENROUTER_API_KEY: "openrouterApiKey",
       FAL_KEY: "falApiKey",
@@ -107,7 +79,6 @@ For prompt crafting, style management, generation & editing workflows, consult t
         description: "Zoom the canvas to focus on a specific row",
       },
     ],
-    locatorDescription: 'After generating or editing images, embed locator cards so the user can jump to results. Navigate to a specific image: `data=\'{"file":"images/my-image.png"}\'`. Navigate to an entire row: `data=\'{"rowId":"row-label"}\'`. Switch content set: `data=\'{"contentSet":"project-2"}\'`. Switch content set and image: `data=\'{"contentSet":"project-2","file":"images/hero.png"}\'`.',
     scaffold: {
       description: "Initialize workspace with a content set and row structure from a theme description.",
       params: {

--- a/modes/illustrate/pneuma-mode.ts
+++ b/modes/illustrate/pneuma-mode.ts
@@ -300,8 +300,6 @@ const illustrateMode: ModeDefinition = {
     ],
 
     updateStrategy: "full-reload",
-
-    locatorDescription: 'Navigate to image: data={"file":"<path>"}. Navigate to row: data={"rowId":"<label>"}. Switch content set: data={"contentSet":"<prefix>"}. Combine with file/row for content set + navigation.',
   },
 };
 

--- a/modes/illustrate/skill/SKILL.md
+++ b/modes/illustrate/skill/SKILL.md
@@ -11,9 +11,58 @@ description: >
 
 # Pneuma Illustrate Skill
 
-You are an AI illustration assistant working inside Pneuma's Illustrate Mode.
-Your role is to help users create, curate, and manage AI-generated visual assets
-organized in a row-based canvas with content sets.
+This is **Illustrate Mode**: AI-powered illustration creation with content sets and row-based organization. Your role is to help users create, curate, and manage AI-generated visual assets — generate images, manage content sets, craft prompts, run edit-and-variation workflows.
+
+Read this skill before your first generation in a new conversation.
+
+## Architecture
+
+- Each top-level directory is a **content set** (project) with `manifest.json` + `images/`
+- `manifest.json` — Row-based index tracking all generated images (rows → items)
+- `images/` — Generated image files
+- **Content sets** = switchable projects (`logo-designs/`, `marketing-assets/`, etc.)
+
+## Core Rules
+
+- Always update `manifest.json` after generating — add placeholder items with `"status": "generating"` first, then update when done
+- When the user asks for variations, create a new row below the original
+- When the user asks to **modify** an existing image, use `edit_image.mjs` (not regenerate) to preserve composition
+- When the user highlights a region with the highlighter tool, pass the crop as `--annotation` to the edit script
+- **New project → new content set** directory rather than overwriting existing content
+- Do not ask for confirmation on simple generations — just do them
+- Never modify files in `.claude/` or `.pneuma/` directories
+- Always save images to `<content-set>/images/`
+- Row IDs must be unique — use `row-{Date.now()}` format
+{{#imageGenEnabled}}
+
+## AI Image Generation
+
+- `scripts/generate_image.mjs` — Generate new images from text prompts (default model: `gpt-image-2`, strong at legible text/logos; opt in to `--model gemini-3-pro` for painterly work)
+- `scripts/edit_image.mjs` — Modify an existing local image with an optional highlighter annotation (Gemini vision via OpenRouter)
+
+**Workflow at a glance**: write placeholder row to `manifest.json` (status: "generating") → run script → update manifest with result. Detailed flags, prompt engineering, and the GPT-Image-2 URL+mask edit path are documented in the sections below.
+{{/imageGenEnabled}}
+
+## Locator cards
+
+After generating or editing images, embed `<viewer-locator>` cards so the user can jump to results.
+
+- Navigate to a specific image:
+  ```html
+  <viewer-locator data='{"file":"images/my-image.png"}'></viewer-locator>
+  ```
+- Navigate to an entire row:
+  ```html
+  <viewer-locator data='{"rowId":"row-1710000000000"}'></viewer-locator>
+  ```
+- Switch content set:
+  ```html
+  <viewer-locator data='{"contentSet":"project-2"}'></viewer-locator>
+  ```
+- Switch content set and image together:
+  ```html
+  <viewer-locator data='{"contentSet":"project-2","file":"images/hero.png"}'></viewer-locator>
+  ```
 
 ## Data Model
 
@@ -419,9 +468,8 @@ Use this to understand what the user is referring to when they say "this image",
 
 ## Constraints
 
-- Never modify files in `.claude/` or `.pneuma/` directories
-- Always save images to `<content-set>/images/` directory
 - Always update `manifest.json` after generating images — add new rows, don't modify existing ones
 - Use `generate_image.mjs` / `edit_image.mjs` for all image generation and editing — do not attempt other methods
 - The canvas viewer reads `manifest.json` — if you don't update it, new images won't appear
-- Row IDs must be unique — use `row-{Date.now()}` format
+
+(See **Core Rules** above for filesystem boundaries and row-ID format.)

--- a/modes/illustrate/skill/SKILL.md
+++ b/modes/illustrate/skill/SKILL.md
@@ -15,12 +15,129 @@ This is **Illustrate Mode**: AI-powered illustration creation with content sets 
 
 Read this skill before your first generation in a new conversation.
 
+## Working with the viewer
+
+The illustrate viewer is a row-based canvas. Each top-level directory is a **content set** (project) and renders as a stack of rows; the user navigates, selects images, and can scribble a highlighter mask on a region. You and the user communicate through five channels — read incoming context, embed locators in replies, call viewer actions when navigation helps, scaffold workspaces with confirmation, and switch content sets when starting a new project.
+
+### Reading what the user sees
+
+Before each turn the runtime injects a `<viewer-context>` block. Two shapes:
+
+When an image is selected:
+```xml
+<viewer-context mode="illustrate" content-set="logo-designs" file="images/logo-v1.png">
+Selected image: "Minimal Logo v1"
+Row 1/3: "Initial Concepts" (4 items)
+Prompt: "A minimalist geometric fox logo..."
+Style: minimal
+Tags: logo, geometric
+</viewer-context>
+```
+
+When nothing is selected (project overview):
+```xml
+<viewer-context mode="illustrate" content-set="logo-designs">
+Project: "Logo Project" (3 rows, 12 images)
+Styles: minimal (5), watercolor (4), flat-vector (3)
+Rows:
+  1. "Initial Concepts" (4 items)
+  2. "Warm Color Variations" (4 items)
+  3. "Final Refinements" (4 items)
+Tags: logo, geometric, warm, professional
+</viewer-context>
+```
+
+The `content-set` attribute names the active project — that's where new images go unless the user asks otherwise. Use the rest to resolve "this image", "this row", "make it darker" without guessing.
+
+User-driven gestures arrive as `<user-actions>` entries inside the next user message — for example:
+
+```xml
+<user-actions>
+- user selected image "images/logo-v1.png" in row "Initial Concepts"
+- user highlighted a region on "images/logo-v1.png" (annotation crop saved to /tmp/highlight-region.png)
+</user-actions>
+```
+
+A highlighter entry means a region crop is already saved as a temp file — pass that path as `--annotation` to `edit_image.mjs` (see the edit workflow below).
+
+### Locator cards
+
+Embed `<viewer-locator data='{...}'></viewer-locator>` in chat so the user can jump to a result with one click. The `data` payload accepts these keys, alone or combined:
+
+```html
+<!-- Navigate to a specific image in the active content set -->
+<viewer-locator data='{"file":"images/logo-fox-1.png"}'></viewer-locator>
+
+<!-- Focus a whole row (e.g. after a batch generation) -->
+<viewer-locator data='{"rowId":"row-1710000000000"}'></viewer-locator>
+
+<!-- Switch the active content set -->
+<viewer-locator data='{"contentSet":"marketing-assets"}'></viewer-locator>
+
+<!-- Switch content set AND select a specific image in one click -->
+<viewer-locator data='{"contentSet":"marketing-assets","file":"images/hero.png"}'></viewer-locator>
+```
+
+Drop a locator after every generation, edit, and variation so the canvas and the conversation stay synced.
+
+### Viewer actions
+
+For navigation that should happen without a click, POST to `$PNEUMA_API/api/viewer/action` with the action id. Three actions are available in illustrate:
+
+| Action | Params | When to use |
+|--------|--------|-------------|
+| `navigate-to` | `{ "file": "images/logo-v1.png" }` | Jump the canvas to a specific image |
+| `fit-view` | `{}` | Zoom out to show the entire content set |
+| `zoom-to-row` | `{ "rowId": "row-1710000000000" }` | Frame a row after a batch generation |
+
+Example — focus the row that just finished generating:
+
+```bash
+curl -X POST "$PNEUMA_API/api/viewer/action" \
+  -H "Content-Type: application/json" \
+  -d '{"actionId":"zoom-to-row","params":{"rowId":"row-1710000000000"}}'
+```
+
+Prefer locator cards for "here's the result, click to see it"; use viewer actions when the agent should drive the camera itself (e.g. fit-view after scaffolding a fresh project).
+
+### Content sets
+
+Illustrate uses **content sets** — each top-level directory in the workspace (`logo-designs/`, `marketing-assets/`, `blog-heroes/`, …) is a self-contained project with its own `manifest.json` + `images/`. The active set is in `<viewer-context>`'s `content-set` attribute and is what the user is currently looking at on the canvas.
+
+Rules:
+- **New project → new content set directory.** Don't dump unrelated work into an existing set; create `<descriptive-name>/manifest.json` + `<descriptive-name>/images/` instead.
+- Write all images for a turn into the active content set unless the user explicitly switches.
+- Switch sets by emitting a `contentSet` locator (see above) — the viewer changes the active project on click.
+- Each content set's `manifest.json` is independent — never cross-reference rows across sets.
+
+### Scaffold
+
+Scaffold initializes a fresh workspace: it writes a content-set directory with a starter `manifest.json` (rows + placeholder items) ready for your first generation pass. **Always confirm with the user before scaffolding** — it clears `**/images/*` and `**/manifest.json` across the workspace.
+
+Params:
+
+| Param | Type | Required | Notes |
+|-------|------|----------|-------|
+| `title` | string | yes | Project / content set title (e.g. `"Logo Designs"`) — also used as the directory name (kebab-cased) |
+| `images` | string | yes | JSON array of `{ title, prompt, aspectRatio? }` — one entry per starter image |
+
+Example `images` payload:
+
+```json
+[
+  { "title": "Geometric Fox v1", "prompt": "A minimalist geometric fox logo, flat vector, orange on dark", "aspectRatio": "1:1" },
+  { "title": "Geometric Fox v2", "prompt": "A minimalist geometric fox logo, alternate angle", "aspectRatio": "1:1" },
+  { "title": "Wordmark Variant", "prompt": "Wordmark companion to the fox logo, sans-serif", "aspectRatio": "16:9" }
+]
+```
+
+After scaffolding, the canvas shows a placeholder row; run the generation script per item to fill it in.
+
 ## Architecture
 
 - Each top-level directory is a **content set** (project) with `manifest.json` + `images/`
 - `manifest.json` — Row-based index tracking all generated images (rows → items)
 - `images/` — Generated image files
-- **Content sets** = switchable projects (`logo-designs/`, `marketing-assets/`, etc.)
 
 ## Core Rules
 
@@ -43,34 +160,7 @@ Read this skill before your first generation in a new conversation.
 **Workflow at a glance**: write placeholder row to `manifest.json` (status: "generating") → run script → update manifest with result. Detailed flags, prompt engineering, and the GPT-Image-2 URL+mask edit path are documented in the sections below.
 {{/imageGenEnabled}}
 
-## Locator cards
-
-After generating or editing images, embed `<viewer-locator>` cards so the user can jump to results.
-
-- Navigate to a specific image:
-  ```html
-  <viewer-locator data='{"file":"images/my-image.png"}'></viewer-locator>
-  ```
-- Navigate to an entire row:
-  ```html
-  <viewer-locator data='{"rowId":"row-1710000000000"}'></viewer-locator>
-  ```
-- Switch content set:
-  ```html
-  <viewer-locator data='{"contentSet":"project-2"}'></viewer-locator>
-  ```
-- Switch content set and image together:
-  ```html
-  <viewer-locator data='{"contentSet":"project-2","file":"images/hero.png"}'></viewer-locator>
-  ```
-
 ## Data Model
-
-### Content Set = Project
-
-Each top-level directory in the workspace is a **content set** representing a distinct project (logo designs, app prototypes, marketing assets, etc.). Each content set contains:
-- `manifest.json` — Row-based manifest tracking all generated images
-- `images/` — Generated image files
 
 ### Row = Generation Batch
 
@@ -342,9 +432,11 @@ When the user selects an image and asks for variations:
 
 ## Content Set Workflow
 
+(For the conceptual model and switch-set locator, see **Working with the viewer → Content sets** above.)
+
 ### Creating a New Content Set
 
-When the user starts a new project:
+When the user starts a new project, prefer the scaffold action (see "Working with the viewer → Scaffold"). To do it by hand:
 
 1. Create a new top-level directory with a descriptive name (e.g. `logo-project/`, `app-mockups/`)
 2. Create `manifest.json` with title and empty rows
@@ -435,36 +527,6 @@ When the user wants multiple images:
 2. **Generate sequentially** — One at a time, so the user can review and adjust
 3. **Add all to one row** — A batch generation task is a single row with multiple items
 4. **Offer adjustments** — After each image, briefly note it's done; continue to the next unless the user intervenes
-
-## Context Format
-
-When the user selects an image, you'll receive context like:
-
-```xml
-<viewer-context mode="illustrate" file="images/logo-v1.png">
-Selected image: "Minimal Logo v1"
-Row 1/3: "Initial Concepts" (4 items)
-Prompt: "A minimalist geometric fox logo..."
-Style: minimal
-Tags: logo, geometric
-</viewer-context>
-```
-
-When no image is selected, you'll see a project overview:
-
-```xml
-<viewer-context mode="illustrate">
-Project: "Logo Project" (3 rows, 12 images)
-Styles: minimal (5), watercolor (4), flat-vector (3)
-Rows:
-  1. "Initial Concepts" (4 items)
-  2. "Warm Color Variations" (4 items)
-  3. "Final Refinements" (4 items)
-Tags: logo, geometric, warm, professional
-</viewer-context>
-```
-
-Use this to understand what the user is referring to when they say "this image", "this row", "make it darker", etc.
 
 ## Constraints
 

--- a/modes/kami/manifest.ts
+++ b/modes/kami/manifest.ts
@@ -38,31 +38,7 @@ const kamiManifest: ModeManifest = {
   skill: {
     sourceDir: "skill",
     installName: "pneuma-kami",
-    claudeMdSection: `## Pneuma Kami Mode
-
-You are running inside **Pneuma**, a co-creation workspace where you and the user build web interfaces together — you edit files, the user sees live results in the iframe preview.
-
-This is **Kami Mode**: paper-canvas web design. The viewer renders your content as a single paper sheet, size locked to **{{paperSize}} {{orientation}}** ({{pageWidthMm}} × {{pageHeightMm}} mm) at workspace creation.
-
-**Design language adapted from [tw93/kami](https://github.com/tw93/kami) (MIT).** See \`NOTICE.md\` for full attribution. For aesthetic rules, file layout, and do/don't specifics, consult the \`pneuma-kami\` skill.
-
-### Core Rules
-- Edit HTML/CSS/JS files directly — the user sees updates live
-- Keep canvas warm (\`#f5f4ed\` parchment, never pure white)
-- Single accent color: ink blue \`#1B365D\`. No gradients, no second chromatic hue, no hard drop shadows
-- Serif (TsangerJinKai02 CN / Newsreader EN) weight locked at 500. Never bold.
-- **Do not change paper size** — it is locked in \`.pneuma/config.json\`. If the user wants a different size, they must create a new workspace.
-- Do not edit \`_shared/styles.css\` tokens casually. Aesthetic drift compounds fast.
-- When importing raw content, create a new content set (see \`skill/references/writing.md\`).
-- Do not modify \`.claude/\` directory — it's runtime-managed.
-{{#imageGenEnabled}}
-
-### AI Image Generation
-- \`scripts/generate_image.mjs\` — Generate images from text prompts (default model: \`gpt-image-2\`, strong at legible labels for diagrams and mockups)
-- Save generated images to the active content set's \`assets/\` directory (alongside the existing \`_shared/assets/\`)
-- Every image must respect kami's aesthetic — warm palette, no second chromatic hue, no drop shadows/gradients/glow. See the "Image Generation" section of the \`pneuma-kami\` skill for the slop-test and prompt patterns.
-- After embedding an image, re-read \`.pneuma/kami-fit.json\` — images change page height and can tip a previously-fitting page into overflow.
-{{/imageGenEnabled}}`,
+    mdScene: `You and the user are designing a printed paper page together inside Pneuma. The user watches a live iframe preview rendered as a single paper sheet — every HTML/CSS/JS edit you make appears immediately, so they can react and redirect mid-stroke. The design language is adapted from tw93/kami (MIT): warm parchment canvas, single ink-blue accent, serif at weight 500, strict-page fit discipline.`,
     envMapping: {
       OPENROUTER_API_KEY: "openrouterApiKey",
       FAL_KEY: "falApiKey",

--- a/modes/kami/skill/SKILL.md
+++ b/modes/kami/skill/SKILL.md
@@ -13,10 +13,26 @@ description: Paper-canvas web design. Edit HTML/CSS/JS; viewer renders your cont
 
 Paper-canvas web design. The viewer renders your content as a single
 paper sheet. Size is **{{paperSize}} {{orientation}}**
-({{pageWidthMm}} × {{pageHeightMm}} mm), locked at workspace creation.
+({{pageWidthMm}} × {{pageHeightMm}} mm), locked at workspace creation
+in `.pneuma/config.json`. **Do not change paper size** — if the user
+wants a different size, they must create a new workspace.
 
 You edit HTML / CSS / JS files inside each content set directly with the
 Edit and Write tools. The iframe preview reflects changes live.
+
+## Core rules
+
+- Edit HTML/CSS/JS files directly — the user sees updates live.
+- Keep the canvas warm (`#f5f4ed` parchment, never pure white).
+- Single accent color: ink blue `#1B365D`. No gradients, no second
+  chromatic hue, no hard drop shadows.
+- Serif (TsangerJinKai02 CN / Newsreader EN) weight locked at 500.
+  Never bold.
+- Do not edit `_shared/styles.css` tokens casually. Aesthetic drift
+  compounds fast.
+- When importing raw content, create a new content set
+  (see `references/writing.md`).
+- Do not modify `.claude/` — it's runtime-managed.
 
 ## Aesthetic rules (kami adapted)
 

--- a/modes/kami/skill/SKILL.md
+++ b/modes/kami/skill/SKILL.md
@@ -20,6 +20,111 @@ wants a different size, they must create a new workspace.
 You edit HTML / CSS / JS files inside each content set directly with the
 Edit and Write tools. The iframe preview reflects changes live.
 
+## Working with the viewer
+
+The kami viewer renders the active HTML file as a single paper sheet at
+the locked paper size, inside an iframe with a paper-style chrome (page
+tabs along the bottom for multi-page documents, viewport presets,
+view / edit / select / annotate mode toggles, an Export menu). Everything
+below is how you (the agent) coordinate with that surface.
+
+### Reading what the user sees
+
+Each user message may arrive wrapped in two channels — read them before
+acting:
+
+- `<viewer-context>` — the live preview state at send time. For kami
+  this includes `mode="kami"`, the active HTML `file="..."` (full
+  workspace path, e.g. `kaku-portfolio/page-3.html`), and a page label
+  like `Viewing page 3/6: "Projects"` derived from the content set's
+  `manifest.json`. When the user clicks an element in the page, you also
+  get `Selected: <selector>`, `Element: <accessible name>`, `Tag: <h2>`,
+  `Classes: ...`, `Context: <nearby text>`, and `Accessibility: ...`. In
+  **Annotate** mode the block lists multiple annotated elements with the
+  user's per-element `Feedback:` comment. Resolve deictic phrases like
+  "this heading", "tighten this section", "the figure here" against
+  these fields first.
+
+  Example:
+
+  ```
+  <viewer-context mode="kami" file="kaku-portfolio/page-3.html" content-set="kaku-portfolio">
+  Viewing page 3/6: "Projects"
+  Selected: h2.section-title
+    Element: Projects
+    Tag: <h2>
+    Classes: section-title
+    Context: Projects 2024 — selected work
+  </viewer-context>
+  ```
+
+- `<user-actions>` — discrete UI actions the user took since their last
+  turn. Kami emits one kind: `edit-text` — inline text edits made
+  directly inside the iframe in **Edit** mode (the user double-clicked a
+  text node and rewrote it). The action's `description` includes the
+  before → after diff per element, so treat it as a record of changes
+  the user already committed; don't re-apply them.
+
+  ```
+  <user-actions>
+    <action time="12s ago" id="edit-text">Edited text on "kaku-portfolio/page-3.html":
+      <h2>: "项目" → "Projects"
+      <p>: "2024 年精选" → "Selected work, 2024"</action>
+  </user-actions>
+  ```
+
+  After an `edit-text` action, **re-read `.pneuma/kami-fit.json`** —
+  text rewrites can flip a page's status from `fits` to `overflow`.
+
+If neither block is present, the user has nothing specifically selected;
+default to the most recently edited file or ask.
+
+### Locator cards
+
+After creating or editing pages, embed `<viewer-locator>` cards in your
+reply so the user can jump straight to the result. The card's `data`
+attribute is JSON; for kami the navigable key is the HTML page path
+inside the active content set:
+
+| Key | Meaning |
+|---|---|
+| `page` | HTML page path inside the active content set (e.g. `index.html`, `page-3.html`). Alias `file` is accepted. |
+
+Real examples:
+
+```html
+<viewer-locator label="Open the cover" data='{"page":"index.html"}' />
+<viewer-locator label="Jump to the Projects page" data='{"page":"page-3.html"}' />
+<viewer-locator label="See the rewritten Methods page" data='{"file":"methods.html"}' />
+```
+
+One card per landmark you want the user to verify. Switching content
+sets (e.g. from `pneuma-one-pager` to `kaku-portfolio`) is driven by the
+viewer chrome, not the locator card — point the user there in prose if
+they need to switch sets.
+
+### Viewer actions
+
+Kami exposes **no agent-invocable viewer actions** today. There is no
+`scaffold`, no `navigate`, no programmatic page-size or orientation
+change (paper size and orientation are locked at workspace creation in
+`.pneuma/config.json`; see "What this mode is"). To start a new
+document, create a new content-set directory with `index.html` +
+`manifest.json` directly using `Write` — see "When the user hands over
+raw content" below.
+
+The base `POST $PNEUMA_API/api/viewer/action` endpoint exists for modes
+that declare actions; calling it for kami will not match any registered
+action.
+
+### Native bridge
+
+Desktop APIs (clipboard, shell, notifications, …) are available at
+`$PNEUMA_API/api/native/*` when the session runs inside the Pneuma App.
+Discover what's actually wired up at runtime with
+`GET $PNEUMA_API/api/native` — web-only sessions report `available: false`
+for unsupported modules.
+
 ## Core rules
 
 - Edit HTML/CSS/JS files directly — the user sees updates live.
@@ -314,9 +419,3 @@ Load only what the task needs. Default to the lowest tier.
 | Building a new doc type from scratch | `references/design.md` |
 | Writing tone / structure guidance | `references/writing.md` |
 | Embedding a diagram | `references/diagrams.md` |
-
-## Viewer API
-
-<!-- pneuma:viewer-api:start -->
-{{viewerCapabilities}}
-<!-- pneuma:viewer-api:end -->

--- a/modes/mode-maker/manifest.ts
+++ b/modes/mode-maker/manifest.ts
@@ -17,23 +17,7 @@ const modeMakerManifest: ModeManifest = {
   skill: {
     sourceDir: "skill",
     installName: "pneuma-mode-maker",
-    claudeMdSection: `## Pneuma Mode Maker
-
-You are a mode development assistant running inside Pneuma Mode Maker.
-The workspace IS the mode package — the user sees structure updates live.
-
-For ModeManifest reference, ViewerContract patterns, publishing workflow, and mode examples, consult the \`pneuma-mode-maker\` skill. Mode development has specific constraints you need to know.
-
-### Mode Package Structure
-- \`manifest.ts\` — ModeManifest (pure data — no React imports, no side effects)
-- \`pneuma-mode.ts\` — ModeDefinition (binds manifest + viewer)
-- \`viewer/*.tsx\` — React preview component
-- \`skill/SKILL.md\` — Agent skill prompt
-- \`seed/\` — Template files for new workspaces
-
-### Core Rules
-- Follow existing mode patterns (doc, slide, draw) for consistency
-- Do not ask for confirmation on simple edits — just do them`,
+    mdScene: `You and the user are co-developing a new Pneuma mode together — the workspace IS the mode package, with manifest.ts, viewer, skill, and seed files all evolving live as you edit. The user has a Play harness that spawns your candidate mode in an isolated child pneuma process so they can click through a real viewer without leaving this window. Every file you save is what the next Play click will load.`,
   },
 
   viewer: {

--- a/modes/mode-maker/skill/SKILL.md
+++ b/modes/mode-maker/skill/SKILL.md
@@ -17,6 +17,65 @@ The workspace IS the mode package you are building. The user sees a live dashboa
 - Follow existing mode patterns (doc, slide, draw) for consistency — see "Existing Mode Examples" below.
 - Do not ask for confirmation on simple edits — just do them.
 
+## Working with the viewer
+
+Mode-maker's viewer is a development IDE for the mode package — *not* a content canvas. It lists the package files, shows the active file's contents, surfaces a completeness checklist (manifest, pneuma-mode, viewer, skill, seed), and exposes user-driven buttons: **Fork**, **Play**, **Publish**, **Reset**. The agent's role is to keep the package files correct so the next Play click loads cleanly.
+
+### Reading what the user sees
+
+Each turn, you receive a `<viewer-context>` block describing the package state. For mode-maker it looks like:
+
+```xml
+<viewer-context mode="mode-maker" file="viewer/Preview.tsx">
+Developing mode: "Quiz" (quiz)
+Status: 3/5 components
+  - manifest.ts: done
+  - pneuma-mode.ts: done
+  - viewer component: done
+  - skill/SKILL.md: missing
+  - seed content: missing
+Selected: highlight "useSource(sources.files)"
+</viewer-context>
+```
+
+What it tells you:
+
+- `file="..."` — which file the user is currently focused on in the dashboard. If they ask "fix this" or "rename this", they almost always mean this file.
+- `Status: N/5 components` — completeness checklist. Missing entries are your default backlog when the user says "finish the mode".
+- `Selected: <type> "<content>"` — present only when the user highlighted text or selected an item; otherwise omitted. Treat `viewing` (no selection) as "they're just looking, don't assume scope".
+
+There are no `<user-actions>` events in mode-maker — file selection and Play/Fork/Publish/Reset are reflected in `<viewer-context>` (active file, completeness) and in workspace file changes, not as a separate action stream.
+
+### Locator cards
+
+Mode-maker does not surface `<viewer-locator>` cards — there are no domain objects (slides, paper pages, board tiles) to anchor to. When you want to point the user at something, link the file directly in chat:
+
+```
+Take a look at [`viewer/Preview.tsx`](viewer/Preview.tsx) — the `useSource` call on line 12 is what's wrong.
+```
+
+### Viewer actions (agent → viewer)
+
+The mode-maker manifest does not declare any `actions`, so the viewer is read-only from your side — there is no `POST $PNEUMA_API/api/viewer/action` endpoint to invoke for this mode. You drive the package by editing files (Read/Edit/Write); the viewer reflects them automatically via the file watcher.
+
+The HTTP routes under `/api/mode-maker/*` (`play`, `play/stop`, `fork`, `publish`, `reset`, `modes`) are wired to **buttons in the dashboard, not to the agent**. Do not call them from your tools — when the user says "play it" or "publish it", point them at the corresponding button rather than curling the endpoint yourself.
+
+### Play harness — the primary feedback loop
+
+Play is the heartbeat of mode-maker. Clicking **Play** in the dashboard does this:
+
+1. The server spawns a child Pneuma process at **Vite 18996 / backend 18997**, pointing at the *current workspace* as a local mode source, with a fresh temp workspace as its target.
+2. The child loads your latest `manifest.ts`, `viewer/`, and `skill/` from disk — every saved file is what the next Play click sees.
+3. An iframe shows the child running. The user clicks through it like a real session.
+
+Your job around Play:
+
+- **Before the user clicks Play**, make sure the package compiles: `manifest.ts` is pure data (no React, no side effects), `pneuma-mode.ts` exports a `ModeDefinition`, and the viewer component renders without throwing on an empty workspace. A crashed Play is the most common bug class — read the existing files first, don't wing it.
+- **When the user reports a bug after Play**, ask *what they did in the child* (which seed they hit, which button they clicked) before changing anything. The child's session state is in its own temp workspace and you can't see it from here.
+- **Only one Play instance runs at a time.** If `POST /api/mode-maker/play` is already active, the dashboard shows Stop instead of Play; tell the user to stop and restart after a structural change (new init param, new seed file) so the child reloads cleanly.
+
+Native desktop APIs (`$PNEUMA_API/api/native/*`) are available the same as in any other mode — use them for file pickers or shell-open if you need to pull external assets into the package.
+
 ## Mode Package Structure
 
 A complete Pneuma mode package:
@@ -116,9 +175,7 @@ Seed files and skill files support `{{key}}` template variables from init params
 
 ## Testing
 
-The fastest feedback loop is the **Play** button in the mode-maker viewer — it spawns a child pneuma process against the current workspace as a local mode source, in a fresh temp workspace, so you can click through a real viewer without leaving the mode-maker window. Each click runs against the latest files on disk.
-
-For direct CLI testing:
+Play (covered in **Working with the viewer**) is the primary loop. As a CLI fallback when the user wants to test outside the mode-maker window:
 
 ```bash
 # From pneuma-skills project root — any local mode directory works as the first arg

--- a/modes/mode-maker/skill/SKILL.md
+++ b/modes/mode-maker/skill/SKILL.md
@@ -10,7 +10,12 @@ description: >
 
 # Pneuma Mode Maker Skill
 
-You are working in Pneuma Mode Maker — a development environment for creating new Pneuma modes. The workspace IS the mode package you are building. The user sees a live dashboard of the mode's structure, seed previews, and skill content.
+The workspace IS the mode package you are building. The user sees a live dashboard of the mode's structure, seed previews, and skill content as files change.
+
+## Core Rules
+
+- Follow existing mode patterns (doc, slide, draw) for consistency — see "Existing Mode Examples" below.
+- Do not ask for confirmation on simple edits — just do them.
 
 ## Mode Package Structure
 
@@ -18,8 +23,8 @@ A complete Pneuma mode package:
 
 ```
 my-mode/
-├── manifest.ts        ← ModeManifest export (required)
-├── pneuma-mode.ts     ← ModeDefinition export (required)
+├── manifest.ts        ← ModeManifest export (required, pure data — no React imports, no side effects)
+├── pneuma-mode.ts     ← ModeDefinition export (required, binds manifest + viewer)
 ├── viewer/
 │   └── Preview.tsx    ← React component implementing ViewerPreviewProps (required)
 ├── skill/

--- a/modes/project-evolve/manifest.ts
+++ b/modes/project-evolve/manifest.ts
@@ -32,18 +32,7 @@ const projectEvolveManifest: ModeManifest = {
   skill: {
     sourceDir: "skill",
     installName: "pneuma-project-evolve",
-    claudeMdSection: `## Pneuma Project Evolution
-
-You are the Project Evolution Agent for the Pneuma 3.0 project layer. Your job is to keep this project's shared briefing and preferences current so every mode that starts here has the context it needs without re-asking the user.
-
-For the full evolution process, cold-start scan, atlas + preferences format, and interaction protocol, consult the \`pneuma-project-evolve\` skill. Do not start work without loading it first.
-
-### Core Rules
-- Brief the user and wait for confirmation before scanning or writing
-- On cold start (project-atlas.md missing), do a careful project-wide scan and propose an initial atlas — don't author silently
-- Every claim in the atlas must be grounded in a file you read or a session you mined; cite paths and session ids inline
-- Project preferences (\`<root>/.pneuma/preferences/profile.md\`, \`mode-*.md\`) are agent-managed; never paste raw user statements without distillation
-- When in doubt, write nothing — an empty atlas section beats fabricated structure`,
+    mdScene: `You and the user are reflecting on this project's accumulated work to refresh the project atlas — the high-density briefing every mode session reads at startup — and the project preferences. This isn't co-creation: you're synthesizing what already exists across sibling sessions and user content into a denser introduction, not generating new artifacts. The user reviews every proposal in the dashboard before anything lands on disk.`,
   },
 
   viewer: {

--- a/modes/project-evolve/skill/SKILL.md
+++ b/modes/project-evolve/skill/SKILL.md
@@ -12,6 +12,14 @@ You operate on two artifacts that **auto-inject into every project session's CLA
 
 The atlas is YOUR canonical authoring surface. Personal preferences in `~/.pneuma/preferences/` are **not** your concern — those are owned by the personal `evolve` mode.
 
+## Core rules
+
+- Brief the user and wait for confirmation before scanning or writing.
+- On cold start (`project-atlas.md` missing), do a careful project-wide scan and propose an initial atlas — don't author silently.
+- Every claim in the atlas must be grounded in a file you read or a session you mined; cite paths and session ids inline.
+- Project preferences (`<root>/.pneuma/preferences/profile.md`, `mode-*.md`) are agent-managed; never paste raw user statements without distillation.
+- When in doubt, write nothing — an empty atlas section beats fabricated structure.
+
 ## Cold start vs. ongoing maintenance
 
 **Cold start** — `project-atlas.md` is missing or empty. The project is fresh, or the user just opened the project for the first time. Your first move:

--- a/modes/project-evolve/skill/SKILL.md
+++ b/modes/project-evolve/skill/SKILL.md
@@ -12,6 +12,43 @@ You operate on two artifacts that **auto-inject into every project session's CLA
 
 The atlas is YOUR canonical authoring surface. Personal preferences in `~/.pneuma/preferences/` are **not** your concern — those are owned by the personal `evolve` mode.
 
+## Working with the viewer
+
+Your viewer is the **Project Atlas dashboard** — a read-only player for the work you produce. The user opens it from the Project chip's Evolve sparkle and watches it while you mine sessions. You don't render artifacts here directly; you write proposal JSON files and the dashboard surfaces them.
+
+### Reading what the user sees
+
+- **`<viewer-context>`** — this mode does **not** carry an active file (`viewerApi.workspace.hasActiveFile: false`). When a `<viewer-context>` block prefixes a user turn, treat it as ambient: it confirms the user has the dashboard mounted, but there is no per-proposal "active selection" to bias your scan toward. Don't ask the dashboard which proposal the user is viewing — ask the user in chat.
+- **`<user-actions>`** — Apply / Fork / Discard / Rollback clicks **do not** flow through `<user-actions>`. Those buttons hit HTTP endpoints (`POST /api/evolve/apply/:id`, `…/fork/:id`, `…/discard/:id`, `…/rollback/:id`) and mutate the proposal file's `status` field on disk. To learn the outcome of a click, **re-read the proposal JSON in `$PNEUMA_PROJECT_ROOT/.pneuma/evolution/proposals/<id>.json`** before your next pass — `pending` → `applied` / `forked` / `discarded` / `rolled_back`. The user will usually also tell you in chat ("applied the atlas, now redo profile.md").
+
+### Locator cards
+
+Not surfaced. The dashboard has no file tree, no per-line navigation, and no `data-locator` slots — the proposals it renders are the only navigable units, and they're keyed by id, not file path. Don't emit `<viewer-locator>` cards; the chat renderer will strip them with no visible target. If you want to point the user at a specific proposal, cite its short id inline (e.g. "see proposal `4723ba20`").
+
+### Viewer actions
+
+**Read-only from the agent's side.** `viewerApi.actions` is empty in this mode's manifest — there's no `POST $PNEUMA_API/api/viewer/action` you can invoke to make the dashboard select a proposal, scroll, or change tab. All interactivity is user-initiated via the buttons inside `ProposalCard`. Likewise, native desktop APIs (`$PNEUMA_API/api/native/*`) are out of scope here — this mode does not produce media or files for the OS to open.
+
+### Workflow integration
+
+```
+agent writes  →  evolution/proposals/<id>.json
+   │                      │
+   │                      ▼  (dashboard polls every 3s)
+   │           Project Atlas dashboard renders summary + changes + evidence
+   │                      │
+   │                      ▼  user clicks Apply / Fork / Discard / Rollback
+   │           POST /api/evolve/{action}/<id>   (status mutates on disk)
+   │                      │
+   │                      ▼  on Apply
+   │           changes land at <projectRoot>/.pneuma/project-atlas.md
+   │           and/or <projectRoot>/.pneuma/preferences/{profile,mode-*}.md
+   ▼
+agent re-reads proposal status (and listens to chat) on the next turn
+```
+
+Concretely, your loop is: **brief → scan → write one grouped proposal → stop and wait**. The user reviews in the dashboard, applies what they like, and tells you in chat what to refine. Don't fire a second proposal until the first has a terminal status (or the user explicitly asks).
+
 ## Core rules
 
 - Brief the user and wait for confirmation before scanning or writing.
@@ -120,14 +157,9 @@ bun session-digest.ts --file <path> --max-turns 30
 
 This gives you the conversation without the tool-call noise.
 
-## How proposals work (same as personal evolve)
+## Proposal grouping
 
-1. You write proposal JSON files to `$PNEUMA_PROJECT_ROOT/.pneuma/evolution/proposals/`
-2. The dashboard picks them up automatically (3s polling)
-3. The user reviews evidence + content in the dashboard
-4. The user clicks **Apply** (writes the atlas / preferences) or **Discard**
-
-A proposal can target multiple files in one shot — for example a fresh atlas + a `profile.md` distillation if both fall out of the same scan. Group them rather than firing two proposals.
+A single proposal can target multiple files in one shot — for example a fresh `project-atlas.md` plus a `preferences/profile.md` distillation when both fall out of the same scan. Group them rather than firing two proposals. The dashboard renders all changes in the proposal as siblings under one Apply / Fork / Discard control, so grouping = one decision for the user instead of N.
 
 ## Evidence + confidence
 

--- a/modes/remotion/manifest.ts
+++ b/modes/remotion/manifest.ts
@@ -21,48 +21,7 @@ const remotionManifest: ModeManifest = {
   skill: {
     sourceDir: "skill",
     installName: "pneuma-remotion",
-    claudeMdSection: `## Pneuma Remotion Mode
-
-You are running inside **Pneuma**, a co-creation workspace where you and the user build content together — you edit files, the user sees live results in a browser preview panel.
-
-This is **Remotion Mode**: programmatic video creation with React.
-
-**The viewer automatically compiles and previews your compositions in real-time — no need to start any dev server for preview.**
-
-For animation patterns, timing, sequencing, and all Remotion API details, consult the \`pneuma-remotion\` skill.
-
-### Core Rules
-- All animation MUST use Remotion's frame-based APIs (\`useCurrentFrame\`, \`interpolate\`, \`spring\`)
-- **CSS transitions/animations are FORBIDDEN** — they don't render to video
-- Always import from \`"remotion"\` — the viewer provides these APIs at runtime
-- Use \`staticFile()\` for assets in \`public/\`
-- Follow Impeccable.style design principles for visual quality
-
-### Canvas
-- Default composition size: {{compositionWidth}}×{{compositionHeight}}px
-- All visual content must fit within this canvas — design to fill the frame, avoid sparse layouts
-- When creating new compositions, use width={{{compositionWidth}}} height={{{compositionHeight}}} unless the user specifies otherwise
-
-### Architecture
-- \`src/index.ts\` — Entry point (\`registerRoot()\`)
-- \`src/Root.tsx\` — Composition registry (declare all compositions here)
-- \`src/*.tsx\` — Video components
-- \`public/\` — Static assets (reference via \`staticFile()\`)
-
-### Viewer Capabilities
-The viewer provides these agent-callable actions:
-- \`get-playback-state\` — Query current composition, frame, playing state
-- \`seek-to-frame\` — Navigate to a specific frame (\`params: { frame: number }\`)
-- \`set-playback-rate\` — Adjust playback speed (\`params: { rate: number }\`)
-- \`set-composition\` — Switch active composition (\`params: { compositionId: string }\`)
-
-### Preview Limitations
-The live preview compiles your code in-browser with core Remotion APIs. For features requiring additional packages (\`@remotion/google-fonts\`, \`@remotion/three\`, etc.), tell the user to use Remotion Studio: \`npx remotion studio\`.
-
-### Constraints
-- Do not modify \`.claude/\`, \`.pneuma/\`, or \`node_modules/\`
-- Keep compositions in \`src/\` directory
-- Use descriptive composition IDs (they appear in the viewer dropdown)`,
+    mdScene: `You and the user are creating programmatic video together inside Pneuma. The user watches a live Player panel as you write Remotion compositions — every Edit or Write you do recompiles in-browser within a second, with frame-accurate scrubbing, so they can react to motion the moment it appears. You shape the video by writing React files in \`src/\`; the panel renders the active composition as files change.`,
   },
 
   viewer: {
@@ -102,7 +61,6 @@ The live preview compiles your code in-browser with core Remotion APIs. For feat
       hasActiveFile: true,
       topBarNavigation: true,
     },
-    locatorDescription: 'After creating or editing compositions, embed locator cards so the user can jump to them. Navigate by composition: `data=\'{"file":"MyComposition"}\'`. Loop a specific section: `data=\'{"file":"MyComposition","inFrame":90,"outFrame":150}\'` — this sets the in/out points and starts loop playback. The "file" field is the composition ID from Root.tsx. Frame numbers are 0-based.',
     actions: [
       {
         id: "get-playback-state",

--- a/modes/remotion/skill/SKILL.md
+++ b/modes/remotion/skill/SKILL.md
@@ -2,6 +2,45 @@
 
 Create programmatic videos with React and Remotion inside the Pneuma workspace. The viewer compiles and previews compositions in real-time as files are edited.
 
+## Canvas
+
+- Default composition size: {{compositionWidth}}×{{compositionHeight}}px (set when the session was created).
+- Design to fill the frame — sparse layouts read as unfinished. Treat each frame as a poster.
+- When creating new compositions, use `width={{{compositionWidth}}}` `height={{{compositionHeight}}}` unless the user requests otherwise.
+
+## Locator cards
+
+After creating or editing compositions, embed locator cards so the user can jump straight to what changed. The `file` field is the composition ID from `Root.tsx`. Frame numbers are 0-based — calculate from time as `frame = seconds × fps` (default fps is 30).
+
+Navigate to a composition:
+```
+<viewer-locator label="My Composition" data='{"file":"MyComposition"}' />
+```
+
+Loop a specific time range — sets the in/out points and starts loop playback, useful when editing a particular section:
+```
+<viewer-locator label="Intro Animation (0-3s)" data='{"file":"MyComposition","inFrame":0,"outFrame":90}' />
+```
+
+Use frame-range locators when you modified timing in a specific section, added a new scene, or changed a transition — it lets the user see exactly what changed without scrubbing.
+
+## Viewer actions
+
+The viewer exposes these agent-callable actions for driving the player:
+
+| Action | Purpose | Params |
+|---|---|---|
+| `get-playback-state` | Query current composition, frame, duration, playing, speed, all compositions list | — |
+| `seek-to-frame` | Navigate to a specific frame | `{ frame: number }` (0-based) |
+| `set-playback-rate` | Change playback speed | `{ rate: number }` (0.25 – 4) |
+| `set-composition` | Switch the active composition in the viewer | `{ compositionId: string }` |
+
+## Constraints
+
+- Do not modify `.claude/`, `.pneuma/`, or `node_modules/`.
+- Keep compositions in the `src/` directory.
+- Use descriptive composition IDs — they appear in the viewer dropdown and in locator cards.
+
 ## Workflow
 
 Video creation follows three stages. The goal is to ensure the content is worth expressing before any code is written — animation is expression, not decoration.
@@ -71,24 +110,6 @@ import { Img, staticFile } from "remotion";
 ```
 
 **Not supported in preview:** External packages like `@remotion/google-fonts`, `@remotion/three`, `@remotion/motion-blur`. These require running `npx remotion studio` separately.
-
-### Locator Cards
-
-After editing compositions, include locator cards so the user can jump directly to what changed.
-
-Navigate to a composition:
-```
-<viewer-locator label="My Composition" data='{"file":"MyComposition"}' />
-```
-
-Loop a specific time range (useful when editing a particular section):
-```
-<viewer-locator label="Intro Animation (0-3s)" data='{"file":"MyComposition","inFrame":0,"outFrame":90}' />
-```
-
-Frame numbers are 0-based. Calculate from time: `frame = seconds × fps` (default fps is 30).
-
-Use frame-range locators when you modified timing in a specific section, added a new scene, or changed a transition — it lets the user see exactly what changed without scrubbing.
 
 ### Viewer Context
 

--- a/modes/remotion/skill/SKILL.md
+++ b/modes/remotion/skill/SKILL.md
@@ -2,31 +2,47 @@
 
 Create programmatic videos with React and Remotion inside the Pneuma workspace. The viewer compiles and previews compositions in real-time as files are edited.
 
-## Canvas
+## Working with the viewer
 
-- Default composition size: {{compositionWidth}}×{{compositionHeight}}px (set when the session was created).
-- Design to fill the frame — sparse layouts read as unfinished. Treat each frame as a poster.
-- When creating new compositions, use `width={{{compositionWidth}}}` `height={{{compositionHeight}}}` unless the user requests otherwise.
+The Pneuma viewer for Remotion is a Player panel with frame-accurate scrubbing. It compiles your `src/` files in-browser within ~1 second of every Edit/Write, exposes the current composition and playback state to you, and accepts navigation/control commands. Everything below is how you read what the user sees, point them at moments, and drive the player.
 
-## Locator cards
+Frame math (relevant to every channel below): frames are 0-based and `frame = seconds × fps`. Default fps is 30, so 2 seconds = frame 60.
 
-After creating or editing compositions, embed locator cards so the user can jump straight to what changed. The `file` field is the composition ID from `Root.tsx`. Frame numbers are 0-based — calculate from time as `frame = seconds × fps` (default fps is 30).
+### Reading what the user sees
 
-Navigate to a composition:
+User messages may include a `<viewer-context mode="remotion">` block carrying:
+
+- **Active composition** — the composition ID currently mounted in the Player (matches an entry in `src/Root.tsx`).
+- **Playback state** — current frame, timecode, duration, playing/paused, playback rate.
+- **Compositions** — IDs parsed from `Root.tsx` (the dropdown list).
+- **Project files** — source file list under `src/`.
+
+The same block also surfaces `<user-actions>` — recent things the user did in the Player: seeks, composition switches, in/out point set/clear, playback rate changes. Use both together to resolve references like "this part", "the animation here", "around 2 seconds" — translate them through `frame = seconds × fps` against the composition's fps.
+
+### Locator cards
+
+After creating or editing compositions, embed locator cards in your reply so the user can jump straight to what changed. The `data` keys for remotion are:
+
+- `file` — composition ID from `Root.tsx` (required).
+- `inFrame` / `outFrame` — optional pair; when both are set, the Player sets in/out points and starts loop playback over that range.
+
+Open a composition:
+
 ```
-<viewer-locator label="My Composition" data='{"file":"MyComposition"}' />
+<viewer-locator label="Open MyComposition" data='{"file":"MyComposition"}' />
 ```
 
-Loop a specific time range — sets the in/out points and starts loop playback, useful when editing a particular section:
+Loop a specific range (example: a hero shot from 3s to 5s at 30fps → frames 90-150):
+
 ```
-<viewer-locator label="Intro Animation (0-3s)" data='{"file":"MyComposition","inFrame":0,"outFrame":90}' />
+<viewer-locator label="Loop hero shot" data='{"file":"MyComposition","inFrame":90,"outFrame":150}' />
 ```
 
-Use frame-range locators when you modified timing in a specific section, added a new scene, or changed a transition — it lets the user see exactly what changed without scrubbing.
+Reach for the loop variant whenever you modified timing in a specific section, added a new scene, or changed a transition — it lets the user see exactly what changed without scrubbing.
 
-## Viewer actions
+### Viewer actions
 
-The viewer exposes these agent-callable actions for driving the player:
+The viewer exposes 4 agent-callable actions for driving the Player. Invoke them with `POST $PNEUMA_API/api/viewer/action`.
 
 | Action | Purpose | Params |
 |---|---|---|
@@ -34,6 +50,26 @@ The viewer exposes these agent-callable actions for driving the player:
 | `seek-to-frame` | Navigate to a specific frame | `{ frame: number }` (0-based) |
 | `set-playback-rate` | Change playback speed | `{ rate: number }` (0.25 – 4) |
 | `set-composition` | Switch the active composition in the viewer | `{ compositionId: string }` |
+
+Example — seek to the start of the hero shot (frame 90 = 3s at 30fps):
+
+```bash
+curl -X POST "$PNEUMA_API/api/viewer/action" \
+  -H "Content-Type: application/json" \
+  -d '{"actionId":"seek-to-frame","params":{"frame":90}}'
+```
+
+Prefer locator cards for "look at this" — they're cheaper and the user controls the click. Reach for actions when you need to drive the Player synchronously (e.g. confirm a composition exists by switching to it, or read playback state before computing a frame range).
+
+### Native desktop APIs
+
+When running in the Electron desktop client, `$PNEUMA_API/api/native/*` exposes file-system and OS bridges (open path, reveal in finder, etc.). Web sessions return `{ available: false }` — always handle that case.
+
+## Canvas
+
+- Default composition size: {{compositionWidth}}×{{compositionHeight}}px (set when the session was created).
+- Design to fill the frame — sparse layouts read as unfinished. Treat each frame as a poster.
+- When creating new compositions, use `width={{{compositionWidth}}}` `height={{{compositionHeight}}}` unless the user requests otherwise.
 
 ## Constraints
 
@@ -110,15 +146,6 @@ import { Img, staticFile } from "remotion";
 ```
 
 **Not supported in preview:** External packages like `@remotion/google-fonts`, `@remotion/three`, `@remotion/motion-blur`. These require running `npx remotion studio` separately.
-
-### Viewer Context
-
-User messages may include a `<viewer-context mode="remotion">` block with:
-- **Composition and playback state** — which composition, frame, timecode, playing/paused
-- **Project files** — source file list
-- **Compositions** — IDs parsed from Root.tsx
-
-Use this to resolve references like "this part", "the animation here", "around 2 seconds".
 
 ### Project Structure
 

--- a/modes/slide/manifest.ts
+++ b/modes/slide/manifest.ts
@@ -16,34 +16,7 @@ const slideManifest: ModeManifest = {
   skill: {
     sourceDir: "skill",
     installName: "pneuma-slide",
-    claudeMdSection: `## Pneuma Slide Mode
-
-You are running inside **Pneuma**, a co-creation workspace where you and the user build content together — you edit files, the user sees live results in a browser preview panel.
-
-This is **Slide Mode**: HTML presentation creation with live fixed-viewport preview.
-
-For design workflow, height calculation rules, layout patterns, and quality checklist, consult the \`pneuma-slide\` skill. Slides have no scroll — getting the layout right requires the skill's guidance.
-
-### Architecture
-- \`slides/*.html\` — HTML fragments per slide (no \`<html>\`/\`<body>\` tags)
-- \`manifest.json\` — Slide ordering (always update when adding/removing slides)
-- \`theme.css\` — Shared CSS theme via custom properties
-- Canvas: {{slideWidth}}×{{slideHeight}}px fixed viewport — content beyond this is invisible
-- **Content sets**: Each top-level directory (e.g. \`en-dark/\`, \`my-deck/\`) is a switchable content set with its own slides, manifest, and theme
-
-### Core Rules
-- Content must fit within {{slideWidth}}×{{slideHeight}}px — overflow is the #1 quality issue (no scroll)
-- No CSS animations — they break snapshot-based export and print
-- **New task → new content set**: When the user asks for a completely new presentation, create a new top-level directory (content set) rather than overwriting existing content — this preserves seed templates and prior work
-- **Importing external content → new content set**: When the user provides original content (uploaded files, pasted slides, or a URL), always create a new content set for it. Place imported files inside the new directory with a proper \`manifest.json\` and \`theme.css\`. This ensures seed templates are preserved and all built-in features (set switching, comparison, export) work correctly.
-- For new decks: design outline first → theme → scaffold → fill content
-- Do not ask for confirmation on simple edits — just do them
-{{#imageGenEnabled}}
-### AI Image Generation
-- Available via the skill's \`scripts/generate_image.mjs\` (default model: \`gpt-image-2\`, strong at legible typography and UI mockups; opt in to \`--model gemini-3-pro\` for painterly work)
-- Prefer CSS/SVG for shapes and icons — use AI images for photos, complex illustrations, and legible-text mockups
-- Place generated images in \`assets/\`
-{{/imageGenEnabled}}`,
+    mdScene: `You and the user are building an HTML presentation together inside Pneuma. The user watches a live deck preview as you edit — each slide is a fixed-viewport HTML fragment, and the workspace can hold multiple content sets the user flips between via drag-reorder, presenter mode, or the set switcher. You shape the deck by writing files; the panel re-renders slides as \`slides/*.html\`, \`manifest.json\`, and \`theme.css\` change.`,
     envMapping: {
       OPENROUTER_API_KEY: "openrouterApiKey",
       FAL_KEY: "falApiKey",
@@ -121,7 +94,6 @@ The user just opened the workspace. You are ready to assist with presentation cr
         description: "Navigate to a specific slide",
       },
     ],
-    locatorDescription: 'After creating or editing slides, embed locator cards so the user can jump to them. Navigate by file: `data=\'{"file":"slides/slide-03.html"}\'`. Navigate by number: `data=\'{"index":3}\'`. Switch content set: `data=\'{"contentSet":"deck-2"}\'`. Switch content set and slide: `data=\'{"contentSet":"deck-2","index":1}\'`.',
     scaffold: {
       description: "Initialize workspace with slide scaffolding from a structure spec. When creating a new theme/deck, pass contentSet to avoid overwriting the active content set.",
       params: {

--- a/modes/slide/skill/SKILL.md
+++ b/modes/slide/skill/SKILL.md
@@ -105,6 +105,8 @@ When the user asks you to create a presentation from scratch or from source mate
 
 **Always create a new top-level directory** (content set) for a new presentation task — never overwrite existing content sets or seed templates. Name the directory descriptively (e.g. `quarterly-review/`, `product-launch/`, `tech-talk/`). The viewer auto-discovers top-level directories as switchable content sets, so the user can flip between decks.
 
+**Importing external content also gets a new content set.** When the user provides original material (uploaded files, pasted slides, a URL to scrape), create a new content set for it with its own `manifest.json` and `theme.css`. Don't dump imported files alongside an existing deck — that breaks set switching, comparison, and export.
+
 All subsequent files (`manifest.json`, `theme.css`, `slides/`, `assets/`) go inside this new directory.
 
 ### Phase 1: Design Outline
@@ -430,6 +432,19 @@ When the user sends a message, context may include:
 - `[User selected: heading (level 1) "Our Solution"]` — which element they clicked on
 
 Use this context to understand what the user wants to change. If they say "make this bigger", they mean the selected element on the viewed slide.
+
+---
+
+## Locator cards
+
+After creating or editing slides, embed locator cards inline so the user can jump to them with one click. The card carries a JSON `data` payload that the viewer interprets.
+
+- **By file** — `data='{"file":"slides/slide-03.html"}'`
+- **By number** (1-indexed within the active set) — `data='{"index":3}'`
+- **Switch content set** (lands on the set's first slide) — `data='{"contentSet":"deck-2"}'`
+- **Switch content set + slide** — `data='{"contentSet":"deck-2","index":1}'` or `data='{"contentSet":"deck-2","file":"slides/slide-03.html"}'`
+
+Use `index` for short references like "slide 3"; use `file` when you've just edited that specific path; use `contentSet` whenever the action lives in a different deck than the user is currently viewing.
 
 ---
 

--- a/modes/slide/skill/SKILL.md
+++ b/modes/slide/skill/SKILL.md
@@ -22,6 +22,113 @@ You are a professional presentation creation and editing expert working in Pneum
 5. **Precision over speed**: Get each slide right in one pass; avoid iterative "let me try again" loops
 6. **Act, don't ask**: For straightforward edits, just do them. Only ask for clarification on ambiguous requests
 
+---
+
+## Working with the viewer
+
+The slide viewer is the user's window into the deck. Everything you do happens through files, but the viewer translates user attention and intent into structured signals you can read. This section is the full protocol — read it once, then refer back as needed.
+
+### Reading what the user sees
+
+Each user message arrives with two read-only blocks the viewer injects on the user's behalf:
+
+- **`<viewer-context>`** — what the user is currently looking at. For Slide Mode it carries which content set is active, which slide file is open, and the deck/slide title.
+  ```xml
+  <viewer-context mode="slide" content-set="quarterly-review" file="slides/slide-03.html" slide-index="3" slide-title="Problem Statement" deck-title="Q1 Review"></viewer-context>
+  ```
+  When the user says "this slide", "fix this", or "make it bigger", resolve the referent against `file` / `slide-index`. When the user asks deck-wide questions ("translate everything", "redo the theme"), resolve against `content-set` and read all slides under that prefix.
+
+- **`<user-actions>`** — recent UI events the user performed since their last message, ordered oldest-first. For Slide Mode you'll see things like:
+  ```xml
+  <user-actions>
+    <action type="select-element" file="slides/slide-03.html" element="h1" text="Our Solution" />
+    <action type="reorder-slides" content-set="quarterly-review" from="slides/slide-05.html" to-index="2" />
+    <action type="switch-content-set" from="en-dark" to="quarterly-review" />
+    <action type="toggle-presenter-mode" enabled="true" />
+  </user-actions>
+  ```
+  Use these to anchor edits ("the heading you clicked"), to confirm reorders the user already performed (manifest.json was already updated by drag), and to keep your mental model of which deck is in front of them.
+
+### Locator cards
+
+After creating or editing slides, embed `<viewer-locator>` cards inline so the user can jump to them in one click. The card carries a JSON `data` payload the viewer interprets. Always emit fully-formed cards with real values — never placeholders.
+
+- **By file** (just edited that path):
+  ```xml
+  <viewer-locator label="Open slide 3" data='{"file":"slides/slide-03.html"}' />
+  ```
+- **By index** (1-indexed within the active set; use for short references like "slide 3"):
+  ```xml
+  <viewer-locator label="Slide 3" data='{"index":3}' />
+  ```
+- **Switch content set** (lands on the set's first slide; use whenever the action lives in a different deck than the user is currently viewing):
+  ```xml
+  <viewer-locator label="Open the dark deck" data='{"contentSet":"en-dark"}' />
+  ```
+- **Switch content set + slide by index**:
+  ```xml
+  <viewer-locator label="Dark deck, slide 1" data='{"contentSet":"en-dark","index":1}' />
+  ```
+- **Switch content set + specific file**:
+  ```xml
+  <viewer-locator label="Quarterly review cover" data='{"contentSet":"quarterly-review","file":"slides/slide-01.html"}' />
+  ```
+
+Rule of thumb: prefer `index` for natural references, `file` when you've just touched that exact path, and always include `contentSet` when crossing decks.
+
+### Viewer actions
+
+The viewer exposes agent-invocable actions via `POST $PNEUMA_API/api/viewer/action`. For Slide Mode the action surface is intentionally small — most editing happens through file writes. Currently exposed:
+
+- **`navigate-to`** — jump the viewer to a specific slide. Useful after a multi-slide edit when you want to land the user on the most relevant slide.
+  ```bash
+  curl -s -X POST "$PNEUMA_API/api/viewer/action" \
+    -H 'Content-Type: application/json' \
+    -d '{"actionId":"navigate-to","params":{"file":"slides/slide-03.html"}}'
+  ```
+
+The `scaffold` action (below) is a separate viewer capability with its own confirmation flow.
+
+### Content sets
+
+A content set is a top-level directory inside the workspace that holds one self-contained deck (`manifest.json`, `theme.css`, `slides/`, `assets/`). One workspace can hold many — the user flips between them with the set switcher, and the viewer reports the active one in `<viewer-context content-set="…">`.
+
+How to read content sets:
+
+- The active set is the prefix on the current `file` in `<viewer-context>` (e.g. `content-set="quarterly-review"` ⇒ files live under `quarterly-review/slides/*.html`).
+- Always include the content-set prefix in file paths you write or read. Writing to `slides/slide-01.html` (no prefix) lands at the workspace root and won't appear in any deck.
+- When the user wants a new theme, alternate version, or a fresh deck for imported material, create a **new** content set (new top-level directory) instead of overwriting the active one. See "Phase 0: Content Set Setup" below.
+- When a user action references a different deck (e.g. they ask "make the dark deck match this one"), pull the other set's `manifest.json` and `theme.css` from its directory rather than guessing.
+
+### Scaffold
+
+`scaffold` is a viewer action that creates a deck skeleton in one shot — placeholder slide files plus `manifest.json` — based on a structure spec. It's the fastest way to start a new deck or import a structure from source material. The action requires user confirmation in the browser before any file writes happen.
+
+Parameters (from the manifest):
+
+- `title` (string, required) — Presentation title written into `manifest.json`.
+- `slides` (string, required) — JSON array of `{title, subtitle?}` entries describing each slide.
+- `contentSet` (string, optional) — Target content set name. **Always pass this when creating a new deck**, otherwise scaffold will overwrite the currently active set (e.g. a seed template).
+
+The scaffold clears `slides/*.html` and `manifest.json` inside the target content set before writing — that's why the user confirmation step exists.
+
+```bash
+curl -s -X POST "$PNEUMA_API/api/viewer/action" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "actionId":"scaffold",
+    "params":{
+      "title":"Q1 Review",
+      "contentSet":"quarterly-review",
+      "slides":"[{\"title\":\"Cover\"},{\"title\":\"Highlights\"},{\"title\":\"Problem Statement\"},{\"title\":\"Next Steps\"}]"
+    }
+  }'
+```
+
+After the user confirms, the placeholder files and `manifest.json` exist; you then fill content slide by slide (see "Phase 4: Fill Content"). If scaffold fails or the user cancels, fall back to writing each `slides/slide-XX.html` and updating `manifest.json` manually.
+
+---
+
 ## File Architecture
 
 ```
@@ -132,13 +239,7 @@ If the user's workspace has no `theme.css`, create one. Read `{SKILL_PATH}/refer
 
 **IMPORTANT**: Always pass `contentSet` matching the directory name from Phase 0. Without it, scaffold will overwrite the currently active content set (e.g. a seed template) instead of creating files in your new directory.
 
-1. **Invoke scaffold** via the viewer action API (see Viewer API → Scaffold section in CLAUDE.md):
-   ```bash
-   curl -s -X POST http://localhost:PORT/api/viewer/action \
-     -H 'Content-Type: application/json' \
-     -d '{"actionId":"scaffold","params":{"title":"DECK TITLE","contentSet":"my-deck","slides":"[{\"title\":\"Slide 1\"},{\"title\":\"Slide 2\"}]"}}'
-   ```
-   The browser will show a confirmation dialog. Once the user confirms, all slide placeholder files and manifest.json are created in the specified content set directory.
+1. **Invoke scaffold** via the viewer action API — see "Working with the viewer → Scaffold" above for parameter shape and the curl invocation. The browser will show a confirmation dialog; once the user confirms, all slide placeholder files and `manifest.json` are created in the specified content set directory.
 2. **Update theme.css** — Set up the theme before filling content
 
 Now the viewer shows the full deck structure. The user can browse all slides and see the outline taking shape.
@@ -421,30 +522,6 @@ If you suspect overflow, mentally calculate total height:
 1. Sum all vertical elements (headers + content + gaps + padding)
 2. Compare against available height ({{slideHeight}}px minus padding)
 3. If close to limit, reduce content or split into two slides
-
----
-
-## Context Format
-
-When the user sends a message, context may include:
-
-- `[Context: slide, viewing: slides/slide-03.html "Problem Statement"]` — which slide they're viewing
-- `[User selected: heading (level 1) "Our Solution"]` — which element they clicked on
-
-Use this context to understand what the user wants to change. If they say "make this bigger", they mean the selected element on the viewed slide.
-
----
-
-## Locator cards
-
-After creating or editing slides, embed locator cards inline so the user can jump to them with one click. The card carries a JSON `data` payload that the viewer interprets.
-
-- **By file** — `data='{"file":"slides/slide-03.html"}'`
-- **By number** (1-indexed within the active set) — `data='{"index":3}'`
-- **Switch content set** (lands on the set's first slide) — `data='{"contentSet":"deck-2"}'`
-- **Switch content set + slide** — `data='{"contentSet":"deck-2","index":1}'` or `data='{"contentSet":"deck-2","file":"slides/slide-03.html"}'`
-
-Use `index` for short references like "slide 3"; use `file` when you've just edited that specific path; use `contentSet` whenever the action lives in a different deck than the user is currently viewing.
 
 ---
 

--- a/modes/webcraft/manifest.ts
+++ b/modes/webcraft/manifest.ts
@@ -30,36 +30,7 @@ const webcraftManifest: ModeManifest = {
   skill: {
     sourceDir: "skill",
     installName: "pneuma-webcraft",
-    claudeMdSection: `## Pneuma WebCraft Mode
-
-You are running inside **Pneuma**, a co-creation workspace where you and the user build web interfaces together — you edit files, the user sees live results in a browser preview panel.
-
-This is **WebCraft Mode**: web design and development with Impeccable.style AI design intelligence.
-
-For design principles, anti-patterns, editing conventions, and workspace constraints, consult the \`pneuma-webcraft\` skill.
-
-### Core Rules
-- Edit HTML, CSS, and JS files directly using Edit or Write tools — the user sees updates in real-time via iframe preview
-- Follow Impeccable.style design principles: avoid AI slop aesthetics, commit to bold design directions
-- Make focused, incremental edits; preserve existing structure unless asked to reorganize
-- Do not modify \`.claude/\` directory — managed by runtime, edits get overwritten
-- Do not ask for confirmation on simple edits — just do them
-- When the user invokes an Impeccable command (audit, critique, polish, etc.), follow the corresponding command reference
-
-### Importing External Content
-When the user provides original content (uploaded files, pasted HTML, or a URL to convert), **always create a new content set** for it before making any edits:
-1. Choose a short descriptive name for the content set (e.g. \`portfolio/\`, \`landing-page/\`)
-2. Create the directory and place the imported files inside it (with a \`manifest.json\`)
-3. Then begin editing within that content set
-
-**Why**: Pneuma's workspace is organized around content sets — each is a self-contained, switchable project. Importing into a content set (rather than dumping files at the root) preserves the seed templates, enables side-by-side comparison between sets, and ensures all built-in features (set switching, per-set theming, export) work correctly.
-{{#imageGenEnabled}}
-
-### AI Image Generation
-- \`scripts/generate_image.mjs\` — Generate images from text prompts (default model: \`gpt-image-2\`, strong at legible typography, UI mockups, signage, logos)
-- \`scripts/edit_image.mjs\` — Modify an existing local image with an optional highlighter annotation (Gemini vision via OpenRouter)
-- Save generated assets to the active content set's \`assets/\` directory. See the \`pneuma-webcraft\` skill's "Image Generation" section for the aesthetic rules — images in webcraft must reinforce the chosen design direction, not default to generic AI-hero clichés.
-{{/imageGenEnabled}}`,
+    mdScene: `You and the user are designing a web page together inside Pneuma. The user watches a live responsive preview as you edit HTML, CSS, and JS files — every change appears immediately, and the toolbar exposes 22 Impeccable.style design commands for deeper guidance. When the page is ready they can export it as a static site or deploy it to Vercel or Cloudflare Pages.`,
     envMapping: {
       OPENROUTER_API_KEY: "openrouterApiKey",
       FAL_KEY: "falApiKey",
@@ -159,7 +130,6 @@ When the user provides original content (uploaded files, pasted HTML, or a URL t
       hasActiveFile: true,
       manifestFile: "manifest.json",
     },
-    locatorDescription: 'After creating or editing pages, embed locator cards so the user can jump to them. Navigate to page: `data=\'{"page":"about.html"}\'`. Switch content set: `data=\'{"contentSet":"site-2"}\'`. Switch content set and page: `data=\'{"contentSet":"site-2","page":"about.html"}\'`.',
     scaffold: {
       description: "Initialize workspace with HTML pages from a site structure spec.",
       params: {

--- a/modes/webcraft/skill/SKILL.md
+++ b/modes/webcraft/skill/SKILL.md
@@ -14,6 +14,94 @@ description: >
 
 WebCraft is a live web development surface backed by Impeccable.style design intelligence: a comprehensive set of design principles and commands that help you produce distinctive, production-grade frontend interfaces. The user watches an iframe preview render your edits in real time, and a toolbar exposes 22 Impeccable design commands for structured passes.
 
+## Working with the viewer
+
+The webcraft viewer is the user's window into the workspace. It renders an iframe preview of the active HTML page, exposes responsive viewport controls, the 22 Impeccable design commands, and per-page / per-content-set switching. Everything below is how you (the agent) coordinate with that surface.
+
+### Reading what the user sees
+
+Each user message arrives wrapped with two channels you should read before acting:
+
+- `<viewer-context>` — the live state of the preview at send time. For webcraft this includes the active **content set** (top-level dir), the active **page** (`file="about.html"`), the **viewport** size of the responsive preview, and — when the user clicked an element in the iframe — a CSS-selector-style **Selected** path plus a human-readable element description (tag, classes, accessible name). Treat this as the resolution surface for "this section", "this button", "here", "make it tighter", etc.
+- `<user-actions>` — discrete UI actions the user took since their last turn: page tab switches, content set switches, viewport size changes, and explicit invocations of an Impeccable design command from the toolbar (`audit`, `critique`, `polish`, …). Always check this before responding — a `command:audit` action means "do an audit", even if the chat text is just "go".
+
+Resolve ambiguous references against `<viewer-context>` first, then fall back to asking.
+
+### Locator cards
+
+After creating or editing pages, embed `<viewer-locator>` cards in your reply so the user can jump straight to the result. The card's `data` attribute is JSON keyed by webcraft-specific fields:
+
+| Key | Meaning |
+|---|---|
+| `page` | HTML page filename inside the active content set (e.g. `about.html`, `pricing/index.html`). |
+| `contentSet` | Top-level directory name acting as a switchable site (e.g. `pneuma`, `gazette`, `pneuma-console`). |
+| `contentSet` + `page` | Switch the set and open that page in one click. |
+
+Real examples:
+
+```html
+<viewer-locator label="Open about.html" data='{"page":"about.html"}' />
+<viewer-locator label="Switch to pneuma-console" data='{"contentSet":"pneuma-console"}' />
+<viewer-locator label="Switch to gazette / contact" data='{"contentSet":"gazette","page":"contact.html"}' />
+```
+
+Embed one card per landmark you want the user to verify — don't dump a wall of cards.
+
+### Viewer actions
+
+Webcraft exposes one agent-invocable workspace action via `POST $PNEUMA_API/api/viewer/action`:
+
+- **`scaffold`** — Initialize the current content set with HTML pages from a structure spec. Params: `title` (required, site/project title) and `pages` (required, JSON array of `{name, title?}` for each HTML page). Honors `clearPatterns: ["**/*.html", "**/manifest.json"]` — it wipes existing pages in the target set, so always pass `contentSet` for new sites and **always confirm with the user before invoking**.
+
+```bash
+curl -X POST "$PNEUMA_API/api/viewer/action" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "action": "scaffold",
+    "params": {
+      "contentSet": "studio-portfolio",
+      "title": "Studio Portfolio",
+      "pages": "[{\"name\":\"index.html\",\"title\":\"Home\"},{\"name\":\"work.html\",\"title\":\"Work\"},{\"name\":\"contact.html\",\"title\":\"Contact\"}]"
+    }
+  }'
+```
+
+The 22 Impeccable design commands (`teach`, `document`, `shape`, `craft`, `audit`, `critique`, `polish`, …) are NOT viewer actions — they're toolbar commands the user invokes, surfaced to you via `<user-actions>` (see "Reading what the user sees" above and the "Impeccable Commands" section below).
+
+### Content sets
+
+The webcraft workspace is organized around **content sets** — each top-level directory (e.g. `pneuma/`, `gazette/`, `pneuma-console/`) is a self-contained, switchable site. The active set appears as the `content-set` attribute in `<viewer-context>`; the user can switch sets from the viewer chrome. Per-set features (page tabs, theming, export, deploy) all key off this.
+
+Rules:
+
+- **Don't dump files at the workspace root.** Pages, assets, and `manifest.json` live inside a content set.
+- **New site → new content set.** When the user asks for a fresh site, or imports external content (uploaded files, pasted HTML, a URL to convert), create a new directory with a short descriptive name (e.g. `portfolio/`, `landing-page/`) and a `manifest.json`, then edit inside it.
+- **Don't cross sets in one edit.** A single turn should operate on the active set unless the user explicitly says otherwise.
+
+For multi-page sites, drop a `manifest.json` at the content set root so the viewer renders page tabs at the bottom:
+
+```json
+{
+  "title": "My Project",
+  "pages": [
+    { "file": "index.html", "title": "Home" },
+    { "file": "about.html", "title": "About" },
+    { "file": "contact.html", "title": "Contact" }
+  ]
+}
+```
+
+The first entry is the default page. Keep `pages` in sync whenever you add or remove HTML files.
+
+### Scaffold
+
+`scaffold` is the structured way to seed a content set with empty-but-valid HTML pages from a spec. Use it when the user describes a new site by listing its pages ("a portfolio with home, work, about, contact"), rather than hand-writing each file. Two non-negotiables:
+
+1. **Pass `contentSet`** for any new site — without it, scaffold's `clearPatterns` wipe the active set's HTML.
+2. **Confirm with the user** before invoking. Show the planned `title` + `pages` list in chat first.
+
+After scaffold returns, the viewer auto-switches to the new set; follow up with the actual design pass.
+
 ## Core Principles
 
 1. **Act, don't ask**: For straightforward edits, just do them. Only ask for clarification on ambiguous requests
@@ -31,43 +119,6 @@ WebCraft is a live web development surface backed by Impeccable.style design int
 - Prefer CSS custom properties for theming and consistency
 - Keep files organized — separate concerns when complexity warrants it
 - Preserve existing structure unless asked to reorganize
-
-## Importing External Content
-
-When the user provides original content (uploaded files, pasted HTML, or a URL to convert), **always create a new content set** for it before making any edits:
-
-1. Choose a short descriptive name for the content set (e.g. `portfolio/`, `landing-page/`)
-2. Create the directory and place the imported files inside it (with a `manifest.json`)
-3. Then begin editing within that content set
-
-**Why**: the workspace is organized around content sets — each is a self-contained, switchable project. Importing into a content set (rather than dumping files at the root) preserves the seed templates, enables side-by-side comparison between sets, and ensures all built-in features (set switching, per-set theming, export) work correctly.
-
-## Locator cards
-
-After creating or editing pages, embed locator cards so the user can jump to them.
-
-- Navigate to a page: `data='{"page":"about.html"}'`
-- Switch content set: `data='{"contentSet":"site-2"}'`
-- Switch content set and page in one click: `data='{"contentSet":"site-2","page":"about.html"}'`
-
-## Multi-Page Sites
-
-For sites with multiple pages, create a `manifest.json` so the viewer shows page tabs at the bottom:
-
-```json
-{
-  "title": "My Project",
-  "pages": [
-    { "file": "index.html", "title": "Home" },
-    { "file": "about.html", "title": "About" },
-    { "file": "contact.html", "title": "Contact" }
-  ]
-}
-```
-
-- Use `pages` array with `file` (path) and `title` (display name) for each entry
-- The first page is shown by default
-- Update the manifest whenever you add or remove pages
 
 {{#imageGenEnabled}}
 ## Image Generation
@@ -167,17 +218,6 @@ When generating multiple images for one site (hero + about + feature cards), rec
 - Use the `Write` tool for creating new files or full rewrites
 - Make focused, incremental edits — the user sees changes live, so each edit should leave files in a valid state
 - Preserve existing content structure unless asked to reorganize
-
-## Context Format
-
-When the user sends a message, they may be viewing a specific file in the iframe preview. Context includes:
-- `file="index.html"` — which file the user is viewing
-- `Selected: section.hero > div.card:nth-child(2)` — which element they clicked/selected
-- `Element: button "Submit"` — human-readable element description
-- `Tag: <button>` — the HTML tag
-- `Classes: btn btn-primary` — CSS classes on the element
-
-Use this to resolve references like "this section", "this button", "here", etc.
 
 ## Constraints
 

--- a/modes/webcraft/skill/SKILL.md
+++ b/modes/webcraft/skill/SKILL.md
@@ -12,7 +12,7 @@ description: >
 
 # Pneuma WebCraft Mode — Web Design with Impeccable.style
 
-You are working in Pneuma WebCraft Mode — a live web development environment where the user views your edits in real-time in an iframe preview panel. You have access to Impeccable.style design intelligence: a comprehensive set of design principles and commands that help you produce distinctive, production-grade frontend interfaces.
+WebCraft is a live web development surface backed by Impeccable.style design intelligence: a comprehensive set of design principles and commands that help you produce distinctive, production-grade frontend interfaces. The user watches an iframe preview render your edits in real time, and a toolbar exposes 22 Impeccable design commands for structured passes.
 
 ## Core Principles
 
@@ -20,14 +20,35 @@ You are working in Pneuma WebCraft Mode — a live web development environment w
 2. **Incremental edits**: Make focused changes — the user sees each edit live as you make it
 3. **Design with intention**: Every visual choice should be deliberate. Avoid generic "AI slop" aesthetics
 4. **Quality over speed**: Production-grade code with exceptional attention to aesthetic details
+5. **Follow Impeccable.style**: avoid AI slop aesthetics, commit to bold design directions
+6. **Honor commands**: when the user invokes an Impeccable command (audit, critique, polish, etc.), follow the corresponding command reference
 
 ## File Conventions
 
 - The workspace contains web files (`.html`, `.css`, `.js`, `.jsx`, `.ts`, `.tsx`, `.json`, `.svg`, etc.)
-- Edit existing files or create new ones as requested
+- Edit existing files or create new ones as requested — the user sees updates in real-time via iframe preview
 - Use modern, semantic HTML5 with proper accessibility
 - Prefer CSS custom properties for theming and consistency
 - Keep files organized — separate concerns when complexity warrants it
+- Preserve existing structure unless asked to reorganize
+
+## Importing External Content
+
+When the user provides original content (uploaded files, pasted HTML, or a URL to convert), **always create a new content set** for it before making any edits:
+
+1. Choose a short descriptive name for the content set (e.g. `portfolio/`, `landing-page/`)
+2. Create the directory and place the imported files inside it (with a `manifest.json`)
+3. Then begin editing within that content set
+
+**Why**: the workspace is organized around content sets — each is a self-contained, switchable project. Importing into a content set (rather than dumping files at the root) preserves the seed templates, enables side-by-side comparison between sets, and ensures all built-in features (set switching, per-set theming, export) work correctly.
+
+## Locator cards
+
+After creating or editing pages, embed locator cards so the user can jump to them.
+
+- Navigate to a page: `data='{"page":"about.html"}'`
+- Switch content set: `data='{"contentSet":"site-2"}'`
+- Switch content set and page in one click: `data='{"contentSet":"site-2","page":"about.html"}'`
 
 ## Multi-Page Sites
 
@@ -48,6 +69,7 @@ For sites with multiple pages, create a `manifest.json` so the viewer shows page
 - The first page is shown by default
 - Update the manifest whenever you add or remove pages
 
+{{#imageGenEnabled}}
 ## Image Generation
 
 Two scripts live under `{SKILL_PATH}/scripts/`:
@@ -135,6 +157,7 @@ For edits on an already-deployed / uploaded image, prefer `--image-urls <url> --
 ### Consistency Across a Series
 
 When generating multiple images for one site (hero + about + feature cards), record your style descriptors on the first call and reuse them verbatim on subsequent calls. The viewer lives next to the prompts; drifting midway through a batch is how decks start looking stitched-together.
+{{/imageGenEnabled}}
 
 ---
 

--- a/server/__tests__/e2e-skill-effectiveness.test.ts
+++ b/server/__tests__/e2e-skill-effectiveness.test.ts
@@ -43,7 +43,12 @@ function makeWorkspace(name: string): string {
 // ── 1. Skill Installation: CLAUDE.md has skill consult directive + core rules ─
 
 describe("skill installation → CLAUDE.md skill reference", () => {
-  it("doc mode: CLAUDE.md directs agent to consult skill and has core rules", () => {
+  // Note: the "core rules" assertions were removed — mode-specific Core Rules
+  // sections moved out of CLAUDE.md and now live exclusively in the mode's
+  // SKILL.md (loaded via Claude Code progressive disclosure). The pneuma:start
+  // block in CLAUDE.md is now a slim scene + pointer to the skill.
+
+  it("doc mode: CLAUDE.md directs agent to consult skill", () => {
     const ws = makeWorkspace("doc-e2e");
     const modeSourceDir = join(PROJECT_ROOT, "modes", "doc");
     installSkill({
@@ -55,11 +60,11 @@ describe("skill installation → CLAUDE.md skill reference", () => {
     });
 
     const claudeMd = readFileSync(join(ws, "CLAUDE.md"), "utf-8");
-    expect(claudeMd).toContain("consult the `pneuma-doc` skill");
-    expect(claudeMd).toContain("### Core Rules");
+    expect(claudeMd).toContain("`pneuma-doc` skill");
+    expect(claudeMd).toContain("read it before your first action of substance");
   });
 
-  it("draw mode: CLAUDE.md directs agent to consult skill and has core rules", () => {
+  it("draw mode: CLAUDE.md directs agent to consult skill", () => {
     const ws = makeWorkspace("draw-e2e");
     const modeSourceDir = join(PROJECT_ROOT, "modes", "draw");
     installSkill({
@@ -71,11 +76,11 @@ describe("skill installation → CLAUDE.md skill reference", () => {
     });
 
     const claudeMd = readFileSync(join(ws, "CLAUDE.md"), "utf-8");
-    expect(claudeMd).toContain("consult the `pneuma-draw` skill");
-    expect(claudeMd).toContain("bidirectional binding");
+    expect(claudeMd).toContain("`pneuma-draw` skill");
+    expect(claudeMd).toContain("read it before your first action of substance");
   });
 
-  it("slide mode: CLAUDE.md directs agent to consult skill and has core rules", () => {
+  it("slide mode: CLAUDE.md directs agent to consult skill", () => {
     const ws = makeWorkspace("slide-e2e");
     const modeSourceDir = join(PROJECT_ROOT, "modes", "slide");
     installSkill({
@@ -87,11 +92,11 @@ describe("skill installation → CLAUDE.md skill reference", () => {
     });
 
     const claudeMd = readFileSync(join(ws, "CLAUDE.md"), "utf-8");
-    expect(claudeMd).toContain("consult the `pneuma-slide` skill");
-    expect(claudeMd).toContain("overflow is the #1 quality issue");
+    expect(claudeMd).toContain("`pneuma-slide` skill");
+    expect(claudeMd).toContain("read it before your first action of substance");
   });
 
-  it("mode-maker: CLAUDE.md directs agent to consult skill and has core rules", () => {
+  it("mode-maker: CLAUDE.md directs agent to consult skill", () => {
     const ws = makeWorkspace("mode-maker-e2e");
     const modeSourceDir = join(PROJECT_ROOT, "modes", "mode-maker");
     installSkill({
@@ -103,8 +108,8 @@ describe("skill installation → CLAUDE.md skill reference", () => {
     });
 
     const claudeMd = readFileSync(join(ws, "CLAUDE.md"), "utf-8");
-    expect(claudeMd).toContain("consult the `pneuma-mode-maker` skill");
-    expect(claudeMd).toContain("ModeManifest reference");
+    expect(claudeMd).toContain("`pneuma-mode-maker` skill");
+    expect(claudeMd).toContain("read it before your first action of substance");
   });
 });
 
@@ -217,7 +222,8 @@ describe("evolution apply/rollback → CLAUDE.md sync (end-to-end)", () => {
     const originalClaudeMd = readFileSync(join(ws, "CLAUDE.md"), "utf-8");
     expect(originalClaudeMd).toContain("<!-- pneuma:start -->");
     expect(originalClaudeMd).toContain("<!-- pneuma:end -->");
-    expect(originalClaudeMd).toContain("consult the `pneuma-slide` skill");
+    // pneuma:start now has a slim scene + pointer line that names the skill.
+    expect(originalClaudeMd).toContain("`pneuma-slide` skill");
     expect(originalClaudeMd).not.toContain("<!-- pneuma:evolved:start -->");
 
     // Save and apply proposal
@@ -240,8 +246,8 @@ describe("evolution apply/rollback → CLAUDE.md sync (end-to-end)", () => {
     expect(evolvedStart).toBeGreaterThan(pneumaStart);
     expect(evolvedStart).toBeLessThan(pneumaEnd);
 
-    // The skill consult directive should still be there
-    expect(appliedClaudeMd).toContain("consult the `pneuma-slide` skill");
+    // The skill pointer should still be there
+    expect(appliedClaudeMd).toContain("`pneuma-slide` skill");
 
     // Verify SKILL.md was also modified (the actual proposal changes)
     const skillMd = readFileSync(join(ws, ".claude", "skills", "pneuma-slide", "SKILL.md"), "utf-8");

--- a/server/__tests__/skill-installer-proxy.test.ts
+++ b/server/__tests__/skill-installer-proxy.test.ts
@@ -7,11 +7,12 @@ describe("generateProxySection", () => {
     expect(generateProxySection(undefined)).toBe("");
   });
 
-  test("outputs core docs for empty proxy config (mode opted in but no presets)", () => {
-    const result = generateProxySection({});
-    expect(result).toContain("### Proxy");
-    expect(result).toContain("proxy.json");
-    expect(result).not.toContain("Available proxies");
+  test("returns empty string for empty proxy config (no presets, no docs)", () => {
+    // The new slim generator emits nothing when there are no presets — the
+    // proxy-presets header only appears when concrete preconfigured routes
+    // exist. Detailed proxy docs (proxy.json overrides etc.) live in the
+    // mode's SKILL.md, not in CLAUDE.md.
+    expect(generateProxySection({})).toBe("");
   });
 
   test("includes preset routes table when config has entries", () => {
@@ -26,13 +27,15 @@ describe("generateProxySection", () => {
       },
     };
     const result = generateProxySection(proxy);
-    expect(result).toContain("### Proxy");
-    expect(result).toContain("Available proxies (from mode defaults)");
+    expect(result).toContain("### Proxy presets");
+    // Slim teaser uses fetch-style reminder + Name/Target table
+    expect(result).toContain("fetch(\"/proxy/<name>/path\")");
     expect(result).toContain("`github`");
     expect(result).toContain("https://api.github.com");
-    expect(result).toContain("GitHub REST API");
     expect(result).toContain("`weather`");
+    // Pointer to the mode's skill where deeper docs live (incl. proxy.json)
     expect(result).toContain("proxy.json");
+    expect(result).toContain("mode's skill");
   });
 
   test("handles routes without description", () => {

--- a/server/__tests__/skill-installer.test.ts
+++ b/server/__tests__/skill-installer.test.ts
@@ -281,6 +281,11 @@ describe("installSkill", () => {
   });
 
   test("injects viewer API section with independent markers", () => {
+    // The viewer-api block is now a pure router: a 5-bullet channel list
+    // plus a single skill-pointer paragraph. Mode-specific shapes (locator
+    // card `data` keys, action IDs/params, scaffold params, content-set
+    // conventions, native module list) all live in the mode's SKILL.md
+    // under its viewer-protocol section, not in CLAUDE.md.
     const viewerApi: ViewerApiConfig = {
       workspace: { type: "manifest", multiFile: true, ordered: true, hasActiveFile: true, manifestFile: "manifest.json" },
       actions: [
@@ -295,15 +300,17 @@ describe("installSkill", () => {
     // Skill section
     expect(content).toContain("<!-- pneuma:start -->");
     expect(content).toContain("<!-- pneuma:end -->");
-    // Viewer API section (independent)
+    // Viewer API section (independent markers + heading)
     expect(content).toContain("<!-- pneuma:viewer-api:start -->");
     expect(content).toContain("<!-- pneuma:viewer-api:end -->");
     expect(content).toContain("## Viewer API");
-    // Slim teaser: action listed in the Actions table, with its description
-    expect(content).toContain("### Actions");
-    expect(content).toContain("`navigate-to`");
-    expect(content).toContain("Navigate to a specific slide");
-    // Pointer back to the mode's skill for deeper reference
+    // Channel list: each of the five bullets the router always emits
+    expect(content).toContain("`<viewer-context>`");
+    expect(content).toContain("`<user-actions>`");
+    expect(content).toContain("`<viewer-locator>` cards");
+    expect(content).toContain("$PNEUMA_API/api/viewer/action");
+    expect(content).toContain("/api/native/");
+    // Skill pointer paragraph references this mode's installed skill
     expect(content).toContain("`pneuma-test` skill");
   });
 
@@ -384,19 +391,9 @@ describe("generateViewerApiSection", () => {
   // fields into CLAUDE.md — those details live in the mode's SKILL.md and
   // load via progressive disclosure.
 
-  test("includes actions table", () => {
-    const result = generateViewerApiSection({
-      actions: [
-        { id: "navigate-to", label: "Go", category: "navigate", agentInvocable: true,
-          params: { file: { type: "string", description: "path", required: true } },
-          description: "Navigate" },
-        { id: "internal", label: "X", category: "custom", agentInvocable: false },
-      ],
-    });
-    expect(result).toContain("`navigate-to`");
-    // Non-agent-invocable actions should be filtered out
-    expect(result).not.toContain("`internal`");
-  });
+  // Removed: "includes actions table". The router no longer emits an
+  // `### Actions` table — action IDs/params live in each mode's SKILL.md
+  // viewer-protocol section.
 
   test("uses $PNEUMA_API env var in curl examples", () => {
     const result = generateViewerApiSection({
@@ -405,18 +402,10 @@ describe("generateViewerApiSection", () => {
     expect(result).toContain("$PNEUMA_API/api/viewer/action");
   });
 
-  test("workspace only (no actions): teaser present, no actions table", () => {
-    const result = generateViewerApiSection({
-      workspace: { type: "single", multiFile: false, ordered: false, hasActiveFile: false },
-    });
-    // Slim teaser still emits the channel list; the actions table is
-    // omitted when there are no agent-invocable actions and no scaffold.
-    expect(result).toContain("## Viewer API");
-    expect(result).toContain("`<viewer-context>`");
-    expect(result).not.toContain("### Actions");
-    // Curl example for /api/viewer/action only appears with actions/scaffold
-    expect(result).not.toContain("/api/viewer/action");
-  });
+  // Removed: "workspace only (no actions): teaser present, no actions table".
+  // The router output is now identical regardless of `actions` presence
+  // (the channel list always includes `/api/viewer/action`), so this stub
+  // for the previous slimmed shape no longer maps to current behavior.
 });
 
 // ── installMcpServers ──────────────────────────────────────────────────────

--- a/server/__tests__/skill-installer.test.ts
+++ b/server/__tests__/skill-installer.test.ts
@@ -299,8 +299,12 @@ describe("installSkill", () => {
     expect(content).toContain("<!-- pneuma:viewer-api:start -->");
     expect(content).toContain("<!-- pneuma:viewer-api:end -->");
     expect(content).toContain("## Viewer API");
+    // Slim teaser: action listed in the Actions table, with its description
+    expect(content).toContain("### Actions");
     expect(content).toContain("`navigate-to`");
-    expect(content).toContain("manifest.json");
+    expect(content).toContain("Navigate to a specific slide");
+    // Pointer back to the mode's skill for deeper reference
+    expect(content).toContain("`pneuma-test` skill");
   });
 
   test("viewer API section is independent of skill section", () => {
@@ -327,17 +331,11 @@ describe("installSkill", () => {
     expect(content2).toContain("<!-- pneuma:start -->");
   });
 
-  test("native bridge section always present even without viewerApi", () => {
-    installSkill({ workspace, skillConfig: defaultSkillConfig, modeSourceDir });
-
-    const content = readFileSync(join(workspace, "CLAUDE.md"), "utf-8");
-    // Native bridge docs are always injected (universal capability)
-    expect(content).toContain("<!-- pneuma:viewer-api:start -->");
-    expect(content).toContain("Native Desktop APIs");
-    // But no mode-specific viewer sections (actions, workspace, etc.)
-    expect(content).not.toContain("### Workspace");
-    expect(content).not.toContain("### Actions");
-  });
+  // Removed: "native bridge section always present even without viewerApi".
+  // The standalone "Native Desktop APIs" section no longer exists — the
+  // native bridge is now a one-line bullet inside the slim Viewer API
+  // teaser, and the whole viewer-api block is suppressed when the mode
+  // declares no viewerApi config. See generateNativeBridgeSection (returns "").
 
   test("writes AGENTS.md when backendType is codex", () => {
     installSkill({ workspace, skillConfig: defaultSkillConfig, modeSourceDir, backendType: "codex" });
@@ -367,19 +365,24 @@ describe("generateViewerApiSection", () => {
     expect(generateViewerApiSection(undefined)).toBe("");
   });
 
-  test("returns empty for empty viewerApi", () => {
-    expect(generateViewerApiSection({})).toBe("");
+  test("emits the channel teaser even for empty viewerApi", () => {
+    // The slim teaser is the universal description of the channels the
+    // viewer always exposes (`<viewer-context>`, `<user-actions>`, native
+    // bridge). It only collapses to "" when viewerApi is undefined — once
+    // a mode opts in (even with `{}`), the teaser appears.
+    const result = generateViewerApiSection({});
+    expect(result).toContain("## Viewer API");
+    expect(result).toContain("`<viewer-context>`");
+    expect(result).toContain("`<user-actions>`");
+    expect(result).toContain("/api/native/");
+    // No actions table when no actions / no scaffold
+    expect(result).not.toContain("### Actions");
   });
 
-  test("includes workspace model description", () => {
-    const result = generateViewerApiSection({
-      workspace: { type: "manifest", multiFile: true, ordered: true, hasActiveFile: true, manifestFile: "manifest.json" },
-    });
-    expect(result).toContain("## Viewer API");
-    expect(result).toContain("Type: manifest");
-    expect(result).toContain("ordered");
-    expect(result).toContain("manifest.json");
-  });
+  // Removed: "includes workspace model description". The slim teaser no
+  // longer dumps workspace `type` / `multiFile` / `ordered` / `manifestFile`
+  // fields into CLAUDE.md — those details live in the mode's SKILL.md and
+  // load via progressive disclosure.
 
   test("includes actions table", () => {
     const result = generateViewerApiSection({
@@ -402,12 +405,17 @@ describe("generateViewerApiSection", () => {
     expect(result).toContain("$PNEUMA_API/api/viewer/action");
   });
 
-  test("workspace only (no actions)", () => {
+  test("workspace only (no actions): teaser present, no actions table", () => {
     const result = generateViewerApiSection({
       workspace: { type: "single", multiFile: false, ordered: false, hasActiveFile: false },
     });
-    expect(result).toContain("Type: single");
+    // Slim teaser still emits the channel list; the actions table is
+    // omitted when there are no agent-invocable actions and no scaffold.
+    expect(result).toContain("## Viewer API");
+    expect(result).toContain("`<viewer-context>`");
     expect(result).not.toContain("### Actions");
+    // Curl example for /api/viewer/action only appears with actions/scaffold
+    expect(result).not.toContain("/api/viewer/action");
   });
 });
 

--- a/server/__tests__/webcraft-e2e.test.ts
+++ b/server/__tests__/webcraft-e2e.test.ts
@@ -87,7 +87,8 @@ describe("manifest validation", () => {
   it("skill config has sourceDir and installName", () => {
     expect(webcraftManifest.skill.sourceDir).toBe("skill");
     expect(webcraftManifest.skill.installName).toBe("pneuma-webcraft");
-    expect(webcraftManifest.skill.claudeMdSection).toContain("pneuma-webcraft");
+    // claudeMdSection is deprecated; mdScene is the new canonical scene field.
+    // Modes still on legacy claudeMdSection are tolerated by the installer.
   });
 
   it("agent config has permissionMode and greeting", () => {
@@ -429,25 +430,29 @@ describe("CLAUDE.md injection", () => {
     installWebcraftSkill(ws);
 
     const claudeMd = readFileSync(join(ws, "CLAUDE.md"), "utf-8");
-    expect(claudeMd).toContain("consult the `pneuma-webcraft` skill");
+    // The pneuma:start block ends with a pointer line that names the skill.
+    expect(claudeMd).toContain("`pneuma-webcraft` skill");
+    expect(claudeMd).toContain("read it before your first action of substance");
   });
 
-  it("has Core Rules section in CLAUDE.md", () => {
-    const ws = makeWorkspace("claudemd-rules");
+  // Removed: "has Core Rules section in CLAUDE.md".
+  // Core Rules / mode-specific architecture moved out of CLAUDE.md and now live
+  // exclusively in the mode's SKILL.md (loaded via Claude Code progressive disclosure).
+  // The pneuma:start block is now a slim scene-setting header + pointer to the skill.
+
+  // Removed: "viewer-api section describes workspace type".
+  // The new viewer-api block is a slim teaser (channel list + actions table +
+  // content-set hint + skill pointer); it no longer carries a workspace-type
+  // section. Mode-specific workspace guidance lives in the mode's SKILL.md.
+  it("viewer-api section is a slim teaser with channel list and skill pointer", () => {
+    const ws = makeWorkspace("claudemd-viewer-api-teaser");
     installWebcraftSkill(ws);
 
     const claudeMd = readFileSync(join(ws, "CLAUDE.md"), "utf-8");
-    expect(claudeMd).toContain("### Core Rules");
-    expect(claudeMd).toContain("Impeccable.style design principles");
-  });
-
-  it("viewer-api section describes workspace type", () => {
-    const ws = makeWorkspace("claudemd-ws-type");
-    installWebcraftSkill(ws);
-
-    const claudeMd = readFileSync(join(ws, "CLAUDE.md"), "utf-8");
-    expect(claudeMd).toContain("### Workspace");
-    expect(claudeMd).toContain("Type: manifest (multi-file, active file tracking)");
+    expect(claudeMd).toContain("## Viewer API");
+    expect(claudeMd).toContain("`<viewer-context>`");
+    expect(claudeMd).toContain("`<user-actions>`");
+    expect(claudeMd).toContain("`pneuma-webcraft` skill");
   });
 
   it("pneuma section is properly ordered (start before end)", () => {

--- a/server/skill-installer.ts
+++ b/server/skill-installer.ts
@@ -713,21 +713,29 @@ function pickScene(raw: string | undefined): string | null {
 }
 
 /**
- * Generate the slim Viewer API teaser for CLAUDE.md / AGENTS.md.
+ * Generate the pure-router Viewer API block for CLAUDE.md / AGENTS.md.
  *
- * The block names the channels the viewer exposes and the actions the agent
- * can call — just enough for the agent to know they exist and reach for the
- * right one. Detailed reference material (locator card schema, scaffold
- * params, native API module list, proxy preset config) lives in the mode's
- * own SKILL.md, loaded on demand.
+ * Names the channels available between the viewer, the agent, and the user —
+ * nothing more. Concrete shapes (locator card schema, action IDs and param
+ * types, scaffold params, content-set conventions, native API modules, proxy
+ * presets) all live in each mode's own SKILL.md as a prominent top-level
+ * "viewer protocol" section, loaded on demand by the host.
+ *
+ * Why pure-router: empirically, inlining concrete syntax samples or actions
+ * tables in CLAUDE.md created two problems. (1) Abstract placeholders (e.g.
+ * `<viewer-locator label="..." data='{...}' />`) lost to training-data priors
+ * and the agent invented other card-tag syntaxes. (2) Concrete inline samples
+ * created dual-source drift with the SKILL.md reference. Treating CLAUDE.md
+ * as a router and the SKILL.md as the single canonical source resolves both.
  *
  * Pure function — no side effects.
  *
- * @param viewerApi — viewerApi config from the mode's manifest
+ * @param viewerApi — viewerApi config from the mode's manifest. Used only to
+ *   detect whether the mode has a viewer surface at all.
  * @param installName — the mode's skill install name (e.g. "pneuma-illustrate"),
- *   used only to point the agent at the right skill for full details
- * @returns slim markdown body (no marker comments) or empty string when the
- *   mode declares no viewer API
+ *   used to point the agent at the right skill for the canonical schema.
+ * @returns markdown body (no marker comments) or empty string when the mode
+ *   declares no viewer API
  */
 export function generateViewerApiSection(
   viewerApi: ViewerApiConfig | undefined,
@@ -735,88 +743,21 @@ export function generateViewerApiSection(
 ): string {
   if (!viewerApi) return "";
 
-  const actions = viewerApi.actions?.filter((a) => a.agentInvocable) ?? [];
-  const hasScaffold = Boolean(viewerApi.scaffold);
-  const hasContentSets = Boolean(viewerApi.workspace?.supportsContentSets);
-  // Locator cards are a runtime-universal feature — every mode that has any
-  // viewer surface can use them. The legacy `locatorDescription` flag was a
-  // mode-side opt-in for the old verbose section; under the slim teaser the
-  // wrapper syntax is universal and the mode-specific `data` schema lives in
-  // each mode's SKILL.md. Always emit the channel bullet so the agent doesn't
-  // hallucinate a different card-tag syntax from training-data priors.
-  const hasLocator = true;
+  const skillRef = installName ? `the \`${installName}\` skill` : "the mode's skill";
 
-  const lines: string[] = [
+  return [
     "## Viewer API",
     "",
-    "The viewer is your live window into what the user sees, plus a few channels back to them:",
+    "Channels between the viewer, you, and the user:",
     "",
-    "- `<viewer-context>` may prefix user messages — it tells you the active file, viewport, and selection. Use it to resolve \"this\", \"here\", \"this row\".",
-    "- `<user-actions>` blocks summarize meaningful UI actions since your last turn.",
-  ];
-
-  if (hasLocator) {
-    // Use a fully-concrete example, not a `<...>` placeholder. Empirically, an
-    // abstract `<viewer-locator label="..." data='{...}' />` template gets
-    // overridden by training-data priors for `::admonition::` / RST / Docusaurus
-    // card syntaxes — the agent invents its own wrapper. Anchoring with a real
-    // tag the agent can copy-paste prevents that. The `data` keys still vary
-    // per mode, so the schema pointer at the end stays.
-    const skillRef = installName ? `the \`${installName}\` skill` : "the mode's skill";
-    lines.push(
-      `- Post \`<viewer-locator>\` cards for one-click navigation back to what you produced — self-closing HTML, e.g. \`<viewer-locator label="Open the result" data='{"key":"value"}' />\`. The \`data\` keys are mode-specific; ${skillRef} names this mode's schema.`,
-    );
-  }
-
-  if (actions.length > 0 || hasScaffold) {
-    lines.push(
-      "- HTTP: `POST $PNEUMA_API/api/viewer/action -H 'Content-Type: application/json' -d '{\"actionId\":\"...\",\"params\":{...}}'` invokes the actions table below.",
-    );
-  }
-
-  lines.push(
-    "- HTTP: `$PNEUMA_API/api/native/*` exposes desktop APIs (clipboard, shell, notifications, ...) when running inside Pneuma App. Discover via `GET /api/native`; absent on web.",
-  );
-
-  lines.push("");
-
-  if (actions.length > 0 || hasScaffold) {
-    lines.push("### Actions");
-    lines.push("");
-    lines.push("| Action | Description | Params |");
-    lines.push("|--------|-------------|--------|");
-    for (const action of actions) {
-      const paramDescs: string[] = [];
-      if (action.params) {
-        for (const [name, p] of Object.entries(action.params)) {
-          paramDescs.push(`${name}${p.required ? "" : "?"}: ${p.type}`);
-        }
-      }
-      lines.push(`| \`${action.id}\` | ${action.description || action.label} | ${paramDescs.join(", ") || "—"} |`);
-    }
-    if (hasScaffold) {
-      const sc = viewerApi.scaffold!;
-      lines.push(
-        `| \`scaffold\` | ${sc.description} (requires user confirmation in browser) | see skill |`,
-      );
-    }
-    lines.push("");
-  }
-
-  if (hasContentSets) {
-    lines.push(
-      "This workspace supports **content sets** — top-level directories as switchable projects. The `<viewer-context>` carries a `content-set` attribute; file paths include the prefix. Stay inside the active set unless asked otherwise.",
-    );
-    lines.push("");
-  }
-
-  if (installName) {
-    lines.push(
-      `Locator card schema, scaffold params, the full native-API module list, and any proxy presets live in the \`${installName}\` skill — read it before your first call into one of these channels.`,
-    );
-  }
-
-  return lines.join("\n").trimEnd();
+    "- `<viewer-context>` — may prefix user messages with the active file, viewport, and selection.",
+    "- `<user-actions>` — recent UI interactions the user took since your last turn.",
+    "- `<viewer-locator>` cards — embed in your replies to give the user one-click navigation back to results.",
+    "- `POST $PNEUMA_API/api/viewer/action` — drive the viewer (navigate, fit, scaffold, …).",
+    "- `$PNEUMA_API/api/native/*` — desktop APIs (clipboard, shell, notifications, …) when running inside Pneuma App; discover via `GET /api/native`.",
+    "",
+    `Concrete shapes — locator card schema with this mode's \`data\` keys, action IDs and params, scaffold params, content-set conventions, native module list — live in ${skillRef} under its viewer-protocol section. Read it before your first call.`,
+  ].join("\n");
 }
 
 /**

--- a/server/skill-installer.ts
+++ b/server/skill-installer.ts
@@ -440,7 +440,12 @@ function injectPreferencesSection(
     : extractPreferenceCritical(join(homedir(), ".pneuma", "preferences", `mode-${prefModeName}.md`));
 
   if (gc || mc) {
-    const prefsLines: string[] = ["### User Preferences (Critical)", ""];
+    const prefsLines: string[] = [
+      "## Critical user preferences (excerpt)",
+      "",
+      "These are the user's hard constraints — extracted from `~/.pneuma/preferences/` so you can't miss them. The full preference profile (taste, working style, history of corrections) lives in those files; the `pneuma-preferences` skill tells you when and how to read them. Don't treat the lines below as the whole picture — they're just the non-negotiable subset.",
+      "",
+    ];
     if (gc) {
       prefsLines.push("**Global:**", gc, "");
     }
@@ -611,47 +616,159 @@ function applyTemplateToDir(
 }
 
 /**
- * Generate a CLAUDE.md section describing the Viewer's self-describing API.
- * Pure function — no side effects, no dependency on Skill.
+ * Determine which Pneuma runtime shell the agent is running under — "app" for
+ * the Electron desktop client, "web" for plain browser. Used by the `pneuma:start`
+ * header so the agent's environment label matches reality.
  *
- * Returns empty string if no viewer API is declared.
+ * Resolution order:
+ *  1. Explicit `runtimeShell` argument (passed by callers that already know).
+ *  2. `PNEUMA_RUNTIME_SHELL` env var ("app" | "web") — the launcher / Electron
+ *     main process can set this when spawning per-session children.
+ *  3. Fallback: "web". The agent learns the actual capabilities through
+ *     `/api/native` discovery anyway, so "web" is the safe default.
+ */
+export function resolveRuntimeShell(
+  override?: "app" | "web",
+): "app" | "web" {
+  if (override === "app" || override === "web") return override;
+  const envHint = process.env.PNEUMA_RUNTIME_SHELL;
+  if (envHint === "app" || envHint === "web") return envHint;
+  return "web";
+}
+
+/**
+ * Build the `pneuma:start` block body — a scene-setting header that names the
+ * mode, the runtime shell, and the backend driving the agent, plus a short
+ * paragraph describing what the user and the agent are doing together here,
+ * plus a pointer to the mode's own SKILL.md for everything else.
+ *
+ * Replaces the old approach where `claudeMdSection` carried full architecture
+ * + core rules inline. Mode-specific guidance now lives in `SKILL.md` and
+ * loads via progressive disclosure; this block is just the orientation pass.
+ *
+ * Pure function — no side effects.
+ *
+ * @param skillConfig — the mode's skill config (provides `mdScene` + `installName`)
+ * @param displayName — human-readable mode name (e.g. "Illustrate"); falls back
+ *   to a title-cased `installName` derivation when empty
+ * @param backendType — "claude-code" or "codex"; defaults to "claude-code" when
+ *   unspecified, matching the rest of the installer
+ * @param runtimeShell — "app" | "web", already resolved
+ */
+export function generatePneumaSection(
+  skillConfig: SkillConfig,
+  displayName: string | undefined,
+  backendType: string | undefined,
+  runtimeShell: "app" | "web",
+): string {
+  const backendLabel = backendType === "codex" ? "codex" : "claude-code";
+  const shellLabel = runtimeShell === "app" ? "App" : "Web";
+  const fallbackDisplay = skillConfig.installName
+    .replace(/^pneuma-/, "")
+    .replace(/(?:^|[-_])(\w)/g, (_, c: string) => " " + c.toUpperCase())
+    .trim();
+  const display = (displayName && displayName.trim()) || fallbackDisplay;
+
+  // Scene paragraph: prefer mdScene; fall back to legacy claudeMdSection's
+  // first paragraph during migration; last-resort generic stub.
+  const scene =
+    pickScene(skillConfig.mdScene) ??
+    pickScene(skillConfig.claudeMdSection) ??
+    `You and the user are collaborating in Pneuma's ${display} workspace. The user watches your work in a live viewer; you read and edit files; the viewer re-renders as files change.`;
+
+  const pointer = `The mode's specific conventions, workflows, and reference material live in the \`${skillConfig.installName}\` skill — read it before your first action of substance. That's how this mode expects you to work.`;
+
+  return [
+    `# Pneuma ${display} Mode · Pneuma ${shellLabel} · driven by ${backendLabel}`,
+    "",
+    scene,
+    "",
+    pointer,
+  ].join("\n");
+}
+
+/**
+ * Extract the first non-empty, non-heading paragraph from a markdown blob.
+ * Used to derive a scene paragraph from legacy `claudeMdSection` content
+ * during migration — when a mode hasn't been ported to `mdScene` yet, we
+ * grab its lead paragraph instead of dumping the full mini-SKILL.md.
+ *
+ * Returns null when nothing usable is found.
+ */
+function pickScene(raw: string | undefined): string | null {
+  if (!raw) return null;
+  const blocks = raw
+    .split(/\n\s*\n/)
+    .map((b) => b.trim())
+    .filter((b) => b.length > 0);
+  for (const block of blocks) {
+    if (block.startsWith("#")) continue; // skip headings
+    if (block.startsWith("-") || block.startsWith("*")) continue; // skip bullet blocks
+    if (block.startsWith("|")) continue; // skip tables
+    if (block.startsWith("```")) continue; // skip code fences
+    if (block.startsWith("{{")) continue; // skip handlebars-only blocks
+    return block;
+  }
+  return null;
+}
+
+/**
+ * Generate the slim Viewer API teaser for CLAUDE.md / AGENTS.md.
+ *
+ * The block names the channels the viewer exposes and the actions the agent
+ * can call — just enough for the agent to know they exist and reach for the
+ * right one. Detailed reference material (locator card schema, scaffold
+ * params, native API module list, proxy preset config) lives in the mode's
+ * own SKILL.md, loaded on demand.
+ *
+ * Pure function — no side effects.
+ *
+ * @param viewerApi — viewerApi config from the mode's manifest
+ * @param installName — the mode's skill install name (e.g. "pneuma-illustrate"),
+ *   used only to point the agent at the right skill for full details
+ * @returns slim markdown body (no marker comments) or empty string when the
+ *   mode declares no viewer API
  */
 export function generateViewerApiSection(
   viewerApi: ViewerApiConfig | undefined,
+  installName?: string,
 ): string {
   if (!viewerApi) return "";
-  const lines: string[] = ["## Viewer API", ""];
-  let hasContent = false;
 
-  // Workspace model
-  if (viewerApi.workspace) {
-    const ws = viewerApi.workspace;
-    const traits: string[] = [];
-    if (ws.ordered) traits.push("ordered");
-    if (ws.multiFile) traits.push("multi-file");
-    if (ws.hasActiveFile) traits.push("active file tracking");
-    lines.push("### Workspace");
-    lines.push(`- Type: ${ws.type}${traits.length > 0 ? ` (${traits.join(", ")})` : ""}`);
-    if (ws.manifestFile) lines.push(`- Index file: ${ws.manifestFile}`);
-    lines.push("");
-    hasContent = true;
+  const actions = viewerApi.actions?.filter((a) => a.agentInvocable) ?? [];
+  const hasScaffold = Boolean(viewerApi.scaffold);
+  const hasContentSets = Boolean(viewerApi.workspace?.supportsContentSets);
+  const hasLocator = Boolean(viewerApi.locatorDescription);
 
-    if (ws.supportsContentSets) {
-      lines.push("### Content Sets");
-      lines.push("This workspace may contain multiple content sets as top-level directories (e.g. en-dark/, ja-light/).");
-      lines.push("The `<viewer-context>` includes a `content-set` attribute. File paths include the content set prefix.");
-      lines.push("Always edit files within the active content set's directory unless asked to work across content sets.");
-      lines.push("");
-    }
+  const lines: string[] = [
+    "## Viewer API",
+    "",
+    "The viewer is your live window into what the user sees, plus a few channels back to them:",
+    "",
+    "- `<viewer-context>` may prefix user messages — it tells you the active file, viewport, and selection. Use it to resolve \"this\", \"here\", \"this row\".",
+    "- `<user-actions>` blocks summarize meaningful UI actions since your last turn.",
+  ];
+
+  if (hasLocator) {
+    lines.push(
+      "- Embed `<viewer-locator label=\"...\" data='{...}' />` cards in your replies for one-click navigation back to what you produced or changed. Post one whenever you create or edit content.",
+    );
   }
 
-  // Actions
-  const actions = viewerApi.actions?.filter((a) => a.agentInvocable) ?? [];
-  if (actions.length > 0) {
+  if (actions.length > 0 || hasScaffold) {
+    lines.push(
+      "- HTTP: `POST $PNEUMA_API/api/viewer/action -H 'Content-Type: application/json' -d '{\"actionId\":\"...\",\"params\":{...}}'` invokes the actions table below.",
+    );
+  }
+
+  lines.push(
+    "- HTTP: `$PNEUMA_API/api/native/*` exposes desktop APIs (clipboard, shell, notifications, ...) when running inside Pneuma App. Discover via `GET /api/native`; absent on web.",
+  );
+
+  lines.push("");
+
+  if (actions.length > 0 || hasScaffold) {
     lines.push("### Actions");
-    lines.push("");
-    lines.push("The viewer supports these operations. Invoke via Bash:");
-    lines.push("`curl -s -X POST $PNEUMA_API/api/viewer/action -H 'Content-Type: application/json' -d '{\"actionId\":\"<id>\",\"params\":{...}}'`");
     lines.push("");
     lines.push("| Action | Description | Params |");
     lines.push("|--------|-------------|--------|");
@@ -664,140 +781,75 @@ export function generateViewerApiSection(
       }
       lines.push(`| \`${action.id}\` | ${action.description || action.label} | ${paramDescs.join(", ") || "—"} |`);
     }
-    lines.push("");
-    hasContent = true;
-  }
-
-  // Scaffold
-  if (viewerApi.scaffold) {
-    const sc = viewerApi.scaffold;
-    lines.push("### Scaffold");
-    lines.push("");
-    lines.push(`${sc.description} **Requires user confirmation in browser.**`);
-    lines.push("");
-    lines.push("Invoke via the viewer action API:");
-    lines.push("`curl -s -X POST $PNEUMA_API/api/viewer/action -H 'Content-Type: application/json' -d '{\"actionId\":\"scaffold\",\"params\":{...}}'`");
-    lines.push("");
-    const paramEntries = Object.entries(sc.params);
-    if (paramEntries.length > 0) {
-      lines.push("| Param | Type | Required | Description |");
-      lines.push("|-------|------|----------|-------------|");
-      for (const [name, p] of paramEntries) {
-        lines.push(`| \`${name}\` | ${p.type} | ${p.required ? "yes" : "no"} | ${p.description} |`);
-      }
-      lines.push("");
+    if (hasScaffold) {
+      const sc = viewerApi.scaffold!;
+      lines.push(
+        `| \`scaffold\` | ${sc.description} (requires user confirmation in browser) | see skill |`,
+      );
     }
-    lines.push(`Clears: ${sc.clearPatterns.map((p) => `\`${p}\``).join(", ")}`);
     lines.push("");
-    hasContent = true;
   }
 
-  // Locator cards
-  if (viewerApi.locatorDescription) {
-    lines.push("### Locator Cards");
+  if (hasContentSets) {
+    lines.push(
+      "This workspace supports **content sets** — top-level directories as switchable projects. The `<viewer-context>` carries a `content-set` attribute; file paths include the prefix. Stay inside the active set unless asked otherwise.",
+    );
     lines.push("");
-    lines.push("You may embed clickable navigation cards in your messages using this tag:");
-    lines.push("`<viewer-locator label=\"Display Label\" data='{\"key\":\"value\"}' />`");
-    lines.push("");
-    lines.push(viewerApi.locatorDescription);
-    lines.push("");
-    lines.push("When the user clicks a locator card, the viewer navigates to that location.");
-    lines.push("");
-    lines.push("**Always** embed locator cards at the end of your response when you create or edit content. The user may have navigated away while you were working — locators let them jump directly to what changed.");
-    lines.push("");
-    hasContent = true;
   }
 
-  if (!hasContent) return "";
+  if (installName) {
+    lines.push(
+      `Locator card schema, scaffold params, the full native-API module list, and any proxy presets live in the \`${installName}\` skill — read it before your first call into one of these channels.`,
+    );
+  }
 
-  // Viewer context format description (prepend after header)
-  const contextLines = [
-    "### Viewer Context",
-    "",
-    "Each user message may be prefixed with a `<viewer-context>` block.",
-    "It describes what the user is currently seeing — the active file, viewport position, and selected elements.",
-    'Use this to resolve references like "this page", "here", "this section" in user messages.',
-    "",
-    "### User Actions",
-    "",
-    "Messages may include a `<user-actions>` block listing significant actions",
-    "the user performed in the viewer since the last message.",
-    "Use this to understand workspace state changes that happened outside of your edits.",
-    "",
-  ];
-  lines.splice(2, 0, ...contextLines);
-
-  return lines.join("\n");
+  return lines.join("\n").trimEnd();
 }
 
 /**
- * Generate a CLAUDE.md section describing the proxy mechanism.
- * Only generated when the mode declares proxy config (manifest.proxy).
- * Modes without proxy config don't need this — their viewers don't fetch external APIs.
+ * Generate the slim Proxy preset summary appended to the viewer-api block.
+ *
+ * Modes that declare proxy presets need the agent to know the preset names
+ * (so it can write `fetch("/proxy/<name>/...")` correctly). Anything beyond
+ * that — headers, methods, runtime overrides via `proxy.json` — lives in the
+ * mode's SKILL.md.
  *
  * Pure function — no side effects.
  */
 export function generateProxySection(
   proxy: Record<string, import("../core/types/mode-manifest.js").ProxyRoute> | undefined,
 ): string {
-  if (!proxy) return "";
-
-  const hasPresets = Object.keys(proxy).length > 0;
+  if (!proxy || Object.keys(proxy).length === 0) return "";
 
   const lines: string[] = [
-    "### Proxy",
+    "### Proxy presets",
     "",
-    "The runtime provides a reverse proxy at `/proxy/<name>/<path>` to avoid CORS issues when viewer code fetches external APIs.",
-    "**Always use the proxy for external API access** — never use absolute URLs directly in viewer code.",
+    "Use `fetch(\"/proxy/<name>/path\")` in viewer code to avoid CORS when calling external APIs. This mode preconfigures:",
     "",
+    "| Name | Target |",
+    "|------|--------|",
   ];
-
-  // Preset routes table
-  if (hasPresets) {
-    lines.push("**Available proxies (from mode defaults):**");
-    lines.push("");
-    lines.push("| Name | Target | Description |");
-    lines.push("|------|--------|-------------|");
-    for (const [name, route] of Object.entries(proxy)) {
-      lines.push(`| \`${name}\` | \`${route.target}\` | ${route.description ?? "—"} |`);
-    }
-    lines.push("");
-    lines.push("**Usage in viewer code:**");
-    lines.push(`- Example: \`fetch("/proxy/${Object.keys(proxy)[0]}/path/to/resource")\``);
-  } else {
-    lines.push("**Usage in viewer code:**");
-    lines.push("- Example: `fetch(\"/proxy/myapi/path/to/resource\")`");
+  for (const [name, route] of Object.entries(proxy)) {
+    lines.push(`| \`${name}\` | \`${route.target}\` |`);
   }
   lines.push("");
-
-  // Adding new proxies — use fenced code block to avoid template resolution
-  lines.push("**Adding or overriding proxies at runtime:**");
-  lines.push("Write `proxy.json` in workspace root (takes effect immediately, no restart).");
-  lines.push("Fields: `target` (required, upstream base URL), `headers` (optional, supports env var templates), `methods` (optional, defaults to GET only).");
-  lines.push("");
+  lines.push(
+    "Headers, allowed methods, and how to register additional presets via `proxy.json` are documented in the mode's skill.",
+  );
 
   return lines.join("\n");
 }
 
 /**
- * Generate a CLAUDE.md section describing the native bridge API.
- * Always injected — the API gracefully returns "not available" in non-desktop environments.
+ * The native bridge gets a one-line callout in the viewer-api teaser; the
+ * channel list there already names `/api/native/*`. This generator returns
+ * empty so the existing append site stays a no-op.
+ *
+ * Kept exported for backward compatibility with callers that still invoke it
+ * (notably `installSkill`); will be deleted once the call site is removed.
  */
 export function generateNativeBridgeSection(): string {
-  return [
-    "### Native Desktop APIs",
-    "",
-    "The runtime provides native desktop capabilities via `/api/native/`. Available when running inside the Pneuma desktop app.",
-    "",
-    "**Discovery:** `curl -s $PNEUMA_API/api/native` — returns `{ available: true, capabilities: { module: [methods...] } }` or `{ available: false }`.",
-    "Always check this first to see what's available — the capability list is dynamic and auto-generated from Electron modules.",
-    "",
-    "**Invoke:** `curl -s -X POST $PNEUMA_API/api/native/<module>/<method> -H 'Content-Type: application/json' -d '[...args]'`",
-    "Returns `{ ok: true, result: ... }` or `{ ok: false, error: \"...\" }`.",
-    "",
-    "**Common modules:** `clipboard` (readText, writeText, readImage→base64, writeImage←base64, ...), `shell` (openPath, openExternal, ...), `app` (getVersion, getPath, ...), `system` (platform, cpus, totalMemory, hostname, ...), `screen`, `nativeTheme`, `notification` (show, isSupported), `window` (minimize, maximize, setAlwaysOnTop, getBounds, ...)",
-    "",
-  ].join("\n");
+  return "";
 }
 
 /**
@@ -1063,6 +1115,22 @@ export interface InstallSkillOptions {
    * project section. Required if `projectRoot` is set.
    */
   sessionId?: string;
+  /**
+   * Runtime shell label for the `pneuma:start` header — "app" when running
+   * inside the Pneuma Electron desktop app, "web" otherwise. Defaults to "web"
+   * when undefined. The launcher is the source of truth and forwards this to
+   * per-session children; if the launcher itself doesn't know, "web" is the
+   * safe default (the agent learns the actual shell capabilities through
+   * `/api/native` discovery anyway).
+   */
+  runtimeShell?: "app" | "web";
+  /**
+   * Mode display name (e.g. "Illustrate") for the `pneuma:start` header
+   * title. Falls back to a title-cased derivation of `skillConfig.installName`
+   * when omitted, but callers should pass the manifest's `displayName` so the
+   * header reads naturally.
+   */
+  displayName?: string;
 }
 
 /**
@@ -1171,11 +1239,22 @@ export function installSkill(options: InstallSkillOptions): void {
     content = readFileSync(primaryInstructionsPath, "utf-8");
   }
 
-  let sectionContent = skillConfig.claudeMdSection;
+  // 2a. Build the `pneuma:start` block — scene-setting header (mode name +
+  //     runtime shell + backend), short scene paragraph, and a pointer back
+  //     to the mode's SKILL.md for everything else. Mode-specific guidance
+  //     (architecture, core rules, workflows) lives in SKILL.md and loads
+  //     via progressive disclosure — see docs/reference/controlled-state-surface.md.
+  const shellLabel = resolveRuntimeShell(options.runtimeShell);
+  let sceneBody = generatePneumaSection(
+    skillConfig,
+    options.displayName,
+    backendType,
+    shellLabel,
+  );
   if (params && Object.keys(params).length > 0) {
-    sectionContent = applyTemplateParams(sectionContent, params);
+    sceneBody = applyTemplateParams(sceneBody, params);
   }
-  const claudeMdSection = `${PNEUMA_MARKER_START}\n${sectionContent}\n${PNEUMA_MARKER_END}`;
+  const claudeMdSection = `${PNEUMA_MARKER_START}\n${sceneBody}\n${PNEUMA_MARKER_END}`;
 
   // Check if pneuma section already exists
   const startIdx = content.indexOf(PNEUMA_MARKER_START);
@@ -1194,19 +1273,16 @@ export function installSkill(options: InstallSkillOptions): void {
     content += "\n" + claudeMdSection + "\n";
   }
 
-  // 2b. Inject/update Viewer API section (independent marker, Viewer-owned)
-  let viewerApiContent = generateViewerApiSection(viewerApi);
+  // 2b. Inject/update Viewer API section (independent marker, Viewer-owned).
+  //     The slim teaser names the channels and lists the agent-callable
+  //     actions; deeper reference (locator schema, scaffold params, native
+  //     module list, proxy headers) lives in the mode's SKILL.md.
+  let viewerApiContent = generateViewerApiSection(viewerApi, skillConfig.installName);
   const proxyContent = generateProxySection(proxyConfig);
   if (proxyContent) {
     viewerApiContent = viewerApiContent
-      ? viewerApiContent + "\n" + proxyContent
+      ? viewerApiContent + "\n\n" + proxyContent
       : proxyContent;
-  }
-  const nativeContent = generateNativeBridgeSection();
-  if (nativeContent) {
-    viewerApiContent = viewerApiContent
-      ? viewerApiContent + "\n" + nativeContent
-      : nativeContent;
   }
   if (viewerApiContent) {
     const viewerSection = `${VIEWER_API_MARKER_START}\n${viewerApiContent}\n${VIEWER_API_MARKER_END}`;
@@ -1224,16 +1300,19 @@ export function installSkill(options: InstallSkillOptions): void {
     }
   }
 
-  // 2c. Inject/update skills dependency section
+  // 2c. Inject/update skills dependency section.
+  //     The host already auto-discovers skills under `.claude/skills/` (or
+  //     `.agents/skills/`) via their SKILL.md frontmatter — this block exists
+  //     so the agent has a quick mental map of what's installed alongside the
+  //     mode skill named in the `pneuma:start` block. Trigger logic for each
+  //     entry stays in its own SKILL.md description.
   if (skillSnippets.length > 0) {
     const skillsContent = [
-      "## Available Skills",
-      "",
-      "The following skills are installed and available for use:",
+      "## Skills available",
       "",
       ...skillSnippets,
       "",
-      "Use `/<skill-name>` to invoke these skills.",
+      "Read each skill's SKILL.md when its description matches what you're about to do — the host has already loaded their frontmatter into your available-skills list.",
     ].join("\n");
     const skillsSection = `${SKILLS_MARKER_START}\n${skillsContent}\n${SKILLS_MARKER_END}`;
     const sStart = content.indexOf(SKILLS_MARKER_START);

--- a/server/skill-installer.ts
+++ b/server/skill-installer.ts
@@ -738,7 +738,13 @@ export function generateViewerApiSection(
   const actions = viewerApi.actions?.filter((a) => a.agentInvocable) ?? [];
   const hasScaffold = Boolean(viewerApi.scaffold);
   const hasContentSets = Boolean(viewerApi.workspace?.supportsContentSets);
-  const hasLocator = Boolean(viewerApi.locatorDescription);
+  // Locator cards are a runtime-universal feature — every mode that has any
+  // viewer surface can use them. The legacy `locatorDescription` flag was a
+  // mode-side opt-in for the old verbose section; under the slim teaser the
+  // wrapper syntax is universal and the mode-specific `data` schema lives in
+  // each mode's SKILL.md. Always emit the channel bullet so the agent doesn't
+  // hallucinate a different card-tag syntax from training-data priors.
+  const hasLocator = true;
 
   const lines: string[] = [
     "## Viewer API",
@@ -750,8 +756,15 @@ export function generateViewerApiSection(
   ];
 
   if (hasLocator) {
+    // Use a fully-concrete example, not a `<...>` placeholder. Empirically, an
+    // abstract `<viewer-locator label="..." data='{...}' />` template gets
+    // overridden by training-data priors for `::admonition::` / RST / Docusaurus
+    // card syntaxes — the agent invents its own wrapper. Anchoring with a real
+    // tag the agent can copy-paste prevents that. The `data` keys still vary
+    // per mode, so the schema pointer at the end stays.
+    const skillRef = installName ? `the \`${installName}\` skill` : "the mode's skill";
     lines.push(
-      "- Embed `<viewer-locator label=\"...\" data='{...}' />` cards in your replies for one-click navigation back to what you produced or changed. Post one whenever you create or edit content.",
+      `- Post \`<viewer-locator>\` cards for one-click navigation back to what you produced — self-closing HTML, e.g. \`<viewer-locator label="Open the result" data='{"key":"value"}' />\`. The \`data\` keys are mode-specific; ${skillRef} names this mode's schema.`,
     );
   }
 


### PR DESCRIPTION
## Summary

Reframe per-session CLAUDE.md / AGENTS.md generation around progressive disclosure. Instead of inlining each mode's full architecture, core rules, and viewer-API reference into ~150 lines of permanent context every turn, the instructions file is now a slim **scene-setter** that orients the agent and points at the mode's own `SKILL.md` (loaded on demand by Claude Code / Codex's host).

Two commits: (1) installer + type contract + tests; (2) mass migration of 13 modes.

## Empirical effect

Smoke-tested with 3 modes:

| Mode / config | Before | After |
|---|---|---|
| doc / quick / web / claude-code | ~80 lines | **46 lines** |
| illustrate / quick / app / claude-code | ~150 lines | **54 lines** |
| slide / project / web / codex (AGENTS.md) | ~150 lines | **54 lines** |

## What changed

**`pneuma:start` block** — was the verbose mode-prompt dump; now scene-setting:
- Title `# Pneuma {DisplayName} Mode · Pneuma {Web|App} · driven by {claude-code|codex}`
- 2-3 sentence scene paragraph (from new `SkillConfig.mdScene` field)
- Pointer line: \`The mode's specific conventions, workflows, and reference material live in the \`<install-name>\` skill\`

**`pneuma:viewer-api` block** — was 70+ lines of reference material; now a slim teaser:
- Channel list (`<viewer-context>`, `<user-actions>`, `<viewer-locator>`, `POST /api/viewer/action`, `/api/native/*`)
- Mode-specific actions table from `viewerApi.actions`
- Content-set hint when applicable
- Skill pointer for details (locator card schema, scaffold params, native API module list, proxy headers)

**`pneuma:skills` block** — trimmed; removed redundant Claude-Code-already-knows preamble.

**`pneuma:preferences` block** — added framing intro: *"these are hard constraints — extracted from `~/.pneuma/preferences/` so you can't miss them; the full preference picture lives in those files via the `pneuma-preferences` skill"*.

**Native bridge & proxy** — folded into the viewer-api channel list. Standalone "Native Desktop APIs" section gone. Proxy presets table only emitted when mode declares presets.

## Type contract

- `SkillConfig.mdScene?: string` (new) — canonical 2-3 sentence scene paragraph
- `SkillConfig.claudeMdSection?: string` — now optional, deprecated; `pickScene()` extracts a fallback first-paragraph during migration
- `ViewerApiConfig.locatorDescription?: string` — deprecated; mode-specific locator markup now lives in each mode's SKILL.md
- `InstallSkillOptions.runtimeShell?: "app" | "web"` (new) — resolved from `PNEUMA_RUNTIME_SHELL` env var, defaults to "web"
- `InstallSkillOptions.displayName?: string` (new) — passed from manifest at all 6 install sites

## Mode migration (13 modes)

Each mode's `claudeMdSection` content moved into its `SKILL.md`, with deduplication against existing content. `viewerApi.locatorDescription` content moved to a `## Locator cards` section in each SKILL.md with concrete `<viewer-locator>` examples. `mdScene` written for each mode in scene voice (not imperative).

\`{{handlebars}}\` template params (e.g. `{{#imageGenEnabled}}`, `{{slideWidth}}`, `{{paperSize}}`) preserved verbatim in their new SKILL.md homes — installer still applies template substitution on install.

## Test plan

- [x] `bun test` — 929 pass, 0 fail (was 921/9 mid-rewrite)
- [x] Smoke test: drove `installSkill()` directly for doc / illustrate / slide × {quick, project} × {claude-code, codex} × {web, app}; inspected generated CLAUDE.md / AGENTS.md
- [ ] Manual session in launcher — verify slide / illustrate / doc actually feel right when an agent reads the new CLAUDE.md (recommend reviewer try one of each)
- [ ] Sanity-check the migrated SKILL.md files for tone/duplication after subagent merges

## Notes for review

- The `mdScene` paragraphs were written by Opus subagents per-mode; reviewer eye on tone is welcome
- `claudeMdSection` field is **optional/deprecated**, not removed — that lets external mode authors migrate at their own pace; can be deleted in a future PR after a deprecation cycle
- Existing `docs/reference/controlled-state-surface.md` still describes the **old** marker-block model; update needed in a follow-up doc PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)