### PR TITLE
feat(pneuma:start): worldview intro + session boot priority

### DIFF
--- a/server/__tests__/e2e-skill-effectiveness.test.ts
+++ b/server/__tests__/e2e-skill-effectiveness.test.ts
@@ -61,7 +61,7 @@ describe("skill installation → CLAUDE.md skill reference", () => {
 
     const claudeMd = readFileSync(join(ws, "CLAUDE.md"), "utf-8");
     expect(claudeMd).toContain("`pneuma-doc` skill");
-    expect(claudeMd).toContain("read it before your first action of substance");
+    expect(claudeMd).toContain("pull it in when you're about to act on a substantive task");
   });
 
   it("draw mode: CLAUDE.md directs agent to consult skill", () => {
@@ -77,7 +77,7 @@ describe("skill installation → CLAUDE.md skill reference", () => {
 
     const claudeMd = readFileSync(join(ws, "CLAUDE.md"), "utf-8");
     expect(claudeMd).toContain("`pneuma-draw` skill");
-    expect(claudeMd).toContain("read it before your first action of substance");
+    expect(claudeMd).toContain("pull it in when you're about to act on a substantive task");
   });
 
   it("slide mode: CLAUDE.md directs agent to consult skill", () => {
@@ -93,7 +93,7 @@ describe("skill installation → CLAUDE.md skill reference", () => {
 
     const claudeMd = readFileSync(join(ws, "CLAUDE.md"), "utf-8");
     expect(claudeMd).toContain("`pneuma-slide` skill");
-    expect(claudeMd).toContain("read it before your first action of substance");
+    expect(claudeMd).toContain("pull it in when you're about to act on a substantive task");
   });
 
   it("mode-maker: CLAUDE.md directs agent to consult skill", () => {
@@ -109,7 +109,7 @@ describe("skill installation → CLAUDE.md skill reference", () => {
 
     const claudeMd = readFileSync(join(ws, "CLAUDE.md"), "utf-8");
     expect(claudeMd).toContain("`pneuma-mode-maker` skill");
-    expect(claudeMd).toContain("read it before your first action of substance");
+    expect(claudeMd).toContain("pull it in when you're about to act on a substantive task");
   });
 });
 

--- a/server/__tests__/webcraft-e2e.test.ts
+++ b/server/__tests__/webcraft-e2e.test.ts
@@ -432,7 +432,7 @@ describe("CLAUDE.md injection", () => {
     const claudeMd = readFileSync(join(ws, "CLAUDE.md"), "utf-8");
     // The pneuma:start block ends with a pointer line that names the skill.
     expect(claudeMd).toContain("`pneuma-webcraft` skill");
-    expect(claudeMd).toContain("read it before your first action of substance");
+    expect(claudeMd).toContain("pull it in when you're about to act on a substantive task");
   });
 
   // Removed: "has Core Rules section in CLAUDE.md".

--- a/server/skill-installer.ts
+++ b/server/skill-installer.ts
@@ -676,7 +676,18 @@ export function generatePneumaSection(
     pickScene(skillConfig.claudeMdSection) ??
     `You and the user are collaborating in Pneuma's ${display} workspace. The user watches your work in a live viewer; you read and edit files; the viewer re-renders as files change.`;
 
-  const pointer = `The mode's specific conventions, workflows, and reference material live in the \`${skillConfig.installName}\` skill — read it before your first action of substance. That's how this mode expects you to work.`;
+  // Pointer + read-priority hint, fused.
+  //
+  // Why fused: the prior version emitted a one-line "read this skill first"
+  // pointer, leaving the agent to figure out what *else* to read on its own.
+  // In practice that meant either over-reading (load atlas + README + sibling
+  // dirs on every cold start, burning context) or under-reading (skip the
+  // skill until late, then backtrack). The hint below orients on a single
+  // pass: the user's actual ask is the work; the mode skill is the procedure
+  // for substantive moves; everything else is loaded on demand. It refuses to
+  // be a "MUST read all of this before responding" rule — that would just
+  // recreate the over-reading failure mode it's trying to prevent.
+  const pointer = `The mode's specific conventions, workflows, and reference material live in the \`${skillConfig.installName}\` skill — pull it in when you're about to act on a substantive task. Read on a need-to-know basis: start with the user's actual ask, reach for this skill when you're about to act, and load wider surfaces (project atlas, sibling sessions, README) only when the task calls for them. You don't need to warm up before talking back.`;
 
   return [
     `# Pneuma ${display} Mode · Pneuma ${shellLabel} · driven by ${backendLabel}`,

--- a/server/skill-installer.ts
+++ b/server/skill-installer.ts
@@ -690,9 +690,13 @@ export function generatePneumaSection(
   const pointer = `The mode's specific conventions, workflows, and reference material live in the \`${skillConfig.installName}\` skill — pull it in when you're about to act on a substantive task. Read on a need-to-know basis: start with the user's actual ask, reach for this skill when you're about to act, and load wider surfaces (project atlas, sibling sessions, README) only when the task calls for them. You don't need to warm up before talking back.`;
 
   return [
-    PNEUMA_PREAMBLE,
+    PNEUMA_INTRO,
     "",
-    `# Pneuma ${display} Mode · Pneuma ${shellLabel} · driven by ${backendLabel}`,
+    `_Session runtime: Pneuma ${shellLabel} · driven by ${backendLabel}._`,
+    "",
+    PNEUMA_THESIS,
+    "",
+    `# Pneuma ${display} Mode`,
     "",
     scene,
     "",
@@ -701,26 +705,30 @@ export function generatePneumaSection(
 }
 
 /**
- * Position-setting preamble that prefaces every per-mode `pneuma:start`
- * block. Three sentences: what Pneuma does (a position, not a definition),
- * what stays unchanged (the agent's actual work), what's amplified (the
- * user's observability of that work).
+ * Three pieces of always-on context emitted at the top of every per-mode
+ * `pneuma:start` block, in this order:
  *
- * Why this shape: the prior version was descriptive — "Pneuma is a
- * co-creation environment where you and a user work on files together…".
- * That tells the agent what kind of thing Pneuma is. It doesn't tell the
- * agent where to stand. The new shape opens with what Pneuma does to the
- * agent's surroundings (turns files into a player), then names what
- * stays the same (the work) and what changes (observability). From that
- * position, the right behavior — keep doing your work, post locator cards
- * when something landed, don't perform for the chat — is inferable.
+ *   1. INTRO — one sentence naming what Pneuma is. The agent reads this
+ *      before anything else mentions "Pneuma's harness", so the later
+ *      thesis paragraph isn't grounded in an undefined term.
+ *   2. Runtime metadata line — italicized "Session runtime: Pneuma Web ·
+ *      driven by claude-code", composed at call time. Used to live in the
+ *      mode H1 ("# Pneuma {Mode} Mode · Pneuma Web · driven by claude-code")
+ *      but mashing three orthogonal facts into one heading reads weird;
+ *      pulled out as metadata so the H1 carries only the mode identity.
+ *   3. THESIS — the position-setting paragraph: what the harness does
+ *      (turns files into a player), what stays the same (the work), what's
+ *      amplified (the user's observability of that work). From that
+ *      position the right behavior is inferable — no rule list needed.
  *
  * The "player" framing reuses the project's existing vocabulary (viewers
  * are live players for agent output) rather than introducing a new
  * metaphor. Mode-specific tone lives in `mdScene`; behavior procedures
  * live in the mode SKILL.md.
  */
-const PNEUMA_PREAMBLE = `**Pneuma**'s harness does one specific thing: it turns the files you're editing into a human-readable player in real time — a deck, a board, a project — so the user can watch your work, select things on it, hand you context, or step in when they need to. The work itself is the same as anywhere else. What's amplified is the user's ability to see it happen.`;
+const PNEUMA_INTRO = `**Pneuma** is a co-creation environment where you do the work and a human user watches it happen — typically through a mode-specific live player they can interact with.`;
+
+const PNEUMA_THESIS = `Pneuma's harness does one specific thing: it turns the files you're editing into that player in real time — a deck, a board, a project — so the user can watch your work, select things on it, hand you context, or step in when they need to. The work itself is the same as anywhere else. What's amplified is the user's ability to see it happen.`;
 
 /**
  * Extract the first non-empty, non-heading paragraph from a markdown blob.

--- a/server/skill-installer.ts
+++ b/server/skill-installer.ts
@@ -702,30 +702,21 @@ export function generatePneumaSection(
 
 /**
  * What-is-Pneuma orientation that prefaces every per-mode `pneuma:start`
- * block. Two parts: a single-sentence definition of the system, then three
- * behavior-shaping axioms.
+ * block. A single sentence — the kind of place this is and how the loop
+ * works.
  *
- * Why this lives in the always-on prompt rather than a skill:
- * - It applies to every mode, every session, every backend. Sinking it into
- *   one of the per-mode skills would force every other skill to either
- *   duplicate it or hope the agent loaded the right one first.
- * - It's framed as orientation, not procedure — there's nothing for the
- *   agent to "lazy-load" on demand. Behavior axioms work by being read once
- *   on entry; if the agent is already 5 turns in and hasn't internalized
- *   them, loading them late doesn't help.
+ * Why one sentence and no more: the bet underneath Pneuma is that the user
+ * "rides along" rather than delegates-or-supervises. That framing is the
+ * actual worldview the agent needs to enter the session correctly. Once
+ * stated, everything else (don't abstract files, don't roleplay, lazy
+ * loading is fine) is inferable from working in such a place — adding
+ * axioms about it just turns the orientation into a rule list and primes
+ * the agent to read the environment as constraints rather than a context.
  *
- * The axioms are deliberately three (covers files-as-surface, agent-identity,
- * lazy/iterative posture). More than that and they stop being axioms; fewer
- * and the agent has to extrapolate. Resist the urge to add safety MUSTs
- * here — those belong in the preferences excerpt or the mode skill.
+ * Mode-specific tone, behavior, and procedure live in `mdScene` and the
+ * mode SKILL.md respectively.
  */
-const PNEUMA_PREAMBLE = `**Pneuma** is a co-creation environment where you and a human user work on the same files together — you read/edit/write through your normal tools, they watch a live viewer of your output and can select, hand you context, or steer along the way.
-
-A few axioms that orient how to be useful here:
-
-- **Files are the canonical surface.** The work IS the files; don't abstract them away or build wrappers around them.
-- **You're you.** No different persona — same judgment, same skills, just collaborating in a place built for shared observation.
-- **Lazy is fine; small wrong turns are cheap.** Pull skills, atlas, README in when the task asks for them; the user can see what you're doing live and redirect mid-flight, so you don't need to nail it in one shot.`;
+const PNEUMA_PREAMBLE = `**Pneuma** is a co-creation environment where you and a human user work on the same files together — you read/edit/write through your normal tools, they watch a live viewer of your output and can select, hand you context, or steer along the way.`;
 
 /**
  * Extract the first non-empty, non-heading paragraph from a markdown blob.

--- a/server/skill-installer.ts
+++ b/server/skill-installer.ts
@@ -690,6 +690,8 @@ export function generatePneumaSection(
   const pointer = `The mode's specific conventions, workflows, and reference material live in the \`${skillConfig.installName}\` skill — pull it in when you're about to act on a substantive task. Read on a need-to-know basis: start with the user's actual ask, reach for this skill when you're about to act, and load wider surfaces (project atlas, sibling sessions, README) only when the task calls for them. You don't need to warm up before talking back.`;
 
   return [
+    PNEUMA_PREAMBLE,
+    "",
     `# Pneuma ${display} Mode · Pneuma ${shellLabel} · driven by ${backendLabel}`,
     "",
     scene,
@@ -697,6 +699,33 @@ export function generatePneumaSection(
     pointer,
   ].join("\n");
 }
+
+/**
+ * What-is-Pneuma orientation that prefaces every per-mode `pneuma:start`
+ * block. Two parts: a single-sentence definition of the system, then three
+ * behavior-shaping axioms.
+ *
+ * Why this lives in the always-on prompt rather than a skill:
+ * - It applies to every mode, every session, every backend. Sinking it into
+ *   one of the per-mode skills would force every other skill to either
+ *   duplicate it or hope the agent loaded the right one first.
+ * - It's framed as orientation, not procedure — there's nothing for the
+ *   agent to "lazy-load" on demand. Behavior axioms work by being read once
+ *   on entry; if the agent is already 5 turns in and hasn't internalized
+ *   them, loading them late doesn't help.
+ *
+ * The axioms are deliberately three (covers files-as-surface, agent-identity,
+ * lazy/iterative posture). More than that and they stop being axioms; fewer
+ * and the agent has to extrapolate. Resist the urge to add safety MUSTs
+ * here — those belong in the preferences excerpt or the mode skill.
+ */
+const PNEUMA_PREAMBLE = `**Pneuma** is a co-creation environment where you and a human user work on the same files together — you read/edit/write through your normal tools, they watch a live viewer of your output and can select, hand you context, or steer along the way.
+
+A few axioms that orient how to be useful here:
+
+- **Files are the canonical surface.** The work IS the files; don't abstract them away or build wrappers around them.
+- **You're you.** No different persona — same judgment, same skills, just collaborating in a place built for shared observation.
+- **Lazy is fine; small wrong turns are cheap.** Pull skills, atlas, README in when the task asks for them; the user can see what you're doing live and redirect mid-flight, so you don't need to nail it in one shot.`;
 
 /**
  * Extract the first non-empty, non-heading paragraph from a markdown blob.

--- a/server/skill-installer.ts
+++ b/server/skill-installer.ts
@@ -701,22 +701,26 @@ export function generatePneumaSection(
 }
 
 /**
- * What-is-Pneuma orientation that prefaces every per-mode `pneuma:start`
- * block. A single sentence — the kind of place this is and how the loop
- * works.
+ * Position-setting preamble that prefaces every per-mode `pneuma:start`
+ * block. Three sentences: what Pneuma does (a position, not a definition),
+ * what stays unchanged (the agent's actual work), what's amplified (the
+ * user's observability of that work).
  *
- * Why one sentence and no more: the bet underneath Pneuma is that the user
- * "rides along" rather than delegates-or-supervises. That framing is the
- * actual worldview the agent needs to enter the session correctly. Once
- * stated, everything else (don't abstract files, don't roleplay, lazy
- * loading is fine) is inferable from working in such a place — adding
- * axioms about it just turns the orientation into a rule list and primes
- * the agent to read the environment as constraints rather than a context.
+ * Why this shape: the prior version was descriptive — "Pneuma is a
+ * co-creation environment where you and a user work on files together…".
+ * That tells the agent what kind of thing Pneuma is. It doesn't tell the
+ * agent where to stand. The new shape opens with what Pneuma does to the
+ * agent's surroundings (turns files into a player), then names what
+ * stays the same (the work) and what changes (observability). From that
+ * position, the right behavior — keep doing your work, post locator cards
+ * when something landed, don't perform for the chat — is inferable.
  *
- * Mode-specific tone, behavior, and procedure live in `mdScene` and the
- * mode SKILL.md respectively.
+ * The "player" framing reuses the project's existing vocabulary (viewers
+ * are live players for agent output) rather than introducing a new
+ * metaphor. Mode-specific tone lives in `mdScene`; behavior procedures
+ * live in the mode SKILL.md.
  */
-const PNEUMA_PREAMBLE = `**Pneuma** is a co-creation environment where you and a human user work on the same files together — you read/edit/write through your normal tools, they watch a live viewer of your output and can select, hand you context, or steer along the way.`;
+const PNEUMA_PREAMBLE = `**Pneuma**'s harness does one specific thing: it turns the files you're editing into a human-readable player in real time — a deck, a board, a project — so the user can watch your work, select things on it, hand you context, or step in when they need to. The work itself is the same as anywhere else. What's amplified is the user's ability to see it happen.`;
 
 /**
  * Extract the first non-empty, non-heading paragraph from a markdown blob.


### PR DESCRIPTION
## Summary

Reshape the always-on `pneuma:start` block in CLAUDE.md / AGENTS.md so the agent walking into a fresh session gets oriented in one pass — what kind of place this is, which flavor specifically, what the place does to its work, then which mode it's in.

## Final shape (illustrate / claude-code / web example)

```
**Pneuma** is a co-creation environment where you do the work and a human
user watches it happen — typically through a mode-specific live player
they can interact with.

_Session runtime: Pneuma Web · driven by claude-code._

Pneuma's harness does one specific thing: it turns the files you're
editing into that player in real time — a deck, a board, a project —
so the user can watch your work, select things on it, hand you context,
or step in when they need to. The work itself is the same as anywhere
else. What's amplified is the user's ability to see it happen.

# Pneuma Illustrate Mode

You and the user are creating illustrations together inside Pneuma's
workspace. ...

The mode's specific conventions, workflows, and reference material live
in the `pneuma-illustrate` skill — pull it in when you're about to act
on a substantive task. Read on a need-to-know basis: start with the
user's actual ask, reach for this skill when you're about to act, and
load wider surfaces (project atlas, sibling sessions, README) only when
the task calls for them. You don't need to warm up before talking back.
```

## Reading order, by intent

1. **What kind of place is this?** — one-sentence intro defines Pneuma.
2. **Which flavor specifically?** — italic runtime metadata (Web vs App, claude-code vs codex).
3. **What does the place do to my work?** — thesis paragraph, now grounded because Pneuma was just introduced. Names what's unchanged (the work) and what's amplified (the user's observability).
4. **What am I specifically doing here?** — H1 carries only the mode identity. mdScene gives the in-mode situation. Pointer + boot priority tells how to read the rest.

## Why this shape

Walking through the iterations on this PR:

- **Started**: just a slim "read this skill before X" pointer. Agent had no read order for everything else, so two failure modes appeared: over-read (load atlas + README + siblings on cold start, burn context) or under-read (skip skill until late, backtrack).
- **Added boot priority** to the pointer — start with user's ask, pull skill when about to act, load wider surfaces on demand.
- **Tried adding three axioms** ("files are the surface", "you're you", "lazy is fine") under the intro. Cut them — they were tactical tips dressed as axioms, every one inferable from "co-creation environment" + agent doing real work. Spelling them out turned orientation into a rule list and primed the agent to read the environment as constraints rather than context.
- **Position over description** — opener became "Pneuma's harness does X to your surroundings" rather than "Pneuma is X" + a list of features. The position frames the agent's behavior without imperatives.
- **Reorder** (final commit) — "Pneuma's harness does X" was hitting the agent before "Pneuma" was introduced. Split into intro → runtime metadata → thesis. H1 stopped carrying runtime/backend metadata too — three orthogonal facts mashed into one heading was visually noisy.

The final 4-piece order reads top-to-bottom without backreferencing.

## What didn't change

- No type changes, no manifest churn, no migration step.
- No new metaphors introduced — "player" is the project's existing vocabulary (viewers are live players for agent output).
- No safety MUSTs in the preamble — those belong in the preferences excerpt or the mode skill.
- mdScene + pointer copy unchanged from the boot-hint commit; only their position relative to the surrounding orientation moved.

## Test plan

- [x] `bun test` — 927 pass, 0 fail
- [x] Smoke-tested for illustrate / remotion / webcraft, claude-code / web
- [x] Manually tested in a real session (live launcher on this branch)

## Commits

1. `feat(skill-installer): add session boot priority hint to pneuma:start`
2. `feat(skill-installer): prepend What-is-Pneuma preamble to pneuma:start`
3. `docs(skill-installer): drop the three axioms from pneuma:start preamble`
4. `docs(skill-installer): rewrite pneuma:start preamble as a position, not a definition`
5. `docs(skill-installer): split pneuma:start into intro + runtime + thesis + mode`

🤖 Generated with [Claude Code](https://claude.com/claude-code)