### PR TITLE
fix: post-3.0 polish — sonar discover indicator + viewer-action timeout

### DIFF
--- a/modes/project-onboard/viewer/OnboardPreview.tsx
+++ b/modes/project-onboard/viewer/OnboardPreview.tsx
@@ -579,6 +579,20 @@ function CarouselLoading({ lastError }: { lastError: string | null }) {
           mix-blend-mode: screen;
           pointer-events: none;
         }
+
+        /* Sonar-style "discovering" indicator — a steady center dot
+           plus two concentric rings emanating outward, staggered so a
+           ring is always mid-flight. Reads as active scanning rather
+           than the generic single-dot pulse.
+           Duration is paced calmly (1.6s) so it doesn't compete with
+           the carousel's slower wipe rhythm. */
+        @keyframes pneuma-discover-ping {
+          0%   { transform: scale(0.4); opacity: 0.65; }
+          100% { transform: scale(2.4); opacity: 0;    }
+        }
+        .pneuma-discover-ring {
+          animation: pneuma-discover-ping 1.6s cubic-bezier(0.16, 1, 0.3, 1) infinite;
+        }
       `}</style>
       <div className="h-full overflow-auto bg-zinc-950 text-zinc-200 flex items-center justify-center">
         <div className="w-full max-w-5xl px-8 py-8 flex flex-col items-center gap-6">
@@ -615,9 +629,17 @@ function CarouselLoading({ lastError }: { lastError: string | null }) {
             ) : null}
           </div>
 
-          {/* Status pill — what's actually happening on the backend */}
-          <div className="flex items-center gap-2 text-sm text-zinc-400">
-            <span className="w-1.5 h-1.5 rounded-full bg-orange-500 animate-pulse" aria-hidden />
+          {/* Status pill — what's actually happening on the backend.
+              The indicator is a sonar-style ping: a steady center dot
+              with two outgoing concentric rings, staggered so the
+              motion never rests. Reads as active "scanning" rather
+              than the generic single-dot pulse. */}
+          <div className="flex items-center gap-3 text-sm text-zinc-400">
+            <span className="relative inline-flex w-3 h-3 items-center justify-center" aria-hidden>
+              <span className="absolute inset-0 rounded-full bg-orange-500 pneuma-discover-ring" />
+              <span className="absolute inset-0 rounded-full bg-orange-500 pneuma-discover-ring [animation-delay:0.8s]" />
+              <span className="relative w-1.5 h-1.5 rounded-full bg-orange-500" />
+            </span>
             <span>Discovering your project — a brief is taking shape.</span>
           </div>
 

--- a/server/ws-bridge-viewer.ts
+++ b/server/ws-bridge-viewer.ts
@@ -10,7 +10,21 @@ import type { ViewerActionResult } from "../core/types/viewer-contract.js";
 import type { Session } from "./ws-bridge-types.js";
 import type { BrowserIncomingMessage } from "./session-types.js";
 
-const VIEWER_ACTION_TIMEOUT_MS = 15_000;
+// Default viewer-action timeout. Most actions are sub-second (a navigate,
+// a fit, a thumbnail capture); the timeout is a safety net for hung
+// browsers, not a real upper bound on legitimate work.
+//
+// 15s used to be the default and broke a real scenario: when a Smart
+// Handoff spawns a fresh session and the agent's first turn includes
+// `scaffold` (e.g. "build a 4-page webcraft site"), the call lands
+// while the browser is still navigating to the new per-session URL +
+// loading the mode bundle + reconnecting WS. The 15s window often
+// closed before the viewer could respond, even though the actual
+// scaffold work was milliseconds. 60s gives the boot path room to
+// breathe without making the worst-case "browser permanently dead"
+// experience meaningfully worse — by then the agent's already in
+// trouble for other reasons.
+const VIEWER_ACTION_TIMEOUT_MS = 60_000;
 
 /**
  * Send a viewer action request to the browser and wait for the result.


### PR DESCRIPTION
Two small fixes from real 3.0 dogfooding.

## #2 — Sonar-style "Discovering" indicator

The OnboardPreview status pill used a generic single orange pulse-dot. Replaced with a sonar ping: solid center + two staggered concentric rings emanating outward via a custom \`pneuma-discover-ping\` keyframe. Reads as active *scanning* rather than the generic dot pulse, matching the "Discovering" verb in the copy.

- 1.6s cycle, eased ring expansion (\`cubic-bezier(0.16, 1, 0.3, 1)\`)
- Two rings, second one delayed 0.8s so a ring is always mid-flight
- Same neon orange (\`#f97316\`) as everything else; calm enough to coexist with the carousel's slower wipe rhythm

## #3 — Bump VIEWER_ACTION_TIMEOUT_MS 15s → 60s

Surfaced when a Smart Handoff spawned a fresh webcraft session and the agent's first turn included a \`scaffold\` call:

1. Agent: \`POST /api/viewer/action {actionId: "scaffold", params}\`
2. Server (\`dispatchViewerAction\`): broadcasts \`viewer_action_request\` over WS
3. Browser: still navigating to per-session URL + loading mode bundle + reconnecting WS — viewer not yet mounted
4. 15s passes, server times out before the viewer is alive

Most viewer actions are sub-second (navigate, fit, thumbnail capture, scaffold itself once mounted); the timeout exists as a safety net for permanently-hung browsers, not a real upper bound on legitimate work. 60s leaves the spawn-to-first-action boot path room to breathe; the worst-case "browser never comes back" UX is meaningfully unchanged because the agent is in trouble for other reasons by then.

## Out of scope

Issue #1 (auto-spawn → frontend doesn't reflect "agent running" state) is also reported but appears tied to the \`claude -p\` stream-json transport switch (PR #91), not the 3.0 onboarding work. Triaged separately as it's a state-sync change with broader blast radius.

## Test plan

- [x] \`bun test\` — 927 pass / 0 fail
- [x] No tests pin the old 15s timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)