### PR TITLE
fix(ws): hydrate session UI from cli_busy in session_init snapshot

### DIFF
--- a/server/session-types.ts
+++ b/server/session-types.ts
@@ -420,6 +420,21 @@ export interface SessionState {
   available_models?: { id: string; name?: string }[];
   pid?: number;
   fast_mode_state?: unknown;
+  /**
+   * Whether the agent backend is currently processing a turn.
+   *
+   * Inverted view of the bridge-internal `Session.cliIdle` flag, surfaced
+   * on the wire so a browser that joins a session mid-turn (after a
+   * `Create & discover` auto-spawn, or after a Smart Handoff confirm)
+   * can hydrate `sessionStatus` + `turnInProgress` from the snapshot
+   * instead of waiting for the next `assistant` chunk to figure it out
+   * — and instead of leaving the chat input enabled while the agent is
+   * already streaming.
+   *
+   * Computed at every `session_init` / `session_update` broadcast; not
+   * persisted in `session.state`. Default `false`.
+   */
+  cli_busy?: boolean;
 }
 
 // ─── Permission Types ────────────────────────────────────────────────────────

--- a/server/ws-bridge-codex.ts
+++ b/server/ws-bridge-codex.ts
@@ -42,13 +42,21 @@ export function attachCodexAdapterHandlers(
     if (msg.type === "session_init") {
       session.state = { ...session.state, ...msg.session, backend_type: "codex" };
       deps.persistSession?.(session);
-      // Broadcast merged state (adapter's partial may lack agent_capabilities)
-      deps.broadcastToBrowsers(session, { type: "session_init", session: session.state });
+      // Broadcast merged state (adapter's partial may lack agent_capabilities).
+      // `cli_busy` reflects the bridge-internal cliIdle so a browser that
+      // joins mid-turn can hydrate UI status from the snapshot.
+      deps.broadcastToBrowsers(session, {
+        type: "session_init",
+        session: { ...session.state, cli_busy: !session.cliIdle },
+      });
       return;
     } else if (msg.type === "session_update") {
       session.state = { ...session.state, ...msg.session, backend_type: "codex" };
       deps.persistSession?.(session);
-      deps.broadcastToBrowsers(session, { type: "session_update", session: session.state });
+      deps.broadcastToBrowsers(session, {
+        type: "session_update",
+        session: { ...session.state, cli_busy: !session.cliIdle },
+      });
       return;
     } else if (msg.type === "status_change") {
       session.state.is_compacting = msg.status === "compacting";

--- a/server/ws-bridge.ts
+++ b/server/ws-bridge.ts
@@ -400,10 +400,15 @@ export class WsBridge {
     session.browserSockets.add(ws);
     console.log(`[ws-bridge] Browser connected for session ${sessionId} (${session.browserSockets.size} browsers)`);
 
-    // Send current session state as snapshot
+    // Send current session state as snapshot. `cli_busy` is computed
+    // here (inverse of the internal `cliIdle` flag) so the joining
+    // browser can hydrate `sessionStatus` / `turnInProgress` from the
+    // actual live state — otherwise an auto-spawn (project-onboard)
+    // or post-handoff target would stream into a UI that thinks the
+    // agent is idle.
     const snapshot: BrowserIncomingMessage = {
       type: "session_init",
-      session: session.state,
+      session: { ...session.state, cli_busy: !session.cliIdle },
     };
     this.sendToBrowser(ws, snapshot);
 
@@ -565,7 +570,7 @@ export class WsBridge {
 
       this.broadcastToBrowsers(session, {
         type: "session_init",
-        session: session.state,
+        session: { ...session.state, cli_busy: !session.cliIdle },
       });
 
       // Flush any messages queued before CLI was initialized

--- a/src/ws.ts
+++ b/src/ws.ts
@@ -326,7 +326,16 @@ function handleParsedMessage(data: BrowserIncomingMessage) {
     case "session_init": {
       store.setSession(data.session);
       store.setCliConnected(true);
-      store.setSessionStatus("idle");
+      // Hydrate live status from the snapshot. Without this, a browser
+      // joining a session that's already mid-turn (auto-spawned
+      // project-onboard, post-handoff target, or just a tab refresh
+      // while the agent is processing) hard-codes UI to "idle" + lets
+      // the user type into the chat — even though the agent is
+      // streaming behind the scenes. The server now ships
+      // `cli_busy` on every session_init / session_update broadcast.
+      const isBusy = (data.session as { cli_busy?: boolean }).cli_busy === true;
+      store.setSessionStatus(isBusy ? "running" : "idle");
+      store.setTurnInProgress(isBusy);
       break;
     }
 


### PR DESCRIPTION
Closes the third item from the post-3.0 dogfood report.

## Symptom

When a browser joined a session that was already mid-turn — auto-spawned project-onboard ("Create & discover" path), post-handoff target session, or even just a tab refresh while the agent was processing — the chat input stayed enabled and the top-right indicator showed **"Idle"** while the agent was actually streaming text. Hand-typing a message in that window would race the in-flight turn.

## Root cause

\`SessionState\` (the wire shape sent in \`session_init\`) didn't carry the agent's busy status. The bridge tracks \`cliIdle\` on \`Session\` internally but never published it.

On the client side:
- \`case "session_init"\` hard-coded \`sessionStatus="idle"\` and didn't touch \`turnInProgress\`.
- \`turnInProgress\` only flipped \`true\` via the user-send path (\`ChatInput\`) or the synthetic-user-message broadcast (\`case "user_message"\`).
- When the synthetic env-tag dispatch fired *before* the browser connected, that broadcast was missed; \`message_history\` replays the env tag's content into chat but doesn't restore status flags.

Net effect: a joining browser saw the chat content (via \`message_history\`) but missed the "we're busy" signal.

## Fix

Surface \`cli_busy\` on the wire and hydrate UI from it.

- **\`SessionState\`** gains an optional \`cli_busy?: boolean\` field, computed at broadcast time (\`!session.cliIdle\`), not persisted in \`session.state\`.
- **\`ws-bridge.ts\`** — both \`session_init\` send sites (\`handleBrowserOpen\` for the joining-mid-turn case + the post-init broadcast) now ship \`cli_busy\`.
- **\`ws-bridge-codex.ts\`** — same for both \`session_init\` and \`session_update\` broadcasts.
- **\`src/ws.ts\` case \`"session_init"\`** — derives \`sessionStatus\` + \`turnInProgress\` from \`data.session.cli_busy\`, replacing the hard-coded \`"idle"\`.

This is the snapshot-time fix. Live transitions (assistant message flips status to running, result flips back) keep working as before; the new code only matters at the moment a browser connects to a session that's already running.

## Test plan

- [x] \`bun test\` — 927 pass / 0 fail
- [ ] Manual: \`Create & discover\` on a fresh project → top-right shows **Running** as soon as the page loads (was: "Idle" until the agent's first complete assistant message)
- [ ] Manual: confirm a Smart Handoff → target session shows **Running** while the inbound brief is being processed (was: same idle bug)
- [ ] Manual: refresh a tab mid-turn → status indicator + input disabled state are correct from page load

🤖 Generated with [Claude Code](https://claude.com/claude-code)