### PR TITLE
feat: Mode Libraries — multi-mode GitHub repo distribution + Gallery v2 + favorites

### DIFF
--- a/bin/pneuma.ts
+++ b/bin/pneuma.ts
@@ -23,8 +23,27 @@ import { loadModeManifest, listBuiltinModes, registerExternalMode } from "../cor
 import type { ModeManifest } from "../core/types/mode-manifest.js";
 import type { AgentBackendType } from "../core/types/agent-backend.js";
 import { applyTemplateParams } from "../server/skill-installer.js";
-import { resolveMode as resolveModeSource, isExternalMode } from "../core/mode-resolver.js";
+import {
+  resolveMode as resolveModeSource,
+  resolveModeOrLibrary,
+  isExternalMode,
+} from "../core/mode-resolver.js";
 import type { ResolvedMode } from "../core/mode-resolver.js";
+import {
+  listLibraries,
+  syncLibrary,
+  setModeActivated,
+  unlinkLibrary,
+  getLibraryDir,
+  detectRepoShape,
+  readLibrary,
+} from "../core/library-registry.js";
+import {
+  initLocalLibrary,
+  publishModeToLibrary,
+  pushLibrary,
+} from "../core/library-publish.js";
+import { createRepo } from "../core/github-cli.js";
 import {
   normalizePersistedSession,
   normalizeSessionRecord,
@@ -1050,11 +1069,42 @@ Options:
         process.exit(1);
       }
       try {
-        const resolved = await resolveModeSource(specifier, PROJECT_ROOT);
-        if (resolved.type === "builtin") {
-          p.log.info(`"${resolved.name}" is a built-in mode — no need to add.`);
+        const result = await resolveModeOrLibrary(specifier, PROJECT_ROOT);
+        if (result.kind === "single") {
+          const resolved = result.resolved;
+          if (resolved.type === "builtin") {
+            p.log.info(`"${resolved.name}" is a built-in mode — no need to add.`);
+          } else {
+            p.log.success(`Mode "${resolved.name}" added at ${resolved.path}`);
+          }
         } else {
-          p.log.success(`Mode "${resolved.name}" added at ${resolved.path}`);
+          // Library install: print a one-shot summary of what landed and
+          // which modes are activated by default. Update reports for a
+          // re-link surface added / removed / version-changed modes.
+          const r = result.report;
+          const lib = r.library;
+          const total = lib.modes.length;
+          const activated = lib.modes.filter((m) => m.activated).length;
+          if (r.noop) {
+            p.log.info(
+              `Library "${lib.name}" already up to date (${total} mode${total === 1 ? "" : "s"}, ${activated} activated).`,
+            );
+          } else if (r.added.length || r.removed.length || r.updated.length) {
+            p.log.success(
+              `Library "${lib.name}" synced at ${result.libraryDir}\n` +
+                `  ${total} mode${total === 1 ? "" : "s"} (${activated} activated)` +
+                (r.added.length ? `\n  + added: ${r.added.join(", ")}` : "") +
+                (r.removed.length ? `\n  - removed: ${r.removed.join(", ")}` : "") +
+                (r.updated.length
+                  ? `\n  ↻ updated: ${r.updated.map((u) => `${u.name} ${u.from} → ${u.to}`).join(", ")}`
+                  : ""),
+            );
+          } else {
+            p.log.success(
+              `Library "${lib.name}" linked at ${result.libraryDir}\n` +
+                `  ${total} mode${total === 1 ? "" : "s"} (${activated} activated): ${lib.modes.map((m) => m.name).join(", ")}`,
+            );
+          }
         }
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
@@ -1064,6 +1114,350 @@ Options:
       return;
     }
     // Unknown mode subcommand — fall through to normal mode resolution
+  }
+
+  // Library subcommand — init, link, list, sync, publish, push, unlink, (de)activate
+  if (rawArgs[0] === "library") {
+    const sub = rawArgs[1];
+    const usage =
+      "Usage:\n" +
+      "  pneuma library init <name> [--display \"...\"] [--description \"...\"] [--github user/repo] [--private]\n" +
+      "  pneuma library link <source>\n" +
+      "  pneuma library list\n" +
+      "  pneuma library sync <id>\n" +
+      "  pneuma library publish <mode> [--to <library-id>] [--as <new-name>] [--push]\n" +
+      "  pneuma library push <id>\n" +
+      "  pneuma library unlink <id> [--force]\n" +
+      "  pneuma library activate <id> <mode>\n" +
+      "  pneuma library deactivate <id> <mode>";
+
+    /** Read the value following a `--flag` option, returning undefined when absent. */
+    const readOpt = (flag: string): string | undefined => {
+      const idx = rawArgs.indexOf(flag);
+      if (idx === -1 || idx + 1 >= rawArgs.length) return undefined;
+      return rawArgs[idx + 1];
+    };
+    const hasFlag = (flag: string): boolean => rawArgs.indexOf(flag) !== -1;
+
+    if (sub === "init") {
+      const name = rawArgs[2];
+      if (!name || name.startsWith("--")) {
+        p.cancel("Usage: pneuma library init <name> [--display \"...\"] [--description \"...\"] [--github user/repo] [--private]");
+        process.exit(1);
+      }
+      const displayName = readOpt("--display");
+      const description = readOpt("--description");
+      const githubSlug = readOpt("--github");
+      const isPrivate = hasFlag("--private");
+      try {
+        const lib = initLocalLibrary({
+          name,
+          ...(displayName ? { displayName } : {}),
+          ...(description ? { description } : {}),
+        });
+        const dir = getLibraryDir(lib.id);
+        p.log.success(`Library "${lib.name}" initialized at ${dir}`);
+        if (githubSlug) {
+          try {
+            const repo = await createRepo({
+              name: githubSlug,
+              visibility: isPrivate ? "private" : "public",
+              sourcePath: dir,
+              ...(description ? { description } : {}),
+            });
+            p.log.success(`Pushed to ${repo.url}`);
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            p.cancel(`GitHub repo create failed: ${msg}`);
+            process.exit(1);
+          }
+        }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        p.cancel(`Failed to init library: ${msg}`);
+        process.exit(1);
+      }
+      return;
+    }
+
+    if (sub === "link") {
+      const source = rawArgs[2];
+      if (!source) {
+        p.cancel("Usage: pneuma library link <source>");
+        process.exit(1);
+      }
+      try {
+        const result = await resolveModeOrLibrary(source, PROJECT_ROOT);
+        if (result.kind === "single") {
+          p.cancel("That repo is a single mode, not a library — use `pneuma mode add` instead.");
+          process.exit(1);
+        }
+        const r = result.report;
+        const lib = r.library;
+        const total = lib.modes.length;
+        const activated = lib.modes.filter((m) => m.activated).length;
+        if (r.noop) {
+          p.log.info(
+            `Library "${lib.name}" already up to date (${total} mode${total === 1 ? "" : "s"}, ${activated} activated).`,
+          );
+        } else if (r.added.length || r.removed.length || r.updated.length) {
+          p.log.success(
+            `Library "${lib.name}" synced at ${result.libraryDir}\n` +
+              `  ${total} mode${total === 1 ? "" : "s"} (${activated} activated)` +
+              (r.added.length ? `\n  + added: ${r.added.join(", ")}` : "") +
+              (r.removed.length ? `\n  - removed: ${r.removed.join(", ")}` : "") +
+              (r.updated.length
+                ? `\n  ↻ updated: ${r.updated.map((u) => `${u.name} ${u.from} → ${u.to}`).join(", ")}`
+                : ""),
+          );
+        } else {
+          p.log.success(
+            `Library "${lib.name}" linked at ${result.libraryDir}\n` +
+              `  ${total} mode${total === 1 ? "" : "s"} (${activated} activated): ${lib.modes.map((m) => m.name).join(", ")}`,
+          );
+        }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        p.cancel(`Failed to link library: ${msg}`);
+        process.exit(1);
+      }
+      return;
+    }
+
+    if (sub === "list") {
+      const libs = listLibraries();
+      if (libs.length === 0) {
+        console.log("No libraries linked. Try `pneuma library link github:user/repo`.");
+        return;
+      }
+      for (const lib of libs) {
+        const total = lib.modes.length;
+        const activated = lib.modes.filter((m) => m.activated).length;
+        const sourceStr =
+          lib.source.type === "github"
+            ? lib.source.url
+            : lib.source.type === "url"
+              ? lib.source.url
+              : lib.source.path;
+        console.log(
+          `  ${lib.id}  (${total} mode${total === 1 ? "" : "s"}, ${activated} activated)  ← ${sourceStr}`,
+        );
+      }
+      return;
+    }
+
+    if (sub === "sync") {
+      const id = rawArgs[2];
+      if (!id) {
+        p.cancel("Usage: pneuma library sync <id>");
+        process.exit(1);
+      }
+      try {
+        const lib = readLibrary(id);
+        if (!lib) {
+          p.cancel(`Library "${id}" is not linked.`);
+          process.exit(1);
+        }
+        const dir = getLibraryDir(id);
+        let newSha: string | null = null;
+        if (lib.source.type === "github") {
+          // Mirror ensureGithubMode's fetch + checkout, inline.
+          const ref = lib.source.ref || "main";
+          const fetchProc = Bun.spawnSync(["git", "fetch", "origin", ref], { cwd: dir, stdout: "pipe", stderr: "pipe" });
+          if (fetchProc.exitCode !== 0) {
+            const err = new TextDecoder().decode(fetchProc.stderr).trim();
+            p.cancel(`git fetch failed: ${err}`);
+            process.exit(1);
+          }
+          const coProc = Bun.spawnSync(["git", "checkout", `origin/${ref}`, "--force"], { cwd: dir, stdout: "pipe", stderr: "pipe" });
+          if (coProc.exitCode !== 0) {
+            const err = new TextDecoder().decode(coProc.stderr).trim();
+            p.cancel(`git checkout failed: ${err}`);
+            process.exit(1);
+          }
+          const shaProc = Bun.spawnSync(["git", "rev-parse", "HEAD"], { cwd: dir, stdout: "pipe", stderr: "pipe" });
+          if (shaProc.exitCode === 0) {
+            const sha = new TextDecoder().decode(shaProc.stdout).trim();
+            newSha = sha || null;
+          }
+        }
+        // Re-detect shape against the (possibly updated) on-disk repo.
+        const shape = detectRepoShape(dir, id);
+        if (shape.kind !== "library") {
+          p.cancel(`Library "${id}" no longer looks like a library on disk.`);
+          process.exit(1);
+        }
+        const report = syncLibrary(id, shape, newSha);
+        const total = report.library.modes.length;
+        const activated = report.library.modes.filter((m) => m.activated).length;
+        if (report.noop) {
+          p.log.info(`Library "${id}" already up to date (${total} mode${total === 1 ? "" : "s"}, ${activated} activated).`);
+        } else {
+          p.log.success(
+            `Library "${id}" synced (${total} mode${total === 1 ? "" : "s"}, ${activated} activated)` +
+              (report.added.length ? `\n  + added: ${report.added.join(", ")}` : "") +
+              (report.removed.length ? `\n  - removed: ${report.removed.join(", ")}` : "") +
+              (report.updated.length
+                ? `\n  ↻ updated: ${report.updated.map((u) => `${u.name} ${u.from} → ${u.to}`).join(", ")}`
+                : ""),
+          );
+        }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        p.cancel(`Failed to sync library: ${msg}`);
+        process.exit(1);
+      }
+      return;
+    }
+
+    if (sub === "publish") {
+      const modeArg = rawArgs[2];
+      if (!modeArg || modeArg.startsWith("--")) {
+        p.cancel("Usage: pneuma library publish <mode> [--to <library-id>] [--as <new-name>] [--push]");
+        process.exit(1);
+      }
+      const toLib = readOpt("--to");
+      const asName = readOpt("--as");
+      const push = hasFlag("--push");
+
+      // Resolve source mode dir.
+      let sourceModeDir: string | null = null;
+      const isPathLike =
+        modeArg.startsWith("/") ||
+        modeArg.startsWith("./") ||
+        modeArg.startsWith("../") ||
+        modeArg.startsWith("~");
+      if (isPathLike) {
+        const expanded = modeArg.startsWith("~") ? join(homedir(), modeArg.slice(1)) : resolve(modeArg);
+        if (!existsSync(expanded)) {
+          p.cancel(`Mode path not found: ${expanded}`);
+          process.exit(1);
+        }
+        sourceModeDir = expanded;
+      } else {
+        const candidates = [
+          join(homedir(), ".pneuma", "modes", modeArg),
+          join(PROJECT_ROOT, "modes", modeArg),
+        ];
+        for (const c of candidates) {
+          if (existsSync(c)) {
+            sourceModeDir = c;
+            break;
+          }
+        }
+        if (!sourceModeDir) {
+          p.cancel(`Mode "${modeArg}" not found in ~/.pneuma/modes/ or builtin modes/.`);
+          process.exit(1);
+        }
+      }
+
+      // Resolve target library id.
+      let libraryId = toLib;
+      if (!libraryId) {
+        const libs = listLibraries();
+        if (libs.length === 0) {
+          p.cancel("No libraries linked. Run `pneuma library init <name>` or `pneuma library link <source>` first.");
+          process.exit(1);
+        }
+        if (libs.length > 1) {
+          p.cancel(`Multiple libraries linked — pass --to <library-id>. Available: ${libs.map((l) => l.id).join(", ")}`);
+          process.exit(1);
+        }
+        libraryId = libs[0].id;
+      }
+
+      try {
+        const result = publishModeToLibrary({
+          sourceModeDir,
+          libraryId,
+          ...(asName ? { name: asName } : {}),
+          push,
+        });
+        p.log.success(`Published ${modeArg} to ${libraryId} at ${result.destDir}`);
+        if (push && result.pushed) {
+          p.log.success(`Pushed`);
+        }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        p.cancel(`Failed to publish: ${msg}`);
+        process.exit(1);
+      }
+      return;
+    }
+
+    if (sub === "push") {
+      const id = rawArgs[2];
+      if (!id) {
+        p.cancel("Usage: pneuma library push <id>");
+        process.exit(1);
+      }
+      try {
+        pushLibrary(id);
+        p.log.success(`Pushed library "${id}"`);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        p.cancel(msg);
+        process.exit(1);
+      }
+      return;
+    }
+
+    if (sub === "unlink") {
+      const id = rawArgs[2];
+      if (!id) {
+        p.cancel("Usage: pneuma library unlink <id> [--force]");
+        process.exit(1);
+      }
+      const force = hasFlag("--force");
+      if (!force) {
+        const confirmed = await p.confirm({
+          message: `Unlink library "${id}"? This will delete its on-disk clone.`,
+          initialValue: false,
+        });
+        if (p.isCancel(confirmed) || !confirmed) {
+          p.cancel("Cancelled.");
+          process.exit(0);
+        }
+      }
+      try {
+        const removed = unlinkLibrary(id);
+        if (removed) {
+          p.log.success(`Library "${id}" removed`);
+        } else {
+          p.log.info(`Library "${id}" not linked.`);
+        }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        p.cancel(`Failed to unlink: ${msg}`);
+        process.exit(1);
+      }
+      return;
+    }
+
+    if (sub === "activate" || sub === "deactivate") {
+      const id = rawArgs[2];
+      const modeName = rawArgs[3];
+      if (!id || !modeName) {
+        p.cancel(`Usage: pneuma library ${sub} <id> <mode>`);
+        process.exit(1);
+      }
+      try {
+        setModeActivated(id, modeName, sub === "activate");
+        p.log.success(
+          sub === "activate"
+            ? `Mode "${modeName}" activated in ${id}`
+            : `Mode "${modeName}" deactivated in ${id}`,
+        );
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        p.cancel(msg);
+        process.exit(1);
+      }
+      return;
+    }
+
+    p.cancel(`Unknown library subcommand: ${sub ?? "(none)"}\n${usage}`);
+    process.exit(1);
   }
 
   // Plugin subcommand — add, list, remove

--- a/core/__tests__/github-cli.test.ts
+++ b/core/__tests__/github-cli.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Tests for `core/github-cli.ts`.
+ *
+ * `detectGh` shells out to the real local `gh` binary. We avoid brittle
+ * `mock.module("bun", ...)` here — instead we probe PATH at test setup
+ * time and gate the assertions on what's actually available.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { detectGh, createRepo } from "../github-cli.js";
+
+/** Returns true when `gh --version` exits 0 within a short timeout. */
+async function probeGhInstalled(): Promise<boolean> {
+  try {
+    const proc = Bun.spawn(["gh", "--version"], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const exited = await Promise.race([
+      proc.exited,
+      new Promise<number>((resolve) =>
+        setTimeout(() => {
+          try {
+            proc.kill();
+          } catch {
+            /* ignore */
+          }
+          resolve(1);
+        }, 5_000),
+      ),
+    ]);
+    return exited === 0;
+  } catch {
+    return false;
+  }
+}
+
+const ghAvailable = await probeGhInstalled();
+
+describe("detectGh", () => {
+  test.skipIf(!ghAvailable)(
+    "reports installed: true with a version string when gh is on PATH",
+    async () => {
+      const status = await detectGh();
+      expect(status.installed).toBe(true);
+      expect(typeof status.version).toBe("string");
+      expect(status.version!.length).toBeGreaterThan(0);
+      // authenticated is a boolean either way — we don't constrain its
+      // value because CI may or may not have a logged-in gh session.
+      expect(typeof status.authenticated).toBe("boolean");
+      if (status.authenticated) {
+        // username is best-effort; if present it's a non-empty string.
+        if (status.username !== undefined) {
+          expect(typeof status.username).toBe("string");
+          expect(status.username.length).toBeGreaterThan(0);
+        }
+      } else {
+        expect(status.hint).toMatch(/gh auth login/);
+      }
+    },
+  );
+
+  test.skipIf(ghAvailable)(
+    "reports installed: false with an install hint when gh is missing",
+    async () => {
+      const status = await detectGh();
+      expect(status.installed).toBe(false);
+      expect(status.authenticated).toBe(false);
+      expect(status.hint).toMatch(/cli\.github\.com/);
+    },
+  );
+
+  test("shape contract — every field has the expected type", async () => {
+    const status = await detectGh();
+    expect(typeof status.installed).toBe("boolean");
+    expect(typeof status.authenticated).toBe("boolean");
+    if (status.version !== undefined) {
+      expect(typeof status.version).toBe("string");
+    }
+    if (status.hint !== undefined) {
+      expect(typeof status.hint).toBe("string");
+    }
+    if (status.username !== undefined) {
+      expect(typeof status.username).toBe("string");
+    }
+  });
+});
+
+describe("createRepo", () => {
+  test.skipIf(ghAvailable)(
+    "throws with the install hint when gh is missing",
+    async () => {
+      await expect(
+        createRepo({
+          name: "fake/fake",
+          sourcePath: "/tmp/does-not-matter",
+        }),
+      ).rejects.toThrow(/cli\.github\.com|gh auth login/);
+    },
+  );
+
+  test.skipIf(!ghAvailable)(
+    "rejects when gh is installed but the call is obviously invalid (smoke)",
+    async () => {
+      // We do NOT actually want to create a real repo, so we point at a
+      // source path that does not exist and a slug we will not collide with.
+      // gh will fail; we just want the call to throw, not to hang.
+      await expect(
+        createRepo({
+          name: "pneuma-tests-do-not-create-this/should-not-exist-" + Date.now(),
+          sourcePath: "/tmp/__pneuma_definitely_not_a_real_path__" + Date.now(),
+        }),
+      ).rejects.toThrow();
+    },
+  );
+});

--- a/core/__tests__/library-publish.test.ts
+++ b/core/__tests__/library-publish.test.ts
@@ -1,0 +1,342 @@
+/**
+ * Tests for `core/library-publish.ts`.
+ *
+ * Reuses the `node:os` homedir mock pattern from library-registry.test.ts so
+ * `~/.pneuma/libraries/` resolves under a per-test tmpdir.
+ */
+
+import { describe, expect, test, beforeEach, afterEach, mock } from "bun:test";
+import {
+  mkdtempSync,
+  rmSync,
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  existsSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// ── Home directory mock (shared pattern with library-registry.test.ts) ──────
+let currentHome = tmpdir();
+mock.module("node:os", () => {
+  const real = require("node:os");
+  return {
+    ...real,
+    homedir: () => currentHome,
+    default: { ...real, homedir: () => currentHome },
+  };
+});
+
+import {
+  initLocalLibrary,
+  publishModeToLibrary,
+  pushLibrary,
+} from "../library-publish.js";
+import {
+  getLibraryDir,
+  getLibrarySidecarPath,
+  readLibrary,
+  detectRepoShape,
+  linkLibrary,
+} from "../library-registry.js";
+import type { LibraryManifest } from "../types/library.js";
+
+// ── Fixture helpers ─────────────────────────────────────────────────────────
+
+function makeSourceMode(
+  dir: string,
+  name: string,
+  version: string,
+  extraFile?: { name: string; body: string },
+): void {
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, "manifest.ts"),
+    `export const manifest = { name: "${name}", version: "${version}" };\n`,
+    "utf-8",
+  );
+  if (extraFile) {
+    writeFileSync(join(dir, extraFile.name), extraFile.body, "utf-8");
+  }
+}
+
+let tmp: string;
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), "libpub-"));
+  currentHome = tmp;
+});
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+// ── initLocalLibrary ────────────────────────────────────────────────────────
+
+describe("initLocalLibrary", () => {
+  test("scaffolds dir + pneuma.library.json (modes: []) + README + .gitignore + sidecar", () => {
+    const lib = initLocalLibrary({
+      name: "my-lib",
+      displayName: "My Library",
+      description: "test description",
+      author: "ada",
+    });
+
+    const libDir = getLibraryDir("my-lib");
+    expect(existsSync(libDir)).toBe(true);
+
+    // Repo-side manifest
+    const repoManifestPath = join(libDir, "pneuma.library.json");
+    expect(existsSync(repoManifestPath)).toBe(true);
+    const repoManifest = JSON.parse(
+      readFileSync(repoManifestPath, "utf-8"),
+    ) as LibraryManifest;
+    expect(repoManifest.version).toBe(1);
+    expect(repoManifest.name).toBe("my-lib");
+    expect(repoManifest.displayName).toBe("My Library");
+    expect(repoManifest.description).toBe("test description");
+    expect(repoManifest.author).toBe("ada");
+    expect(repoManifest.modes).toEqual([]);
+
+    // README + .gitignore
+    expect(existsSync(join(libDir, "README.md"))).toBe(true);
+    expect(readFileSync(join(libDir, "README.md"), "utf-8")).toContain(
+      "My Library",
+    );
+    expect(existsSync(join(libDir, ".gitignore"))).toBe(true);
+    expect(readFileSync(join(libDir, ".gitignore"), "utf-8")).toContain(
+      ".library.json",
+    );
+
+    // Sidecar
+    expect(existsSync(getLibrarySidecarPath("my-lib"))).toBe(true);
+    expect(lib.id).toBe("my-lib");
+    expect(lib.name).toBe("my-lib");
+    expect(lib.modes).toEqual([]);
+    expect(lib.source).toEqual({ type: "local", path: libDir });
+  });
+
+  test("initializes git repo when git binary is available; if missing, library is still returned", () => {
+    const lib = initLocalLibrary({ name: "git-lib" });
+    expect(lib).toBeDefined();
+    // The publish module's try/catch wraps the three git commands. With git
+    // installed on the test host we expect .git to be present. If a future
+    // CI lacks git, the helper logs a warning and the library is still
+    // returned — so we only assert the return shape strictly.
+    const dotGit = join(getLibraryDir("git-lib"), ".git");
+    // We expect git to exist on dev machines + CI but tolerate absence.
+    if (existsSync(dotGit)) {
+      expect(existsSync(dotGit)).toBe(true);
+    }
+    expect(lib.id).toBe("git-lib");
+  });
+
+  test("throws when a library with the same id already exists", () => {
+    initLocalLibrary({ name: "dup-lib" });
+    expect(() => initLocalLibrary({ name: "dup-lib" })).toThrow(
+      /already exists/,
+    );
+  });
+
+  test("rejects slug with slash", () => {
+    expect(() => initLocalLibrary({ name: "bad/name" })).toThrow(
+      /Invalid library\/mode name/,
+    );
+  });
+
+  test("rejects empty slug", () => {
+    expect(() => initLocalLibrary({ name: "" })).toThrow(
+      /1.{1,2}80 chars/,
+    );
+  });
+
+  test("rejects slug starting with a dot", () => {
+    expect(() => initLocalLibrary({ name: ".hidden" })).toThrow(
+      /must not start with/,
+    );
+  });
+
+  test("rejects slug longer than 80 chars", () => {
+    const huge = "a".repeat(81);
+    expect(() => initLocalLibrary({ name: huge })).toThrow(/1.{1,2}80 chars/);
+  });
+});
+
+// ── publishModeToLibrary ────────────────────────────────────────────────────
+
+describe("publishModeToLibrary", () => {
+  test("copies the mode into the library, updates pneuma.library.json, syncs sidecar (added: true)", () => {
+    initLocalLibrary({ name: "pub-lib" });
+    const src = join(tmp, "src", "alpha");
+    makeSourceMode(src, "alpha", "0.1.0", { name: "README.md", body: "# alpha" });
+
+    const result = publishModeToLibrary({
+      sourceModeDir: src,
+      libraryId: "pub-lib",
+    });
+
+    expect(result.added).toBe(true);
+    expect(existsSync(result.destDir)).toBe(true);
+    expect(existsSync(join(result.destDir, "manifest.ts"))).toBe(true);
+    expect(existsSync(join(result.destDir, "README.md"))).toBe(true);
+
+    // pneuma.library.json entry was added
+    const repoManifest = JSON.parse(
+      readFileSync(join(getLibraryDir("pub-lib"), "pneuma.library.json"), "utf-8"),
+    ) as LibraryManifest;
+    expect(repoManifest.modes).toEqual([{ path: "alpha" }]);
+
+    // Sidecar reflects the new mode
+    const lib = readLibrary("pub-lib")!;
+    expect(lib.modes.map((m) => m.name)).toEqual(["alpha"]);
+    expect(lib.modes[0].manifestVersion).toBe("0.1.0");
+  });
+
+  test("idempotent — re-publishing the same name does not duplicate the pneuma.library.json entry", () => {
+    initLocalLibrary({ name: "idem-lib" });
+    const src = join(tmp, "src", "alpha");
+    makeSourceMode(src, "alpha", "0.1.0");
+
+    publishModeToLibrary({ sourceModeDir: src, libraryId: "idem-lib" });
+    const result2 = publishModeToLibrary({ sourceModeDir: src, libraryId: "idem-lib" });
+
+    expect(result2.added).toBe(false);
+    const repoManifest = JSON.parse(
+      readFileSync(join(getLibraryDir("idem-lib"), "pneuma.library.json"), "utf-8"),
+    ) as LibraryManifest;
+    expect(repoManifest.modes).toEqual([{ path: "alpha" }]);
+  });
+
+  test("re-publishing with different content updates files and returns added: false", () => {
+    initLocalLibrary({ name: "upd-lib" });
+    const src = join(tmp, "src", "alpha");
+    makeSourceMode(src, "alpha", "0.1.0", { name: "data.txt", body: "v1" });
+    publishModeToLibrary({ sourceModeDir: src, libraryId: "upd-lib" });
+
+    // Mutate source content
+    writeFileSync(join(src, "data.txt"), "v2", "utf-8");
+    makeSourceMode(src, "alpha", "0.2.0");
+
+    const result2 = publishModeToLibrary({ sourceModeDir: src, libraryId: "upd-lib" });
+    expect(result2.added).toBe(false);
+    expect(readFileSync(join(result2.destDir, "data.txt"), "utf-8")).toBe("v2");
+
+    const lib = readLibrary("upd-lib")!;
+    expect(lib.modes[0].manifestVersion).toBe("0.2.0");
+  });
+
+  test("supports --as override to rename inside the library", () => {
+    initLocalLibrary({ name: "rename-lib" });
+    const src = join(tmp, "src", "raw-name");
+    makeSourceMode(src, "raw-name", "0.1.0");
+
+    const result = publishModeToLibrary({
+      sourceModeDir: src,
+      libraryId: "rename-lib",
+      name: "renamed",
+    });
+
+    expect(result.destDir.endsWith("/renamed")).toBe(true);
+    expect(existsSync(join(getLibraryDir("rename-lib"), "renamed", "manifest.ts"))).toBe(true);
+    expect(existsSync(join(getLibraryDir("rename-lib"), "raw-name"))).toBe(false);
+
+    const lib = readLibrary("rename-lib")!;
+    expect(lib.modes.map((m) => m.name)).toEqual(["renamed"]);
+  });
+
+  test("rejects mode name with path separator (escape attempt)", () => {
+    initLocalLibrary({ name: "escape-lib" });
+    const src = join(tmp, "src", "alpha");
+    makeSourceMode(src, "alpha", "0.1.0");
+
+    expect(() =>
+      publishModeToLibrary({
+        sourceModeDir: src,
+        libraryId: "escape-lib",
+        name: "../oops",
+      }),
+    ).toThrow(/Invalid library\/mode name/);
+  });
+
+  test("rejects mode name with disallowed special chars", () => {
+    initLocalLibrary({ name: "special-lib" });
+    const src = join(tmp, "src", "alpha");
+    makeSourceMode(src, "alpha", "0.1.0");
+
+    expect(() =>
+      publishModeToLibrary({
+        sourceModeDir: src,
+        libraryId: "special-lib",
+        name: "no spaces",
+      }),
+    ).toThrow(/Invalid library\/mode name/);
+  });
+
+  test("throws helpful message when library is not linked", () => {
+    const src = join(tmp, "src", "alpha");
+    makeSourceMode(src, "alpha", "0.1.0");
+    expect(() =>
+      publishModeToLibrary({ sourceModeDir: src, libraryId: "ghost-lib" }),
+    ).toThrow(/Library "ghost-lib" is not linked/);
+  });
+
+  test("throws when source dir is missing", () => {
+    initLocalLibrary({ name: "missing-src-lib" });
+    expect(() =>
+      publishModeToLibrary({
+        sourceModeDir: join(tmp, "does-not-exist"),
+        libraryId: "missing-src-lib",
+      }),
+    ).toThrow(/Source mode dir not found/);
+  });
+
+  test("throws when source dir has no manifest", () => {
+    initLocalLibrary({ name: "no-manifest-lib" });
+    const src = join(tmp, "src", "bad");
+    mkdirSync(src, { recursive: true });
+    writeFileSync(join(src, "README.md"), "not a mode", "utf-8");
+
+    expect(() =>
+      publishModeToLibrary({ sourceModeDir: src, libraryId: "no-manifest-lib" }),
+    ).toThrow(/not a mode package/);
+  });
+
+  test("publish with push: true and no remote configured throws with the 'Fix git credentials' hint", () => {
+    initLocalLibrary({ name: "no-remote-lib" });
+    const src = join(tmp, "src", "alpha");
+    makeSourceMode(src, "alpha", "0.1.0");
+
+    expect(() =>
+      publishModeToLibrary({
+        sourceModeDir: src,
+        libraryId: "no-remote-lib",
+        push: true,
+      }),
+    ).toThrow(/Fix git credentials/);
+  });
+});
+
+// ── pushLibrary ─────────────────────────────────────────────────────────────
+
+describe("pushLibrary", () => {
+  test("throws when the library dir does not exist", () => {
+    expect(() => pushLibrary("ghost-lib")).toThrow(/not linked locally/);
+  });
+
+  test("throws when the library has no .git", () => {
+    // Plant a library dir with a sidecar but no .git.
+    const id = "no-git-lib";
+    const dir = getLibraryDir(id);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "pneuma.library.json"),
+      JSON.stringify({ version: 1, name: id, modes: [] }, null, 2),
+    );
+    const shape = detectRepoShape(dir, id);
+    if (shape.kind !== "library") throw new Error("expected library");
+    linkLibrary(id, dir, shape, { type: "local", path: dir }, null);
+
+    expect(() => pushLibrary(id)).toThrow(/no git repo/);
+  });
+});

--- a/core/__tests__/library-registry.test.ts
+++ b/core/__tests__/library-registry.test.ts
@@ -1,0 +1,644 @@
+/**
+ * Tests for `core/library-registry.ts`.
+ *
+ * Isolation strategy: the registry calls `homedir()` from `node:os`. Bun caches
+ * `os.homedir()` at process start (it does NOT re-read `$HOME` at call time),
+ * so we use `bun:test`'s `mock.module` to swap the function for one that reads
+ * a mutable variable. Each test sets up its own tmpdir and points the
+ * mocked-out `homedir` at it.
+ */
+
+import { describe, expect, test, beforeEach, afterEach, mock } from "bun:test";
+import {
+  mkdtempSync,
+  rmSync,
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  existsSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// ── Home directory mock ─────────────────────────────────────────────────────
+//
+// `mock.module` is process-global and registered once. We thread the actual
+// tmp dir through a mutable closure variable so each test can rotate the home
+// root without re-registering the mock.
+let currentHome = tmpdir();
+mock.module("node:os", () => {
+  const real = require("node:os");
+  return {
+    ...real,
+    homedir: () => currentHome,
+    default: { ...real, homedir: () => currentHome },
+  };
+});
+
+// Import AFTER mock registration so the module's top-level `homedir` reference
+// resolves to the mocked binding. (Static imports below this point are fine —
+// they still go through the mocked `node:os`.)
+import {
+  detectRepoShape,
+  linkLibrary,
+  syncLibrary,
+  setModeActivated,
+  acceptModeUpdate,
+  listLibraries,
+  unlinkLibrary,
+  getLibraryModePath,
+  getLibrariesDir,
+  getLibraryDir,
+  getLibrarySidecarPath,
+  readLibrary,
+  writeLibrary,
+  type RepoShape,
+} from "../library-registry.js";
+import type { InstalledLibrary } from "../types/library.js";
+
+// ── Fixture helpers ─────────────────────────────────────────────────────────
+
+function makeMode(dir: string, name: string, version: string): void {
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, "manifest.ts"),
+    `export const manifest = { name: "${name}", version: "${version}" };\n`,
+    "utf-8",
+  );
+}
+
+function makeRepoRootMode(repoDir: string, name: string, version: string): void {
+  makeMode(repoDir, name, version);
+}
+
+function makeLibraryJson(repoDir: string, body: unknown): void {
+  mkdirSync(repoDir, { recursive: true });
+  writeFileSync(
+    join(repoDir, "pneuma.library.json"),
+    typeof body === "string" ? body : JSON.stringify(body, null, 2),
+    "utf-8",
+  );
+}
+
+/** Create an empty library dir under the mocked home and return its path. */
+function setupLibraryDir(id: string): string {
+  const dir = getLibraryDir(id);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+// ── Lifecycle ───────────────────────────────────────────────────────────────
+
+let tmp: string;
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), "libreg-"));
+  currentHome = tmp;
+});
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+// ── detectRepoShape ─────────────────────────────────────────────────────────
+
+describe("detectRepoShape", () => {
+  test("single-mode repo (root manifest.ts) → kind: single", () => {
+    const repo = join(tmp, "repo");
+    makeRepoRootMode(repo, "doc", "1.0.0");
+
+    const shape = detectRepoShape(repo, "default-name");
+    expect(shape.kind).toBe("single");
+  });
+
+  test("explicit library via pneuma.library.json", () => {
+    const repo = join(tmp, "explicit-lib");
+    makeMode(join(repo, "modes", "alpha"), "alpha", "0.2.1");
+    makeMode(join(repo, "modes", "beta"), "beta", "1.4.0");
+    makeLibraryJson(repo, {
+      version: 1,
+      name: "explicit-lib",
+      displayName: "Explicit Library",
+      description: "two modes",
+      author: "ada",
+      modes: [
+        { path: "modes/alpha" },
+        { path: "modes/beta", name: "beta-renamed" },
+      ],
+    });
+
+    const shape = detectRepoShape(repo, "fallback-name");
+    expect(shape.kind).toBe("library");
+    if (shape.kind !== "library") throw new Error("type narrow");
+    expect(shape.manifest.name).toBe("explicit-lib");
+    expect(shape.manifest.displayName).toBe("Explicit Library");
+    expect(shape.manifest.author).toBe("ada");
+
+    expect(shape.modes).toHaveLength(2);
+    const alpha = shape.modes.find((m) => m.name === "alpha");
+    const beta = shape.modes.find((m) => m.name === "beta-renamed");
+    expect(alpha).toBeDefined();
+    expect(alpha!.relPath).toBe("modes/alpha");
+    expect(alpha!.manifestVersion).toBe("0.2.1");
+    expect(beta).toBeDefined();
+    expect(beta!.relPath).toBe("modes/beta");
+    expect(beta!.manifestVersion).toBe("1.4.0");
+  });
+
+  test("implicit library (no root manifest, subdirs with manifest) → library, sorted", () => {
+    const repo = join(tmp, "implicit-lib");
+    makeMode(join(repo, "zulu"), "zulu", "0.1.0");
+    makeMode(join(repo, "alpha"), "alpha", "0.2.0");
+    makeMode(join(repo, "mike"), "mike", "0.3.0");
+    // A non-mode subdir should be ignored.
+    mkdirSync(join(repo, "docs"), { recursive: true });
+    writeFileSync(join(repo, "docs", "README.md"), "no manifest here");
+    // A dot-dir should be skipped.
+    mkdirSync(join(repo, ".git"), { recursive: true });
+    writeFileSync(join(repo, ".git", "manifest.ts"), "noise");
+
+    const shape = detectRepoShape(repo, "implicit-lib");
+    expect(shape.kind).toBe("library");
+    if (shape.kind !== "library") throw new Error("type narrow");
+    expect(shape.manifest.name).toBe("implicit-lib");
+    expect(shape.modes.map((m) => m.name)).toEqual(["alpha", "mike", "zulu"]);
+    expect(shape.modes.map((m) => m.manifestVersion)).toEqual([
+      "0.2.0",
+      "0.3.0",
+      "0.1.0",
+    ]);
+  });
+
+  test("malformed pneuma.library.json throws", () => {
+    const repo = join(tmp, "bad-json");
+    makeMode(join(repo, "alpha"), "alpha", "0.1.0");
+    makeLibraryJson(repo, "not json {[");
+
+    expect(() => detectRepoShape(repo, "bad")).toThrow(/not valid JSON/);
+  });
+
+  test("pneuma.library.json with unsupported version throws", () => {
+    const repo = join(tmp, "bad-version");
+    makeMode(join(repo, "alpha"), "alpha", "0.1.0");
+    makeLibraryJson(repo, { version: 2, name: "x" });
+
+    expect(() => detectRepoShape(repo, "x")).toThrow(/unsupported version/);
+  });
+
+  test("explicit entry pointing at a missing path throws", () => {
+    const repo = join(tmp, "missing-entry");
+    makeLibraryJson(repo, {
+      version: 1,
+      name: "missing-entry",
+      modes: [{ path: "modes/nope" }],
+    });
+
+    expect(() => detectRepoShape(repo, "missing-entry")).toThrow(
+      /has no manifest\.ts/,
+    );
+  });
+
+  test("explicit entry with ../escape path throws", () => {
+    const repo = join(tmp, "escape");
+    makeLibraryJson(repo, {
+      version: 1,
+      name: "escape",
+      modes: [{ path: "../escape-target" }],
+    });
+    // Target exists outside the repo — the safeSubpath check must still reject.
+    makeMode(join(tmp, "escape-target"), "escape-target", "0.0.1");
+
+    expect(() => detectRepoShape(repo, "escape")).toThrow(/escapes the repo root/);
+  });
+
+  test("empty repo (no root manifest, no subdir manifests) returns kind: single", () => {
+    const repo = join(tmp, "empty");
+    mkdirSync(repo, { recursive: true });
+
+    const shape = detectRepoShape(repo, "empty");
+    expect(shape.kind).toBe("single");
+  });
+});
+
+// ── linkLibrary ─────────────────────────────────────────────────────────────
+
+describe("linkLibrary", () => {
+  test("writes sidecar, defaults activated: true, returns report with all modes in added", () => {
+    const id = "user-repo";
+    const repoDir = setupLibraryDir(id);
+    makeMode(join(repoDir, "alpha"), "alpha", "0.1.0");
+    makeMode(join(repoDir, "beta"), "beta", "0.2.0");
+
+    const shape = detectRepoShape(repoDir, id);
+    expect(shape.kind).toBe("library");
+    if (shape.kind !== "library") throw new Error("type narrow");
+
+    const report = linkLibrary(
+      id,
+      repoDir,
+      shape,
+      { type: "github", url: "github:user/repo", ref: "main" },
+      "deadbeef",
+    );
+
+    expect(report.added.sort()).toEqual(["alpha", "beta"]);
+    expect(report.removed).toEqual([]);
+    expect(report.updated).toEqual([]);
+    expect(report.noop).toBe(false);
+
+    // Sidecar exists with expected shape.
+    const sidecarPath = getLibrarySidecarPath(id);
+    expect(existsSync(sidecarPath)).toBe(true);
+    const persisted = JSON.parse(readFileSync(sidecarPath, "utf-8")) as InstalledLibrary;
+    expect(persisted.id).toBe(id);
+    expect(persisted.sha).toBe("deadbeef");
+    expect(persisted.source).toEqual({
+      type: "github",
+      url: "github:user/repo",
+      ref: "main",
+    });
+    expect(persisted.modes).toHaveLength(2);
+    for (const m of persisted.modes) {
+      expect(m.activated).toBe(true);
+      expect(m.installedVersion).toBe(m.manifestVersion);
+    }
+  });
+
+  test("refuses repoDir that doesn't match expected library dir", () => {
+    const id = "user-repo";
+    setupLibraryDir(id); // create the real dir so resolveExplicitEntries paths exist
+    const elsewhere = mkdtempSync(join(tmpdir(), "elsewhere-"));
+    try {
+      makeMode(join(elsewhere, "alpha"), "alpha", "0.1.0");
+      const shape = detectRepoShape(elsewhere, id);
+      if (shape.kind !== "library") throw new Error("expected library shape");
+
+      expect(() =>
+        linkLibrary(
+          id,
+          elsewhere,
+          shape,
+          { type: "github", url: "x", ref: "main" },
+          null,
+        ),
+      ).toThrow(/does not match expected/);
+    } finally {
+      rmSync(elsewhere, { recursive: true, force: true });
+    }
+  });
+});
+
+// ── syncLibrary ─────────────────────────────────────────────────────────────
+
+describe("syncLibrary", () => {
+  function initialLink(id: string, modes: { name: string; version: string }[], sha: string | null) {
+    const repoDir = setupLibraryDir(id);
+    for (const m of modes) makeMode(join(repoDir, m.name), m.name, m.version);
+    const shape = detectRepoShape(repoDir, id);
+    if (shape.kind !== "library") throw new Error("expected library shape");
+    linkLibrary(id, repoDir, shape, { type: "github", url: "x", ref: "main" }, sha);
+    return repoDir;
+  }
+
+  test("no changes + same sha → noop: true, all diff arrays empty", () => {
+    const id = "noop-lib";
+    initialLink(id, [{ name: "alpha", version: "0.1.0" }], "sha-1");
+
+    const shape = detectRepoShape(getLibraryDir(id), id);
+    if (shape.kind !== "library") throw new Error("expected library shape");
+    const report = syncLibrary(id, shape, "sha-1");
+
+    expect(report.added).toEqual([]);
+    expect(report.removed).toEqual([]);
+    expect(report.updated).toEqual([]);
+    expect(report.noop).toBe(true);
+  });
+
+  test("new mode appears → added, defaults to activated: true", () => {
+    const id = "add-lib";
+    const repoDir = initialLink(id, [{ name: "alpha", version: "0.1.0" }], "sha-1");
+
+    // Add a new mode to the repo on disk, advance sha.
+    makeMode(join(repoDir, "beta"), "beta", "0.2.0");
+    const shape = detectRepoShape(repoDir, id);
+    if (shape.kind !== "library") throw new Error("expected library shape");
+    const report = syncLibrary(id, shape, "sha-2");
+
+    expect(report.added).toEqual(["beta"]);
+    expect(report.removed).toEqual([]);
+    expect(report.updated).toEqual([]);
+    expect(report.noop).toBe(false);
+
+    const lib = readLibrary(id)!;
+    const beta = lib.modes.find((m) => m.name === "beta")!;
+    expect(beta.activated).toBe(true);
+    expect(beta.installedVersion).toBe("0.2.0");
+  });
+
+  test("mode disappears from shape → removed", () => {
+    const id = "remove-lib";
+    const repoDir = initialLink(
+      id,
+      [
+        { name: "alpha", version: "0.1.0" },
+        { name: "beta", version: "0.2.0" },
+      ],
+      "sha-1",
+    );
+
+    // Physically remove the beta dir.
+    rmSync(join(repoDir, "beta"), { recursive: true, force: true });
+    const shape = detectRepoShape(repoDir, id);
+    if (shape.kind !== "library") throw new Error("expected library shape");
+    const report = syncLibrary(id, shape, "sha-2");
+
+    expect(report.added).toEqual([]);
+    expect(report.removed).toEqual(["beta"]);
+    expect(report.updated).toEqual([]);
+
+    const lib = readLibrary(id)!;
+    expect(lib.modes.map((m) => m.name)).toEqual(["alpha"]);
+  });
+
+  test("manifest version bump → updated entry, installedVersion NOT bumped", () => {
+    const id = "update-lib";
+    const repoDir = initialLink(id, [{ name: "alpha", version: "0.1.0" }], "sha-1");
+
+    // Bump the on-disk manifest.
+    makeMode(join(repoDir, "alpha"), "alpha", "0.2.0");
+    const shape = detectRepoShape(repoDir, id);
+    if (shape.kind !== "library") throw new Error("expected library shape");
+    const report = syncLibrary(id, shape, "sha-2");
+
+    expect(report.added).toEqual([]);
+    expect(report.removed).toEqual([]);
+    expect(report.updated).toEqual([{ name: "alpha", from: "0.1.0", to: "0.2.0" }]);
+
+    const lib = readLibrary(id)!;
+    const alpha = lib.modes.find((m) => m.name === "alpha")!;
+    expect(alpha.manifestVersion).toBe("0.2.0");
+    // Accept-explicitly contract: installedVersion stays at the previously accepted value.
+    expect(alpha.installedVersion).toBe("0.1.0");
+  });
+
+  test("activated flag is preserved across syncs", () => {
+    const id = "preserve-lib";
+    const repoDir = initialLink(
+      id,
+      [
+        { name: "alpha", version: "0.1.0" },
+        { name: "beta", version: "0.2.0" },
+      ],
+      "sha-1",
+    );
+
+    // User deactivates alpha.
+    setModeActivated(id, "alpha", false);
+    expect(readLibrary(id)!.modes.find((m) => m.name === "alpha")!.activated).toBe(false);
+
+    // Sync (no shape changes, just a new sha).
+    const shape = detectRepoShape(repoDir, id);
+    if (shape.kind !== "library") throw new Error("expected library shape");
+    syncLibrary(id, shape, "sha-2");
+
+    const lib = readLibrary(id)!;
+    expect(lib.modes.find((m) => m.name === "alpha")!.activated).toBe(false);
+    expect(lib.modes.find((m) => m.name === "beta")!.activated).toBe(true);
+  });
+
+  test("syncLibrary without prior sidecar throws", () => {
+    const id = "no-prior";
+    const repoDir = setupLibraryDir(id);
+    makeMode(join(repoDir, "alpha"), "alpha", "0.1.0");
+    const shape = detectRepoShape(repoDir, id);
+    if (shape.kind !== "library") throw new Error("expected library shape");
+
+    expect(() => syncLibrary(id, shape, "sha-1")).toThrow(/no sidecar/);
+  });
+});
+
+// ── setModeActivated ────────────────────────────────────────────────────────
+
+describe("setModeActivated", () => {
+  function setup(id: string) {
+    const repoDir = setupLibraryDir(id);
+    makeMode(join(repoDir, "alpha"), "alpha", "0.1.0");
+    const shape = detectRepoShape(repoDir, id);
+    if (shape.kind !== "library") throw new Error("expected library shape");
+    linkLibrary(id, repoDir, shape, { type: "github", url: "x", ref: "main" }, "sha-1");
+  }
+
+  test("flips activated flag atomically and persists", () => {
+    setup("flip-lib");
+
+    setModeActivated("flip-lib", "alpha", false);
+    expect(readLibrary("flip-lib")!.modes[0].activated).toBe(false);
+
+    setModeActivated("flip-lib", "alpha", true);
+    expect(readLibrary("flip-lib")!.modes[0].activated).toBe(true);
+  });
+
+  test("idempotent when value already matches (returns prev, no churn)", () => {
+    setup("idem-lib");
+
+    const before = readLibrary("idem-lib")!;
+    const after = setModeActivated("idem-lib", "alpha", true); // already true after link
+    expect(after.modes[0].activated).toBe(true);
+    // Should return the same library shape — lastSync etc. unchanged.
+    expect(after.lastSync).toBe(before.lastSync);
+  });
+
+  test("throws when library unknown", () => {
+    expect(() => setModeActivated("nope", "alpha", false)).toThrow(/Library nope not found/);
+  });
+
+  test("throws when mode unknown", () => {
+    setup("unknown-mode-lib");
+    expect(() => setModeActivated("unknown-mode-lib", "ghost", false)).toThrow(
+      /Mode ghost not found/,
+    );
+  });
+});
+
+// ── acceptModeUpdate ────────────────────────────────────────────────────────
+
+describe("acceptModeUpdate", () => {
+  test("sets installedVersion = manifestVersion", () => {
+    const id = "accept-lib";
+    const repoDir = setupLibraryDir(id);
+    makeMode(join(repoDir, "alpha"), "alpha", "0.1.0");
+    const shape = detectRepoShape(repoDir, id);
+    if (shape.kind !== "library") throw new Error("expected library shape");
+    linkLibrary(id, repoDir, shape, { type: "github", url: "x", ref: "main" }, "sha-1");
+
+    // Bump manifest + sync (creates an update-available state).
+    makeMode(join(repoDir, "alpha"), "alpha", "0.3.0");
+    const shape2 = detectRepoShape(repoDir, id);
+    if (shape2.kind !== "library") throw new Error("expected library shape");
+    syncLibrary(id, shape2, "sha-2");
+    expect(readLibrary(id)!.modes[0].installedVersion).toBe("0.1.0");
+    expect(readLibrary(id)!.modes[0].manifestVersion).toBe("0.3.0");
+
+    acceptModeUpdate(id, "alpha");
+    const lib = readLibrary(id)!;
+    expect(lib.modes[0].installedVersion).toBe("0.3.0");
+    expect(lib.modes[0].manifestVersion).toBe("0.3.0");
+  });
+
+  test("idempotent when already up to date", () => {
+    const id = "accept-idem";
+    const repoDir = setupLibraryDir(id);
+    makeMode(join(repoDir, "alpha"), "alpha", "0.1.0");
+    const shape = detectRepoShape(repoDir, id);
+    if (shape.kind !== "library") throw new Error("expected library shape");
+    linkLibrary(id, repoDir, shape, { type: "github", url: "x", ref: "main" }, "sha-1");
+
+    const before = readLibrary(id)!;
+    const after = acceptModeUpdate(id, "alpha");
+    expect(after.modes[0].installedVersion).toBe("0.1.0");
+    expect(after.lastSync).toBe(before.lastSync);
+  });
+
+  test("throws when library or mode unknown", () => {
+    expect(() => acceptModeUpdate("nope", "alpha")).toThrow(/Library nope not found/);
+
+    const id = "exists";
+    const repoDir = setupLibraryDir(id);
+    makeMode(join(repoDir, "alpha"), "alpha", "0.1.0");
+    const shape = detectRepoShape(repoDir, id);
+    if (shape.kind !== "library") throw new Error("expected library shape");
+    linkLibrary(id, repoDir, shape, { type: "github", url: "x", ref: "main" }, null);
+
+    expect(() => acceptModeUpdate(id, "ghost")).toThrow(/Mode ghost not found/);
+  });
+});
+
+// ── listLibraries ───────────────────────────────────────────────────────────
+
+describe("listLibraries", () => {
+  test("returns [] when libraries root is missing", () => {
+    expect(listLibraries()).toEqual([]);
+  });
+
+  test("enumerates installed libraries, sorted by lastSync desc", () => {
+    const ids = ["lib-a", "lib-b", "lib-c"];
+    for (const id of ids) {
+      const repoDir = setupLibraryDir(id);
+      makeMode(join(repoDir, "alpha"), "alpha", "0.1.0");
+      const shape = detectRepoShape(repoDir, id);
+      if (shape.kind !== "library") throw new Error("expected library shape");
+      linkLibrary(id, repoDir, shape, { type: "github", url: "x", ref: "main" }, "sha-1");
+    }
+
+    // Stomp lastSync values to deterministic timestamps so the sort order is testable.
+    const libA = readLibrary("lib-a")!;
+    const libB = readLibrary("lib-b")!;
+    const libC = readLibrary("lib-c")!;
+    writeLibrary({ ...libA, lastSync: 100 });
+    writeLibrary({ ...libB, lastSync: 300 });
+    writeLibrary({ ...libC, lastSync: 200 });
+
+    const list = listLibraries();
+    expect(list.map((l) => l.id)).toEqual(["lib-b", "lib-c", "lib-a"]);
+  });
+
+  test("skips corrupt sidecars without throwing", () => {
+    // Good library.
+    const goodId = "good-lib";
+    const repoDir = setupLibraryDir(goodId);
+    makeMode(join(repoDir, "alpha"), "alpha", "0.1.0");
+    const shape = detectRepoShape(repoDir, goodId);
+    if (shape.kind !== "library") throw new Error("expected library shape");
+    linkLibrary(goodId, repoDir, shape, { type: "github", url: "x", ref: "main" }, "sha-1");
+
+    // Corrupt sidecar.
+    const corruptId = "corrupt-lib";
+    const corruptDir = setupLibraryDir(corruptId);
+    writeFileSync(join(corruptDir, ".library.json"), "{{ not json", "utf-8");
+
+    // Dir with no sidecar (treated as in-flight — readLibrary returns null).
+    setupLibraryDir("no-sidecar");
+
+    const list = listLibraries();
+    expect(list.map((l) => l.id)).toEqual([goodId]);
+  });
+});
+
+// ── unlinkLibrary ───────────────────────────────────────────────────────────
+
+describe("unlinkLibrary", () => {
+  test("removes the on-disk dir and returns true", () => {
+    const id = "rm-lib";
+    const repoDir = setupLibraryDir(id);
+    makeMode(join(repoDir, "alpha"), "alpha", "0.1.0");
+    const shape = detectRepoShape(repoDir, id);
+    if (shape.kind !== "library") throw new Error("expected library shape");
+    linkLibrary(id, repoDir, shape, { type: "github", url: "x", ref: "main" }, "sha-1");
+    expect(existsSync(getLibraryDir(id))).toBe(true);
+
+    expect(unlinkLibrary(id)).toBe(true);
+    expect(existsSync(getLibraryDir(id))).toBe(false);
+  });
+
+  test("returns false when nothing to remove", () => {
+    expect(unlinkLibrary("ghost-lib")).toBe(false);
+  });
+});
+
+// ── getLibraryModePath ──────────────────────────────────────────────────────
+
+describe("getLibraryModePath", () => {
+  function setup(id: string) {
+    const repoDir = setupLibraryDir(id);
+    makeMode(join(repoDir, "alpha"), "alpha", "0.1.0");
+    const shape = detectRepoShape(repoDir, id);
+    if (shape.kind !== "library") throw new Error("expected library shape");
+    linkLibrary(id, repoDir, shape, { type: "github", url: "x", ref: "main" }, "sha-1");
+    return repoDir;
+  }
+
+  test("returns absolute path when mode exists on disk", () => {
+    const repoDir = setup("path-lib");
+    const resolved = getLibraryModePath("path-lib", "alpha");
+    expect(resolved).toBe(join(repoDir, "alpha"));
+  });
+
+  test("returns null when library unknown", () => {
+    expect(getLibraryModePath("ghost", "alpha")).toBeNull();
+  });
+
+  test("returns null when mode unknown", () => {
+    setup("known-lib");
+    expect(getLibraryModePath("known-lib", "ghost")).toBeNull();
+  });
+
+  test("returns null when on-disk path no longer has a manifest.ts", () => {
+    const repoDir = setup("stale-lib");
+    rmSync(join(repoDir, "alpha", "manifest.ts"), { force: true });
+    expect(getLibraryModePath("stale-lib", "alpha")).toBeNull();
+  });
+
+  test("returns null when on-disk path is gone entirely", () => {
+    const repoDir = setup("gone-lib");
+    rmSync(join(repoDir, "alpha"), { recursive: true, force: true });
+    expect(getLibraryModePath("gone-lib", "alpha")).toBeNull();
+  });
+});
+
+// ── getLibrariesDir / getLibraryDir sanity ──────────────────────────────────
+
+describe("path helpers honor mocked home", () => {
+  test("getLibrariesDir resolves under tmp home", () => {
+    expect(getLibrariesDir()).toBe(join(tmp, ".pneuma", "libraries"));
+  });
+
+  test("getLibraryDir composes id into libraries root", () => {
+    expect(getLibraryDir("foo")).toBe(join(tmp, ".pneuma", "libraries", "foo"));
+  });
+
+  test("getLibrarySidecarPath points at .library.json under the library dir", () => {
+    expect(getLibrarySidecarPath("foo")).toBe(
+      join(tmp, ".pneuma", "libraries", "foo", ".library.json"),
+    );
+  });
+});

--- a/core/__tests__/mode-resolver.test.ts
+++ b/core/__tests__/mode-resolver.test.ts
@@ -101,6 +101,24 @@ describe("parseModeSpecifier", () => {
   test("throws for invalid github specifier (empty user)", () => {
     expect(() => parseModeSpecifier("github:/repo")).toThrow("Invalid GitHub mode specifier");
   });
+
+  // ── URL specifiers ─────────────────────────────────────────────────
+
+  test("parses R2-style modes/<name>/<version>.tar.gz URL", () => {
+    const result = parseModeSpecifier("https://r2.example.com/modes/foo/1.0.tar.gz");
+    expect(result.type).toBe("url");
+    expect(result.name).toBe("foo");
+    expect(result.urlSpec?.url).toBe("https://r2.example.com/modes/foo/1.0.tar.gz");
+  });
+
+  test("parses a non-R2 tar.gz URL by falling back to filename stem", () => {
+    // No `modes/<name>/<version>.tar.gz` shape — fall back to the filename
+    // with version-like trailing tokens stripped.
+    const result = parseModeSpecifier("https://example.com/downloads/widget-1.2.3.tar.gz");
+    expect(result.type).toBe("url");
+    expect(result.urlSpec?.url).toBe("https://example.com/downloads/widget-1.2.3.tar.gz");
+    expect(result.name.length).toBeGreaterThan(0);
+  });
 });
 
 // ── resolveMode integration tests ─────────────────────────────────────

--- a/core/favorites.ts
+++ b/core/favorites.ts
@@ -1,0 +1,103 @@
+/**
+ * Favorites — per-user pinned mode list.
+ *
+ * Persisted at `~/.pneuma/favorites.json`. A flat list of mode names
+ * (`["webcraft", "slide", …]`); display order in the launcher reflects
+ * the file's order, so user-reordering is a future extension that
+ * doesn't require schema migration.
+ *
+ * When the file is absent we fall back to a curated default set so
+ * first-run users see a sensible Quick Start instead of an alphabetical
+ * blob. Defaults are intentionally a strict subset of the builtins
+ * shipped with Pneuma — a user-deleted builtin name will just no-op
+ * (the launcher filters favorites against the current registry before
+ * rendering).
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+import { homedir } from "node:os";
+import { randomBytes } from "node:crypto";
+
+/**
+ * First-run favorites. Order matters — these are surfaced in this order
+ * in the Quick Start grid and the project mode-tile picker until the
+ * user reorders. Keep this list small enough that all entries fit on
+ * one row of the Quick Start grid at typical viewport widths.
+ */
+export const DEFAULT_FAVORITES: readonly string[] = [
+  "webcraft",
+  "slide",
+  "diagram",
+  "illustrate",
+  "remotion",
+  "kami",
+];
+
+export interface FavoritesFile {
+  version: 1;
+  modes: string[];
+}
+
+export function getFavoritesPath(): string {
+  return join(homedir(), ".pneuma", "favorites.json");
+}
+
+/**
+ * Read the persisted favorites list. Returns the default set when the
+ * file is missing OR when it's malformed in any way — favorites are not
+ * load-bearing state, so we degrade silently rather than throw.
+ */
+export function readFavorites(): string[] {
+  const path = getFavoritesPath();
+  if (!existsSync(path)) return [...DEFAULT_FAVORITES];
+  try {
+    const raw = readFileSync(path, "utf-8");
+    const parsed = JSON.parse(raw) as Partial<FavoritesFile>;
+    if (parsed && Array.isArray(parsed.modes)) {
+      // Filter to strings and dedupe while preserving order.
+      const seen = new Set<string>();
+      const out: string[] = [];
+      for (const name of parsed.modes) {
+        if (typeof name !== "string") continue;
+        if (!name || seen.has(name)) continue;
+        seen.add(name);
+        out.push(name);
+      }
+      return out;
+    }
+  } catch {
+    /* fall through to default */
+  }
+  return [...DEFAULT_FAVORITES];
+}
+
+/**
+ * Atomic write (tmp + rename) so concurrent reads never see a torn
+ * file. Creates the parent dir if needed; tolerates missing parent.
+ */
+export function writeFavorites(modes: string[]): void {
+  const path = getFavoritesPath();
+  mkdirSync(dirname(path), { recursive: true });
+  // Dedupe + drop non-strings before persisting. Empty list is valid
+  // (user explicitly cleared favorites — we honor that instead of
+  // re-seeding defaults silently).
+  const seen = new Set<string>();
+  const cleaned: string[] = [];
+  for (const name of modes) {
+    if (typeof name !== "string") continue;
+    if (!name || seen.has(name)) continue;
+    seen.add(name);
+    cleaned.push(name);
+  }
+  const payload: FavoritesFile = { version: 1, modes: cleaned };
+  const tmp = `${path}.tmp.${process.pid}.${randomBytes(4).toString("hex")}`;
+  writeFileSync(tmp, JSON.stringify(payload, null, 2), "utf-8");
+  renameSync(tmp, path);
+}

--- a/core/github-cli.ts
+++ b/core/github-cli.ts
@@ -1,0 +1,227 @@
+/**
+ * GitHub CLI bridge — auth-detection + repo-create wrapper.
+ *
+ * Pneuma's author-side flow leans on a working local `gh` install (with
+ * `gh auth login` already done). This module is the thin layer that
+ * answers "is gh ready?" for the settings UI and runs the few gh
+ * commands we actually invoke.
+ *
+ * No PAT fallback in v1 — when gh is missing or unauthenticated, the
+ * settings panel surfaces an install hint. The `library push` path
+ * still works through whatever git credentials the user has set up
+ * (gh credential helper, ssh, system keychain), it just won't help
+ * configure them.
+ */
+
+const GH_PROBE_TIMEOUT_MS = 5_000;
+
+export interface GhStatus {
+  /** True when `gh` is on PATH and responds to `gh --version`. */
+  installed: boolean;
+  /** True when `gh auth status` reports an active session. */
+  authenticated: boolean;
+  /** Login handle from `gh api user` when authenticated. */
+  username?: string;
+  /** Resolved gh version string (best-effort). */
+  version?: string;
+  /** When installed=false or authenticated=false, a friendly remediation. */
+  hint?: string;
+}
+
+/**
+ * Probe local `gh` install + auth. Best-effort and fast — every value is
+ * optional so a partial probe (e.g. gh present but `gh api user` slow)
+ * still yields useful UI state.
+ *
+ * Cached per-call: callers (the launcher settings panel, the CLI's `library
+ * status` summary) hit this every few seconds at worst.
+ */
+export async function detectGh(): Promise<GhStatus> {
+  // Step 1 — `gh --version`. Fast, no network. Use it as the installed
+  // probe.
+  let version: string | undefined;
+  try {
+    const proc = Bun.spawn(["gh", "--version"], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const exited = await Promise.race([
+      proc.exited,
+      new Promise<number>((resolve) =>
+        setTimeout(() => {
+          try {
+            proc.kill();
+          } catch {
+            /* ignore */
+          }
+          resolve(1);
+        }, GH_PROBE_TIMEOUT_MS),
+      ),
+    ]);
+    if (exited === 0) {
+      const out = await new Response(proc.stdout).text();
+      const match = out.match(/gh version ([^\s]+)/);
+      version = match ? match[1] : undefined;
+    }
+  } catch {
+    // `gh` not on PATH → fall through to "not installed".
+  }
+
+  if (!version) {
+    return {
+      installed: false,
+      authenticated: false,
+      hint: "Install the GitHub CLI to publish libraries: https://cli.github.com/ (e.g. `brew install gh`).",
+    };
+  }
+
+  // Step 2 — `gh auth status`. Slower (touches keyring), but still local.
+  // We discriminate three results: authenticated / unauthenticated /
+  // probe-failed. Probe-failed is reported as unauthenticated with a
+  // generic hint, since the UX is the same.
+  let authed = false;
+  try {
+    const proc = Bun.spawn(["gh", "auth", "status"], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const exited = await Promise.race([
+      proc.exited,
+      new Promise<number>((resolve) =>
+        setTimeout(() => {
+          try {
+            proc.kill();
+          } catch {
+            /* ignore */
+          }
+          resolve(1);
+        }, GH_PROBE_TIMEOUT_MS),
+      ),
+    ]);
+    authed = exited === 0;
+  } catch {
+    authed = false;
+  }
+
+  if (!authed) {
+    return {
+      installed: true,
+      authenticated: false,
+      version,
+      hint: "Sign in with `gh auth login` to enable library publish.",
+    };
+  }
+
+  // Step 3 — `gh api user`. Optional; just gives the settings panel a name
+  // to show.
+  let username: string | undefined;
+  try {
+    const proc = Bun.spawn(["gh", "api", "user", "--jq", ".login"], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const exited = await Promise.race([
+      proc.exited,
+      new Promise<number>((resolve) =>
+        setTimeout(() => {
+          try {
+            proc.kill();
+          } catch {
+            /* ignore */
+          }
+          resolve(1);
+        }, GH_PROBE_TIMEOUT_MS),
+      ),
+    ]);
+    if (exited === 0) {
+      const out = (await new Response(proc.stdout).text()).trim();
+      if (out) username = out;
+    }
+  } catch {
+    // Non-fatal — we have authenticated=true already.
+  }
+
+  return {
+    installed: true,
+    authenticated: true,
+    version,
+    ...(username ? { username } : {}),
+  };
+}
+
+// ── Repo creation ───────────────────────────────────────────────────────────
+
+export interface CreateRepoOptions {
+  /** `<user>/<repo>` or just `<repo>` (uses gh's default owner). */
+  name: string;
+  /** Public or private. Default "public". */
+  visibility?: "public" | "private";
+  /** Path to the local directory to push as the initial commit. */
+  sourcePath: string;
+  /** Optional one-line repo description. */
+  description?: string;
+}
+
+export interface CreateRepoResult {
+  /** Resolved `<owner>/<repo>` slug. */
+  fullName: string;
+  /** HTTPS URL (gh prints this on success). */
+  url: string;
+}
+
+/**
+ * Create a GitHub repo and push the source dir as the initial commit.
+ * Runs `gh repo create … --source --push` in one shot, then captures the
+ * resulting URL from stdout.
+ *
+ * Requires `gh` installed AND authenticated. Throws with a friendly hint
+ * when either is missing — callers (CLI + UI) surface that text directly.
+ */
+export async function createRepo(opts: CreateRepoOptions): Promise<CreateRepoResult> {
+  const status = await detectGh();
+  if (!status.installed) {
+    throw new Error(
+      status.hint || "GitHub CLI not installed. Install it from https://cli.github.com/",
+    );
+  }
+  if (!status.authenticated) {
+    throw new Error(
+      status.hint || "Not signed in to GitHub. Run `gh auth login` first.",
+    );
+  }
+
+  const visibility = opts.visibility ?? "public";
+  const args = [
+    "repo",
+    "create",
+    opts.name,
+    `--${visibility}`,
+    "--source",
+    opts.sourcePath,
+    "--push",
+  ];
+  if (opts.description) {
+    args.push("--description", opts.description);
+  }
+
+  const proc = Bun.spawn(["gh", ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const exited = await proc.exited;
+  const stdout = (await new Response(proc.stdout).text()).trim();
+  const stderr = (await new Response(proc.stderr).text()).trim();
+  if (exited !== 0) {
+    throw new Error(
+      `gh repo create failed (exit ${exited}): ${stderr || stdout || "unknown error"}`,
+    );
+  }
+
+  // gh prints the URL on success. Pull it out, and also try `gh repo
+  // view --json` as a fallback in case the output format ever changes.
+  const urlMatch = stdout.match(/https?:\/\/github\.com\/[^\s]+/);
+  const url = urlMatch ? urlMatch[0] : `https://github.com/${opts.name}`;
+  const fullName = url.replace(/^https?:\/\/github\.com\//, "");
+
+  return { fullName, url };
+}

--- a/core/library-publish.ts
+++ b/core/library-publish.ts
@@ -1,0 +1,418 @@
+/**
+ * Library publish — author-side operations for a multi-mode library.
+ *
+ * The consume side (clone, detect, link, sync) lives in `library-registry.ts`.
+ * This module covers the inverse flow: scaffold a brand-new library, copy a
+ * mode into an existing one, push to its GitHub remote.
+ *
+ * Each operation is single-step and reversible by the user. We deliberately
+ * do not chain "init + commit + push" by default — the user reviews what
+ * landed locally before going public.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  cpSync,
+  rmSync,
+  statSync,
+} from "node:fs";
+import { dirname, join, basename, isAbsolute, normalize, sep, resolve } from "node:path";
+import {
+  detectRepoShape,
+  getLibrariesDir,
+  getLibraryDir,
+  getLibrarySidecarPath,
+  linkLibrary,
+  syncLibrary,
+  readLibrary,
+  writeLibrary,
+  type RepoShape,
+} from "./library-registry.js";
+import type { InstalledLibrary, LibraryManifest } from "./types/library.js";
+
+const GIT_TIMEOUT_MS = 30_000;
+
+/** Initial scaffolding planted by `pneuma library init`. */
+const STARTER_README = (name: string) => `# ${name}
+
+A [Pneuma](https://github.com/pandazki/pneuma-skills) mode library.
+
+Install it from any Pneuma session with:
+
+\`\`\`
+pneuma mode add github:<your-user>/<your-repo>
+\`\`\`
+
+## Modes
+
+Add modes via \`pneuma library publish <mode-name>\` from any local mode.
+This file is regenerated as you publish — feel free to edit freely below.
+`;
+
+const STARTER_GITIGNORE = `# Pneuma library sidecar
+.library.json
+
+# Local-only artifacts
+.DS_Store
+node_modules
+`;
+
+// ── Init ────────────────────────────────────────────────────────────────────
+
+export interface InitLocalLibraryOptions {
+  /** Library slug — also the directory name under ~/.pneuma/libraries/. */
+  name: string;
+  /** Display name shown in the launcher card. Defaults to `name`. */
+  displayName?: string;
+  /** One-line description for the launcher card. */
+  description?: string;
+  /** Optional author handle (display only). */
+  author?: string;
+}
+
+/**
+ * Scaffold a brand-new local library and write its `.library.json` sidecar.
+ *
+ * The result is a working library directory ready for `git remote add` +
+ * `git push`. We deliberately leave remote wiring to the user (or to the
+ * `--github` flag in the CLI, which uses `gh repo create --source --push`
+ * for a one-shot init + remote + push).
+ */
+export function initLocalLibrary(opts: InitLocalLibraryOptions): InstalledLibrary {
+  const id = opts.name;
+  validateLibraryId(id);
+  const dir = getLibraryDir(id);
+  if (existsSync(dir)) {
+    throw new Error(
+      `[library-publish] ${dir} already exists. Pick a different name or unlink the existing library first.`,
+    );
+  }
+  mkdirSync(dir, { recursive: true });
+
+  // Write the repo-side manifest. Authors expand it later (description,
+  // explicit modes list) — we ship a minimal stub.
+  const repoManifest: LibraryManifest = {
+    version: 1,
+    name: id,
+    ...(opts.displayName ? { displayName: opts.displayName } : {}),
+    ...(opts.description ? { description: opts.description } : {}),
+    ...(opts.author ? { author: opts.author } : {}),
+    modes: [],
+  };
+  writeFileSync(
+    join(dir, "pneuma.library.json"),
+    JSON.stringify(repoManifest, null, 2),
+    "utf-8",
+  );
+  writeFileSync(join(dir, "README.md"), STARTER_README(opts.displayName || id), "utf-8");
+  writeFileSync(join(dir, ".gitignore"), STARTER_GITIGNORE, "utf-8");
+
+  // Init the git repo. We don't fail the whole init if git is missing —
+  // libraries can be useful locally; the user just can't push.
+  try {
+    runGitSync(["init", "-b", "main"], dir);
+    runGitSync(["add", "."], dir);
+    runGitSync(
+      ["commit", "-m", `Initial commit: ${id} library scaffold`],
+      dir,
+    );
+  } catch (err) {
+    console.warn(
+      `[library-publish] git init failed (continuing without git): ${String(err)}`,
+    );
+  }
+
+  // Write the consume-side sidecar. The library starts empty until the
+  // first publish.
+  const shape: Extract<RepoShape, { kind: "library" }> = {
+    kind: "library",
+    manifest: repoManifest,
+    modes: [],
+  };
+  const report = linkLibrary(
+    id,
+    dir,
+    shape,
+    { type: "local", path: dir },
+    readGitShaSync(dir),
+  );
+  return report.library;
+}
+
+// ── Publish ─────────────────────────────────────────────────────────────────
+
+export interface PublishOptions {
+  /** Absolute path to the mode dir being published (must have manifest.ts). */
+  sourceModeDir: string;
+  /** Target library id (= dir name under ~/.pneuma/libraries/). */
+  libraryId: string;
+  /**
+   * Optional override for the mode's name inside the library. Defaults to
+   * the source dir basename, which the resolver then surfaces verbatim.
+   */
+  name?: string;
+  /**
+   * When true, push to the library's git remote after committing. Off by
+   * default — most flows want the user to inspect locally first.
+   */
+  push?: boolean;
+}
+
+export interface PublishResult {
+  /** Path the mode landed at inside the library. */
+  destDir: string;
+  /** Updated library state after sync. */
+  library: InstalledLibrary;
+  /** True when the mode was added; false when it was already present and got rewritten. */
+  added: boolean;
+  /** True when a git commit was created. False when the working tree was already clean. */
+  committed: boolean;
+  /** True when `push: true` was requested AND the push succeeded. */
+  pushed: boolean;
+}
+
+/**
+ * Copy a mode directory into a linked library, update the repo's
+ * `pneuma.library.json` (when present) to include the new mode, sync the
+ * sidecar, and optionally push.
+ *
+ * The source is copied **into** the library — we don't move or symlink.
+ * That keeps the original (typically `~/.pneuma/modes/<x>/` or a project
+ * session dir) intact, which is what users expect.
+ */
+export function publishModeToLibrary(opts: PublishOptions): PublishResult {
+  const lib = readLibrary(opts.libraryId);
+  if (!lib) {
+    throw new Error(`[library-publish] Library "${opts.libraryId}" is not linked.`);
+  }
+  const libDir = getLibraryDir(opts.libraryId);
+  if (!existsSync(opts.sourceModeDir)) {
+    throw new Error(`[library-publish] Source mode dir not found: ${opts.sourceModeDir}`);
+  }
+  if (!hasManifest(opts.sourceModeDir)) {
+    throw new Error(
+      `[library-publish] ${opts.sourceModeDir} is not a mode package (no manifest.ts).`,
+    );
+  }
+
+  const modeName = (opts.name || basename(opts.sourceModeDir)).trim();
+  if (!modeName) {
+    throw new Error(`[library-publish] Could not derive a mode name; pass --as <name>.`);
+  }
+  validateLibraryId(modeName); // mode names share the same slug rules
+
+  const destDir = join(libDir, modeName);
+  const safe = safeSubpath(libDir, modeName);
+  if (!safe || safe !== destDir) {
+    throw new Error(`[library-publish] Mode name "${modeName}" escapes the library root`);
+  }
+
+  const wasPresent = existsSync(destDir);
+  if (wasPresent) {
+    rmSync(destDir, { recursive: true, force: true });
+  }
+  cpSync(opts.sourceModeDir, destDir, { recursive: true });
+
+  // Update the repo-side index, if one exists. Auto-scan libraries don't
+  // strictly need an entry, but a maintained `pneuma.library.json` lets
+  // authors curate display order and intentionally omit WIP dirs.
+  upsertRepoManifestEntry(libDir, modeName);
+
+  // Reconcile the consume-side sidecar.
+  const shape = detectRepoShape(libDir, lib.name);
+  if (shape.kind !== "library") {
+    throw new Error(
+      `[library-publish] Library ${opts.libraryId} no longer looks like a library after publish — aborting`,
+    );
+  }
+  const sha = readGitShaSync(libDir);
+  const reconciled = syncLibrary(opts.libraryId, shape, sha);
+
+  // Stage + commit. We tolerate "nothing to commit" because rewriting an
+  // already-current mode is a valid no-op publish (e.g. user clicked the
+  // button twice).
+  let committed = false;
+  try {
+    runGitSync(["add", "-A"], libDir);
+    if (hasStagedChanges(libDir)) {
+      const verb = wasPresent ? "update" : "add";
+      runGitSync(
+        [
+          "commit",
+          "-m",
+          `library: ${verb} ${modeName}`,
+        ],
+        libDir,
+      );
+      committed = true;
+    }
+  } catch (err) {
+    console.warn(`[library-publish] git commit failed: ${String(err)}`);
+  }
+
+  // After commit, the sha may have moved — re-record so the sidecar
+  // matches HEAD.
+  if (committed) {
+    const newSha = readGitShaSync(libDir);
+    const refreshed = readLibrary(opts.libraryId);
+    if (refreshed) {
+      writeLibrary({ ...refreshed, sha: newSha, lastSync: Date.now() });
+    }
+  }
+
+  let pushed = false;
+  if (opts.push) {
+    try {
+      pushLibrary(opts.libraryId);
+      pushed = true;
+    } catch (err) {
+      // Bubble up — push failure is the most common author-side error
+      // and the user needs to see it explicitly.
+      throw new Error(
+        `Published locally but push failed: ${err instanceof Error ? err.message : String(err)}. ` +
+          `Fix git credentials (try \`gh auth login\`) and run \`pneuma library push ${opts.libraryId}\`.`,
+      );
+    }
+  }
+
+  return {
+    destDir,
+    library: reconciled.library,
+    added: !wasPresent,
+    committed,
+    pushed,
+  };
+}
+
+/**
+ * Push the library's local clone to its `origin` remote. Used by both the
+ * CLI (`pneuma library push`) and the publish `--push` flag.
+ */
+export function pushLibrary(libraryId: string): void {
+  const dir = getLibraryDir(libraryId);
+  if (!existsSync(dir)) {
+    throw new Error(`Library "${libraryId}" is not linked locally.`);
+  }
+  if (!existsSync(join(dir, ".git"))) {
+    throw new Error(
+      `Library "${libraryId}" has no git repo. Run \`git init\` + \`git remote add origin …\` first, ` +
+        `or re-create with \`pneuma library init\`.`,
+    );
+  }
+  runGitSync(["push", "origin", "HEAD"], dir);
+}
+
+/**
+ * Idempotent insert/update of one entry in the repo-side
+ * `pneuma.library.json`. When the file is absent we leave it that way —
+ * the resolver's auto-scan path picks up the mode on next install.
+ */
+function upsertRepoManifestEntry(libDir: string, modeName: string): void {
+  const path = join(libDir, "pneuma.library.json");
+  if (!existsSync(path)) return;
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf-8");
+  } catch {
+    return;
+  }
+  let parsed: LibraryManifest;
+  try {
+    parsed = JSON.parse(raw) as LibraryManifest;
+  } catch {
+    return;
+  }
+  const entries = parsed.modes ?? [];
+  if (entries.some((e) => (e.name ?? basename(e.path)) === modeName)) {
+    return; // already listed
+  }
+  entries.push({ path: modeName });
+  parsed.modes = entries;
+  writeFileSync(path, JSON.stringify(parsed, null, 2), "utf-8");
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function hasManifest(dir: string): boolean {
+  return (
+    existsSync(join(dir, "manifest.ts")) ||
+    existsSync(join(dir, "manifest.js"))
+  );
+}
+
+/**
+ * Library + mode slug rules: alphanumerics, dash, underscore, dot. Same
+ * restrictions on both because mode dir names sit inside library dirs.
+ * Reject control characters and path separators outright.
+ */
+function validateLibraryId(id: string): void {
+  if (!id || id.length > 80) {
+    throw new Error(`Invalid library/mode name: must be 1–80 chars`);
+  }
+  if (!/^[A-Za-z0-9._-]+$/.test(id)) {
+    throw new Error(
+      `Invalid library/mode name "${id}": use only letters, digits, dot, dash, underscore`,
+    );
+  }
+  if (id.startsWith(".") || id.startsWith("-")) {
+    throw new Error(`Library/mode name must not start with "." or "-"`);
+  }
+}
+
+function safeSubpath(root: string, rel: string): string | null {
+  if (isAbsolute(rel)) return null;
+  const resolved = normalize(join(root, rel));
+  if (resolved !== root && !resolved.startsWith(root + sep)) return null;
+  return resolved;
+}
+
+function runGitSync(args: string[], cwd: string): string {
+  const proc = Bun.spawnSync(["git", ...args], {
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+    // Bun.spawnSync doesn't honor a timeout option, but `git` operations
+    // here are local-only except `push` — keep the helper simple.
+  });
+  if (proc.exitCode !== 0) {
+    const stderr = new TextDecoder().decode(proc.stderr).trim();
+    throw new Error(`git ${args[0]} failed (code ${proc.exitCode}): ${stderr}`);
+  }
+  return new TextDecoder().decode(proc.stdout);
+}
+
+function readGitShaSync(cwd: string): string | null {
+  try {
+    const out = runGitSync(["rev-parse", "HEAD"], cwd);
+    const sha = out.trim();
+    return sha || null;
+  } catch {
+    return null;
+  }
+}
+
+function hasStagedChanges(cwd: string): boolean {
+  try {
+    const proc = Bun.spawnSync(["git", "diff", "--cached", "--quiet"], {
+      cwd,
+      stdout: "ignore",
+      stderr: "ignore",
+    });
+    return proc.exitCode !== 0;
+  } catch {
+    return false;
+  }
+}
+
+// Re-export for callers that compose with library-registry without
+// pulling that module directly.
+export { getLibrariesDir, getLibraryDir, getLibrarySidecarPath };
+
+// Silence the "unused" lint for `resolve` / `statSync` / `dirname` —
+// kept for future helpers (path-normalization, conflict-resolution).
+void resolve;
+void statSync;
+void dirname;

--- a/core/library-registry.ts
+++ b/core/library-registry.ts
@@ -1,0 +1,608 @@
+/**
+ * Library Registry — `~/.pneuma/libraries/` CRUD layer.
+ *
+ * One library = one cloned repo containing N modes. Each lives under
+ * `~/.pneuma/libraries/<id>/` next to a `.library.json` sidecar that
+ * tracks source URL, last-synced git sha, and per-mode activation.
+ *
+ * This module is the single source of truth for that directory tree.
+ * It owns shape detection (`detectRepoShape`), the link / sync / activate
+ * lifecycle, and atomic sidecar reads/writes. Higher layers (the resolver,
+ * CLI, server routes) call in here — they do not touch the layout
+ * directly.
+ *
+ * Design notes:
+ * - Sync API to match the surrounding sync resolver / mode-loader code.
+ *   Git invocations are spawned via `Bun.spawn` and awaited; everything
+ *   else is plain fs.
+ * - Writes are atomic (tmp-then-rename) so concurrent pneuma processes
+ *   can't observe a torn `.library.json`.
+ * - "Not found" is a `null` return, not an exception. Schema errors and
+ *   filesystem failures still throw — they're bugs, not flow control.
+ */
+
+import {
+  existsSync,
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  renameSync,
+  rmSync,
+  statSync,
+} from "node:fs";
+import { join, basename, isAbsolute, normalize, sep } from "node:path";
+import { homedir } from "node:os";
+import { randomBytes } from "node:crypto";
+import type {
+  InstalledLibrary,
+  InstalledLibraryMode,
+  LibraryManifest,
+  LibrarySource,
+} from "./types/library.js";
+
+/** Root directory for all installed libraries. */
+export function getLibrariesDir(): string {
+  return join(homedir(), ".pneuma", "libraries");
+}
+
+/** Absolute path to one library's directory. */
+export function getLibraryDir(id: string): string {
+  return join(getLibrariesDir(), id);
+}
+
+/** Absolute path to one library's sidecar. */
+export function getLibrarySidecarPath(id: string): string {
+  return join(getLibraryDir(id), ".library.json");
+}
+
+// ── Shape detection ─────────────────────────────────────────────────────────
+
+/** Result of inspecting a repo on disk after clone/extract. */
+export type RepoShape =
+  | { kind: "single" }
+  | {
+      kind: "library";
+      /** Resolved library manifest — derived from `pneuma.library.json` or auto-scan. */
+      manifest: LibraryManifest;
+      /** Per-mode entries with resolved manifest version. */
+      modes: ResolvedRepoMode[];
+    };
+
+/** A mode discovered inside a library repo, with its manifest version resolved. */
+export interface ResolvedRepoMode {
+  /** Installed mode name (display + filesystem). */
+  name: string;
+  /** Path relative to the repo root, e.g. "modes/dual-reader". */
+  relPath: string;
+  /** Version read from the mode's manifest.ts. */
+  manifestVersion: string;
+}
+
+/**
+ * Inspect a freshly-cloned (or freshly-extracted) repo and classify it.
+ *
+ * Rules, in order:
+ * 1. Root has `manifest.ts` (or `.js`) → single-mode repo (legacy path, unchanged).
+ * 2. Root has `pneuma.library.json` → library, modes from explicit index.
+ * 3. Otherwise scan immediate subdirs; any subdir with `manifest.ts` → library.
+ *
+ * Throws on malformed `pneuma.library.json` or when an explicit entry points
+ * at a missing/non-mode path. A repo that matches neither pattern (no root
+ * manifest, no subdir manifests, no library.json) returns `{ kind: "single" }`
+ * to let the caller's existing single-mode validation throw the usual
+ * "missing manifest" error — that keeps the failure message stable.
+ *
+ * @param repoDir Absolute path to the cloned repo root.
+ * @param defaultLibraryName Library name to fall back to when the repo
+ *   doesn't ship a `pneuma.library.json` (typically `<user>-<repo>`).
+ */
+export function detectRepoShape(
+  repoDir: string,
+  defaultLibraryName: string,
+): RepoShape {
+  if (hasManifest(repoDir)) {
+    return { kind: "single" };
+  }
+
+  const libManifestPath = join(repoDir, "pneuma.library.json");
+  if (existsSync(libManifestPath)) {
+    const manifest = parseLibraryManifest(libManifestPath, defaultLibraryName);
+    const modes = resolveExplicitEntries(repoDir, manifest);
+    return { kind: "library", manifest, modes };
+  }
+
+  const scanned = autoScanModes(repoDir);
+  if (scanned.length > 0) {
+    const manifest: LibraryManifest = { version: 1, name: defaultLibraryName };
+    return { kind: "library", manifest, modes: scanned };
+  }
+
+  // No root manifest, no library manifest, no subdir manifests. Hand back
+  // `single` so the caller's existing validator surfaces the canonical
+  // "missing manifest.ts" error message — we don't want to break that path.
+  return { kind: "single" };
+}
+
+function hasManifest(dir: string): boolean {
+  return (
+    existsSync(join(dir, "manifest.ts")) ||
+    existsSync(join(dir, "manifest.js"))
+  );
+}
+
+function parseLibraryManifest(
+  path: string,
+  defaultName: string,
+): LibraryManifest {
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf-8");
+  } catch (err) {
+    throw new Error(`[library-registry] Failed to read ${path}: ${String(err)}`);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `[library-registry] ${path} is not valid JSON: ${String(err)}`,
+    );
+  }
+
+  if (!parsed || typeof parsed !== "object") {
+    throw new Error(`[library-registry] ${path}: expected JSON object`);
+  }
+
+  const obj = parsed as Record<string, unknown>;
+  if (obj.version !== 1) {
+    throw new Error(
+      `[library-registry] ${path}: unsupported version ${String(obj.version)} (expected 1)`,
+    );
+  }
+  const name = typeof obj.name === "string" && obj.name ? obj.name : defaultName;
+  const manifest: LibraryManifest = { version: 1, name };
+  if (typeof obj.displayName === "string") manifest.displayName = obj.displayName;
+  if (typeof obj.description === "string") manifest.description = obj.description;
+  if (typeof obj.author === "string") manifest.author = obj.author;
+  if (Array.isArray(obj.modes)) {
+    manifest.modes = obj.modes.map((entry, i) => {
+      if (!entry || typeof entry !== "object") {
+        throw new Error(
+          `[library-registry] ${path}: modes[${i}] must be an object`,
+        );
+      }
+      const e = entry as Record<string, unknown>;
+      if (typeof e.path !== "string" || !e.path) {
+        throw new Error(
+          `[library-registry] ${path}: modes[${i}].path is required`,
+        );
+      }
+      return {
+        path: e.path,
+        ...(typeof e.name === "string" && e.name ? { name: e.name } : {}),
+      };
+    });
+  }
+  return manifest;
+}
+
+function resolveExplicitEntries(
+  repoDir: string,
+  manifest: LibraryManifest,
+): ResolvedRepoMode[] {
+  if (!manifest.modes || manifest.modes.length === 0) {
+    // Explicit manifest but no entries → empty library is allowed but rare.
+    return [];
+  }
+  const out: ResolvedRepoMode[] = [];
+  for (const entry of manifest.modes) {
+    const safe = safeSubpath(repoDir, entry.path);
+    if (!safe) {
+      throw new Error(
+        `[library-registry] pneuma.library.json entry "${entry.path}" escapes the repo root`,
+      );
+    }
+    if (!hasManifest(safe)) {
+      throw new Error(
+        `[library-registry] pneuma.library.json entry "${entry.path}" has no manifest.ts`,
+      );
+    }
+    const name = entry.name ?? basename(safe);
+    out.push({
+      name,
+      relPath: entry.path,
+      manifestVersion: readManifestVersion(safe),
+    });
+  }
+  return out;
+}
+
+function autoScanModes(repoDir: string): ResolvedRepoMode[] {
+  let entries;
+  try {
+    entries = readdirSync(repoDir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const out: ResolvedRepoMode[] = [];
+  for (const ent of entries) {
+    if (!ent.isDirectory()) continue;
+    if (ent.name.startsWith(".")) continue; // skip .git, etc.
+    const sub = join(repoDir, ent.name);
+    if (!hasManifest(sub)) continue;
+    out.push({
+      name: ent.name,
+      relPath: ent.name,
+      manifestVersion: readManifestVersion(sub),
+    });
+  }
+  // Stable ordering for deterministic UI / sidecar.
+  out.sort((a, b) => a.name.localeCompare(b.name));
+  return out;
+}
+
+/**
+ * Pull the manifest's `version` field out without evaluating TS.
+ * Mirrors the regex extraction in `core/utils/manifest-parser.ts` but
+ * scoped to just the version — we don't need the rest here.
+ * Falls back to "0.0.0" when missing or unreadable.
+ */
+function readManifestVersion(modeDir: string): string {
+  for (const fname of ["manifest.ts", "manifest.js"]) {
+    const full = join(modeDir, fname);
+    if (!existsSync(full)) continue;
+    try {
+      const src = readFileSync(full, "utf-8");
+      const match = src.match(/version\s*:\s*["'`]([^"'`]+)["'`]/);
+      if (match) return match[1];
+    } catch {
+      // fall through
+    }
+  }
+  return "0.0.0";
+}
+
+function safeSubpath(root: string, rel: string): string | null {
+  if (isAbsolute(rel)) return null;
+  const resolved = normalize(join(root, rel));
+  // Must stay rooted under `root` (defense against "../" escapes).
+  if (resolved !== root && !resolved.startsWith(root + sep)) return null;
+  return resolved;
+}
+
+// ── Sidecar I/O ─────────────────────────────────────────────────────────────
+
+/**
+ * Read a library's `.library.json`. Returns null when the file is absent
+ * (which happens for first-time installs before the sidecar is written).
+ * Throws on schema mismatch — that's a real bug, not a missing-file case.
+ */
+export function readLibrary(id: string): InstalledLibrary | null {
+  const path = getLibrarySidecarPath(id);
+  if (!existsSync(path)) return null;
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf-8");
+  } catch (err) {
+    throw new Error(`[library-registry] Failed to read ${path}: ${String(err)}`);
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `[library-registry] ${path} is not valid JSON: ${String(err)}`,
+    );
+  }
+  if (!parsed || typeof parsed !== "object") {
+    throw new Error(`[library-registry] ${path}: expected JSON object`);
+  }
+  // We trust the shape since Pneuma is the only writer. Schema migrations
+  // would land here as discriminated branches.
+  return parsed as InstalledLibrary;
+}
+
+/** Atomic write of `.library.json`. Creates the parent dir if needed. */
+export function writeLibrary(library: InstalledLibrary): void {
+  const dir = getLibraryDir(library.id);
+  mkdirSync(dir, { recursive: true });
+  const path = getLibrarySidecarPath(library.id);
+  const tmp = `${path}.tmp.${process.pid}.${randomBytes(4).toString("hex")}`;
+  writeFileSync(tmp, JSON.stringify(library, null, 2), "utf-8");
+  renameSync(tmp, path);
+}
+
+// ── Listing ─────────────────────────────────────────────────────────────────
+
+/**
+ * Enumerate all installed libraries. Skips entries without a sidecar
+ * (treated as in-flight / corrupted; callers can offer a repair).
+ */
+export function listLibraries(): InstalledLibrary[] {
+  const root = getLibrariesDir();
+  if (!existsSync(root)) return [];
+  let entries;
+  try {
+    entries = readdirSync(root, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const out: InstalledLibrary[] = [];
+  for (const ent of entries) {
+    if (!ent.isDirectory()) continue;
+    if (ent.name.startsWith(".")) continue;
+    let lib: InstalledLibrary | null = null;
+    try {
+      lib = readLibrary(ent.name);
+    } catch {
+      continue; // skip corrupt sidecars; surfaced separately via repair UX
+    }
+    if (lib) out.push(lib);
+  }
+  out.sort((a, b) => b.lastSync - a.lastSync);
+  return out;
+}
+
+// ── Link (first-time install) ───────────────────────────────────────────────
+
+/** Result of a link or sync operation, suitable for CLI reporting. */
+export interface LibrarySyncReport {
+  library: InstalledLibrary;
+  added: string[];
+  removed: string[];
+  updated: { name: string; from: string; to: string }[];
+  /** True when the underlying git sha didn't change. */
+  noop: boolean;
+}
+
+/**
+ * Materialize an `InstalledLibrary` from a freshly-cloned repo + its
+ * detected shape. Used by the resolver's library branch after clone.
+ *
+ * @param id Library id (e.g. `<user>-<repo>`).
+ * @param repoDir Absolute path to the cloned repo on disk (matches `getLibraryDir(id)`).
+ * @param shape Detected repo shape (must be `kind: "library"`).
+ * @param source Where the library was linked from.
+ * @param sha Git sha (or content hash) observed for this clone, or null when unknown.
+ */
+export function linkLibrary(
+  id: string,
+  repoDir: string,
+  shape: Extract<RepoShape, { kind: "library" }>,
+  source: LibrarySource,
+  sha: string | null,
+): LibrarySyncReport {
+  // Refuse to install over an unrelated directory by accident.
+  const expectedDir = getLibraryDir(id);
+  if (normalize(repoDir) !== normalize(expectedDir)) {
+    throw new Error(
+      `[library-registry] linkLibrary: repoDir ${repoDir} does not match expected ${expectedDir}`,
+    );
+  }
+
+  const modes: InstalledLibraryMode[] = shape.modes.map((m) => ({
+    name: m.name,
+    path: m.relPath,
+    manifestVersion: m.manifestVersion,
+    activated: true,
+    installedVersion: m.manifestVersion,
+  }));
+
+  const library: InstalledLibrary = {
+    version: 1,
+    id,
+    name: shape.manifest.name,
+    ...(shape.manifest.displayName ? { displayName: shape.manifest.displayName } : {}),
+    ...(shape.manifest.description ? { description: shape.manifest.description } : {}),
+    ...(shape.manifest.author ? { author: shape.manifest.author } : {}),
+    source,
+    sha,
+    lastSync: Date.now(),
+    modes,
+  };
+  writeLibrary(library);
+  return {
+    library,
+    added: modes.map((m) => m.name),
+    removed: [],
+    updated: [],
+    noop: false,
+  };
+}
+
+// ── Sync (reconcile sidecar after re-fetch) ─────────────────────────────────
+
+/**
+ * Reconcile a library's sidecar against the current state of its on-disk
+ * repo. Caller is responsible for advancing the repo (git fetch + checkout
+ * or re-extract) before invoking this — `syncLibrary` does not touch git.
+ *
+ * Diff rules:
+ * - New mode (in repo, not in sidecar) → added, `activated: true` by default.
+ * - Removed mode (in sidecar, not in repo) → dropped.
+ * - Mode whose manifest version differs from the recorded `manifestVersion`
+ *   → recorded as `updated`; `installedVersion` is NOT bumped automatically
+ *   (mirrors the existing skill-update prompt — the user accepts updates
+ *   explicitly via the launcher).
+ * - `activated` is preserved for existing modes.
+ *
+ * @param id Library id.
+ * @param shape Detected shape from re-running `detectRepoShape`.
+ * @param newSha Git sha (or null) observed after the advance.
+ */
+export function syncLibrary(
+  id: string,
+  shape: Extract<RepoShape, { kind: "library" }>,
+  newSha: string | null,
+): LibrarySyncReport {
+  const prev = readLibrary(id);
+  if (!prev) {
+    throw new Error(
+      `[library-registry] syncLibrary: ${id} has no sidecar; call linkLibrary first`,
+    );
+  }
+
+  const prevByName = new Map(prev.modes.map((m) => [m.name, m]));
+  const nextByName = new Map(shape.modes.map((m) => [m.name, m]));
+
+  const added: string[] = [];
+  const updated: { name: string; from: string; to: string }[] = [];
+  const modes: InstalledLibraryMode[] = [];
+
+  for (const m of shape.modes) {
+    const prior = prevByName.get(m.name);
+    if (!prior) {
+      added.push(m.name);
+      modes.push({
+        name: m.name,
+        path: m.relPath,
+        manifestVersion: m.manifestVersion,
+        activated: true,
+        installedVersion: m.manifestVersion,
+      });
+      continue;
+    }
+    if (prior.manifestVersion !== m.manifestVersion) {
+      updated.push({
+        name: m.name,
+        from: prior.manifestVersion,
+        to: m.manifestVersion,
+      });
+    }
+    modes.push({
+      name: m.name,
+      path: m.relPath,
+      manifestVersion: m.manifestVersion,
+      activated: prior.activated,
+      installedVersion: prior.installedVersion,
+    });
+  }
+
+  const removed: string[] = [];
+  for (const m of prev.modes) {
+    if (!nextByName.has(m.name)) removed.push(m.name);
+  }
+
+  const noop =
+    prev.sha !== null &&
+    newSha !== null &&
+    prev.sha === newSha &&
+    added.length === 0 &&
+    removed.length === 0 &&
+    updated.length === 0;
+
+  const library: InstalledLibrary = {
+    ...prev,
+    name: shape.manifest.name,
+    ...(shape.manifest.displayName !== undefined
+      ? { displayName: shape.manifest.displayName }
+      : { displayName: prev.displayName }),
+    ...(shape.manifest.description !== undefined
+      ? { description: shape.manifest.description }
+      : { description: prev.description }),
+    ...(shape.manifest.author !== undefined
+      ? { author: shape.manifest.author }
+      : { author: prev.author }),
+    sha: newSha,
+    lastSync: Date.now(),
+    modes,
+  };
+  writeLibrary(library);
+  return { library, added, removed, updated, noop };
+}
+
+// ── Activation ──────────────────────────────────────────────────────────────
+
+/**
+ * Flip a mode's `activated` flag. Returns the updated library so callers
+ * can broadcast a UI tick. Throws when the library or mode doesn't exist —
+ * those are caller bugs (the UI shouldn't offer activation for things
+ * that aren't there).
+ */
+export function setModeActivated(
+  id: string,
+  modeName: string,
+  activated: boolean,
+): InstalledLibrary {
+  const prev = readLibrary(id);
+  if (!prev) {
+    throw new Error(`[library-registry] Library ${id} not found`);
+  }
+  const idx = prev.modes.findIndex((m) => m.name === modeName);
+  if (idx === -1) {
+    throw new Error(
+      `[library-registry] Mode ${modeName} not found in library ${id}`,
+    );
+  }
+  if (prev.modes[idx].activated === activated) return prev;
+  const modes = prev.modes.slice();
+  modes[idx] = { ...modes[idx], activated };
+  const next: InstalledLibrary = { ...prev, modes };
+  writeLibrary(next);
+  return next;
+}
+
+/**
+ * Accept the current `manifestVersion` of a mode as installed. Called by
+ * the launcher's skill-update flow when the user clicks "Update". Idempotent.
+ */
+export function acceptModeUpdate(id: string, modeName: string): InstalledLibrary {
+  const prev = readLibrary(id);
+  if (!prev) {
+    throw new Error(`[library-registry] Library ${id} not found`);
+  }
+  const idx = prev.modes.findIndex((m) => m.name === modeName);
+  if (idx === -1) {
+    throw new Error(
+      `[library-registry] Mode ${modeName} not found in library ${id}`,
+    );
+  }
+  const m = prev.modes[idx];
+  if (m.installedVersion === m.manifestVersion) return prev;
+  const modes = prev.modes.slice();
+  modes[idx] = { ...m, installedVersion: m.manifestVersion };
+  const next: InstalledLibrary = { ...prev, modes };
+  writeLibrary(next);
+  return next;
+}
+
+// ── Unlink ──────────────────────────────────────────────────────────────────
+
+/**
+ * Remove a library and its on-disk clone. Returns true when something was
+ * removed, false when the library wasn't there.
+ */
+export function unlinkLibrary(id: string): boolean {
+  const dir = getLibraryDir(id);
+  if (!existsSync(dir)) return false;
+  rmSync(dir, { recursive: true, force: true });
+  return true;
+}
+
+// ── Resolution helpers (used by registry endpoint) ──────────────────────────
+
+/**
+ * Absolute on-disk path for a library mode. Returns `null` when either
+ * the library or the mode is unknown — callers (the registry endpoint,
+ * the mode loader) treat this as "not installed" rather than an error.
+ */
+export function getLibraryModePath(id: string, modeName: string): string | null {
+  const lib = readLibrary(id);
+  if (!lib) return null;
+  const m = lib.modes.find((mm) => mm.name === modeName);
+  if (!m) return null;
+  const dir = getLibraryDir(id);
+  const safe = safeSubpath(dir, m.path);
+  if (!safe || !existsSync(safe)) return null;
+  // Sanity check — the directory should still look like a mode package.
+  if (!hasManifest(safe)) return null;
+  // Confirm the resolved path is actually a directory.
+  try {
+    if (!statSync(safe).isDirectory()) return null;
+  } catch {
+    return null;
+  }
+  return safe;
+}

--- a/core/mode-resolver.ts
+++ b/core/mode-resolver.ts
@@ -7,11 +7,35 @@
  * - github: "github:user/repo" or "github:user/repo#branch" — GitHub repository
  *
  * GitHub repositories are cloned to the ~/.pneuma/modes/{user}-{repo}/ cache directory.
+ *
+ * Multi-mode repos ("libraries") are detected at install time and routed
+ * to `~/.pneuma/libraries/<id>/` instead, with a `.library.json` sidecar
+ * tracking per-mode activation + last-synced git sha. See
+ * `core/library-registry.ts` for the shape rules.
  */
 
 import { resolve, join, basename } from "node:path";
-import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync, statSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+  statSync,
+  renameSync,
+  rmSync,
+} from "node:fs";
 import { homedir } from "node:os";
+import {
+  detectRepoShape,
+  getLibrariesDir,
+  getLibraryDir,
+  getLibrarySidecarPath,
+  linkLibrary,
+  syncLibrary,
+  unlinkLibrary,
+  type LibrarySyncReport,
+} from "./library-registry.js";
 
 export type ModeSourceType = "builtin" | "local" | "github" | "url";
 
@@ -121,8 +145,154 @@ export function parseModeSpecifier(specifier: string): {
 }
 
 /**
+ * Result of resolving a mode source — either a single mode or a library
+ * containing many modes. Single-mode resolution preserves the existing
+ * `ResolvedMode` shape for legacy callers (mode launch path).
+ */
+export type ResolveResult =
+  | { kind: "single"; resolved: ResolvedMode }
+  | {
+      kind: "library";
+      /** Atomic state after link/sync — added/removed/updated counts. */
+      report: LibrarySyncReport;
+      /** Absolute path to the library's on-disk root. */
+      libraryDir: string;
+      /** Original specifier as provided by the user. */
+      specifier: string;
+    };
+
+/**
+ * Resolve a mode specifier, supporting both single-mode and multi-mode
+ * (library) repos. Use this from install-aware callers (`pneuma mode add`,
+ * library server routes). Launch-path callers should keep using
+ * {@link resolveMode}, which throws a helpful error when the specifier
+ * points at a library.
+ */
+export async function resolveModeOrLibrary(
+  specifier: string,
+  projectRoot: string,
+): Promise<ResolveResult> {
+  const parsed = parseModeSpecifier(specifier);
+
+  switch (parsed.type) {
+    case "builtin":
+    case "local": {
+      // No library possibility — these specifiers point at a single mode
+      // by definition (either a builtin name or an absolute path).
+      const resolved = await resolveMode(specifier, projectRoot);
+      return { kind: "single", resolved };
+    }
+
+    case "github": {
+      const { user, repo, ref } = parsed.github!;
+      const id = `${user}-${repo}`;
+
+      // Path A — already installed as a library. Update in-place and sync
+      // the sidecar so activation flags and installedVersion carry over.
+      if (existsSync(getLibrarySidecarPath(id))) {
+        const libDir = getLibraryDir(id);
+        await ensureGithubMode(user, repo, ref, libDir);
+        const shape = detectRepoShape(libDir, id);
+        if (shape.kind === "library") {
+          const sha = await readGitSha(libDir);
+          const report = syncLibrary(id, shape, sha);
+          return { kind: "library", report, libraryDir: libDir, specifier };
+        }
+        // Repo morphed away from library back to single — rare, but rather
+        // than leave a stale sidecar around, drop it and fall through to
+        // the normal single-mode path which clones into modes/<id>/.
+        unlinkLibrary(id);
+      }
+
+      // Path B — fresh install. Clone into the single-mode cache; if it
+      // turns out to be a library, move into libraries/<id>/ and write a
+      // fresh sidecar.
+      const singleDir = join(MODES_CACHE_DIR, id);
+      await ensureGithubMode(user, repo, ref, singleDir);
+      const shape = detectRepoShape(singleDir, id);
+
+      if (shape.kind === "single") {
+        validateModePackage(singleDir);
+        return {
+          kind: "single",
+          resolved: { type: "github", name: id, path: singleDir, specifier },
+        };
+      }
+
+      const libDir = getLibraryDir(id);
+      mkdirSync(getLibrariesDir(), { recursive: true });
+      if (existsSync(libDir)) {
+        rmSync(libDir, { recursive: true, force: true });
+      }
+      renameSync(singleDir, libDir);
+      const sha = await readGitSha(libDir);
+      const report = linkLibrary(
+        id,
+        libDir,
+        shape,
+        { type: "github", url: specifier, ref },
+        sha,
+      );
+      return { kind: "library", report, libraryDir: libDir, specifier };
+    }
+
+    case "url": {
+      const { url } = parsed.urlSpec!;
+      const id = parsed.name;
+
+      // Path A — already a library. Re-extract in-place (URL tarballs
+      // have no incremental update story), then reconcile sidecar.
+      if (existsSync(getLibrarySidecarPath(id))) {
+        const libDir = getLibraryDir(id);
+        await ensureUrlMode(url, libDir);
+        const shape = detectRepoShape(libDir, id);
+        if (shape.kind === "library") {
+          const report = syncLibrary(id, shape, null);
+          return { kind: "library", report, libraryDir: libDir, specifier };
+        }
+        unlinkLibrary(id);
+      }
+
+      // Path B — fresh extract to the single-mode cache, then maybe move.
+      const singleDir = join(MODES_CACHE_DIR, id);
+      await ensureUrlMode(url, singleDir);
+      const shape = detectRepoShape(singleDir, id);
+
+      if (shape.kind === "single") {
+        validateModePackage(singleDir);
+        return {
+          kind: "single",
+          resolved: { type: "url", name: id, path: singleDir, specifier },
+        };
+      }
+
+      const libDir = getLibraryDir(id);
+      mkdirSync(getLibrariesDir(), { recursive: true });
+      if (existsSync(libDir)) {
+        rmSync(libDir, { recursive: true, force: true });
+      }
+      renameSync(singleDir, libDir);
+      const report = linkLibrary(
+        id,
+        libDir,
+        shape,
+        { type: "url", url },
+        null,
+      );
+      return { kind: "library", report, libraryDir: libDir, specifier };
+    }
+  }
+}
+
+/**
  * Resolve a mode specifier to a local directory path.
  * For GitHub modes, this clones/updates the repository.
+ *
+ * When the specifier points at a multi-mode repo (library), this throws
+ * with a message directing the caller to {@link resolveModeOrLibrary} or
+ * to the `pneuma mode add` CLI. The launch path should never receive a
+ * library specifier directly — library modes are launched by their
+ * resolved on-disk path after `mode add`.
  *
  * @param specifier — Mode specifier string (e.g. "doc", "./my-mode", "github:user/repo")
  * @param projectRoot — Absolute path to the pneuma-skills project root
@@ -159,30 +329,20 @@ export async function resolveMode(
       };
     }
 
-    case "github": {
-      const { user, repo, ref } = parsed.github!;
-      const cacheDir = join(MODES_CACHE_DIR, `${user}-${repo}`);
-      await ensureGithubMode(user, repo, ref, cacheDir);
-      validateModePackage(cacheDir);
-      return {
-        type: "github",
-        name: parsed.name,
-        path: cacheDir,
-        specifier,
-      };
-    }
-
+    case "github":
     case "url": {
-      const { url } = parsed.urlSpec!;
-      const cacheDir = join(MODES_CACHE_DIR, parsed.name);
-      await ensureUrlMode(url, cacheDir);
-      validateModePackage(cacheDir);
-      return {
-        type: "url",
-        name: parsed.name,
-        path: cacheDir,
-        specifier,
-      };
+      // Delegate to library-aware resolver so a library specifier produces
+      // a single, helpful error instead of failing the "missing manifest.ts"
+      // check on the cloned repo root.
+      const r = await resolveModeOrLibrary(specifier, projectRoot);
+      if (r.kind === "library") {
+        const names = r.report.library.modes.map((m) => m.name).join(", ");
+        throw new Error(
+          `"${specifier}" is a mode library with ${r.report.library.modes.length} mode(s). ` +
+            `Run \`pneuma mode add ${specifier}\` first, then launch one of: ${names}.`,
+        );
+      }
+      return r.resolved;
     }
   }
 }
@@ -334,6 +494,22 @@ function patchViteEnvTokens(cacheDir: string): void {
       console.log(`[mode-resolver] Patched import.meta.env tokens in ${patched} bundle file(s) under .build/`);
     }
   } catch { /* .build/ access failed, skip */ }
+}
+
+/**
+ * Read the HEAD sha of a clone. Returns null when the directory isn't a
+ * git repo (e.g. URL-tarball extracts) or when `git` itself fails — both
+ * are non-fatal: callers persist the null and the library still works,
+ * just without sha-based "no updates" short-circuit.
+ */
+async function readGitSha(cacheDir: string): Promise<string | null> {
+  try {
+    const out = await runGit(["rev-parse", "HEAD"], cacheDir);
+    const sha = out.trim();
+    return sha || null;
+  } catch {
+    return null;
+  }
 }
 
 /**

--- a/core/types/index.ts
+++ b/core/types/index.ts
@@ -79,3 +79,11 @@ export type {
 
 export type { ProjectManifest, ProjectSummary } from "./project-manifest.js";
 export { isProjectManifest } from "./project-manifest.js";
+
+export type {
+  LibraryManifest,
+  LibraryModeEntry,
+  LibrarySource,
+  InstalledLibrary,
+  InstalledLibraryMode,
+} from "./library.js";

--- a/core/types/library.ts
+++ b/core/types/library.ts
@@ -1,0 +1,129 @@
+/**
+ * Mode Library — distribute multiple modes through a single source.
+ *
+ * Today a `github:user/repo` specifier resolves to a single mode (one
+ * `manifest.ts` at the repo root). A library lets one repo host N modes:
+ * `pneuma mode add github:user/repo` clones once into
+ * `~/.pneuma/libraries/<id>/`, and each contained mode is independently
+ * activated / deactivated / updated.
+ *
+ * Two shapes are surfaced here:
+ *
+ * 1. **LibraryManifest** — the optional `pneuma.library.json` at the repo
+ *    root. Authors use it to name the library + restrict / re-label which
+ *    subdirs ship as modes. If absent, the resolver auto-scans immediate
+ *    subdirs for `manifest.ts`.
+ *
+ * 2. **InstalledLibrary** — the `.library.json` sidecar Pneuma writes to
+ *    `~/.pneuma/libraries/<id>/`. Records the source URL/ref, last-synced
+ *    git sha, and per-mode activation + installed-version state so the
+ *    launcher can show "N updates available" and update on demand.
+ */
+
+// ── Repo side: `pneuma.library.json` ────────────────────────────────────────
+
+/** One entry in the repo-side library index. */
+export interface LibraryModeEntry {
+  /** Path to the mode directory, relative to the repo root. */
+  path: string;
+  /**
+   * Optional override for the mode's installed name. Defaults to the
+   * directory basename, which then defaults to the mode's manifest name.
+   */
+  name?: string;
+}
+
+/**
+ * The `pneuma.library.json` file at the root of a multi-mode repo. Fully
+ * optional — when absent, the resolver auto-scans immediate subdirs.
+ */
+export interface LibraryManifest {
+  /** Schema version. Currently always 1. */
+  version: 1;
+  /** Library slug. Defaults to `<user>-<repo>` for github sources. */
+  name: string;
+  /** Human-readable display name shown in the launcher. */
+  displayName?: string;
+  /** Optional one-line description for the launcher card. */
+  description?: string;
+  /** Optional author handle (display only). */
+  author?: string;
+  /** Explicit list of modes to ship. Absence falls back to auto-scan. */
+  modes?: LibraryModeEntry[];
+}
+
+// ── Local side: `.library.json` sidecar ─────────────────────────────────────
+
+/** Discriminated union of where a library was installed from. */
+export type LibrarySource =
+  | {
+      type: "github";
+      /** Original specifier, e.g. `github:user/repo#branch` */
+      url: string;
+      /** Resolved git ref (branch / tag). Default "main". */
+      ref: string;
+    }
+  | {
+      type: "url";
+      /** Tar.gz URL */
+      url: string;
+    }
+  | {
+      type: "local";
+      /** Absolute path the library was linked from (rarely useful) */
+      path: string;
+    };
+
+/** Per-mode state inside an installed library. */
+export interface InstalledLibraryMode {
+  /** Installed mode name (display + filesystem). */
+  name: string;
+  /** Relative path inside the library dir to the mode package. */
+  path: string;
+  /**
+   * Manifest version observed on last sync. Used to detect updates
+   * available since `installedVersion` was last accepted.
+   */
+  manifestVersion: string;
+  /**
+   * Whether this mode is visible in the launcher / loadable via
+   * `pneuma <name>`. Deactivated modes remain on disk so re-activation
+   * is a zero-cost local flip.
+   */
+  activated: boolean;
+  /**
+   * Last manifest version the user explicitly accepted (mirrors the
+   * existing skill-update dismiss flow). Equal to `manifestVersion`
+   * after install/update; lags when an update is available but
+   * unaccepted. `null` until first install.
+   */
+  installedVersion: string | null;
+}
+
+/** The `.library.json` sidecar Pneuma maintains. */
+export interface InstalledLibrary {
+  /** Schema version. Currently always 1. */
+  version: 1;
+  /** Stable library id. For github sources: `<user>-<repo>`. */
+  id: string;
+  /** Library slug from the repo manifest (or derived). */
+  name: string;
+  /** Optional display name (mirrors `LibraryManifest.displayName`). */
+  displayName?: string;
+  /** Optional description (mirrors `LibraryManifest.description`). */
+  description?: string;
+  /** Optional author handle (mirrors `LibraryManifest.author`). */
+  author?: string;
+  /** Where this library was linked from. */
+  source: LibrarySource;
+  /**
+   * Git sha (or content hash for non-git sources) observed on last sync.
+   * Used to short-circuit "no-op" syncs and to feed the launcher's
+   * "X updates available" surface.
+   */
+  sha: string | null;
+  /** Unix ms timestamp of the last successful sync. */
+  lastSync: number;
+  /** Per-mode state. Order matches launcher display order. */
+  modes: InstalledLibraryMode[];
+}

--- a/server/__tests__/library-routes.test.ts
+++ b/server/__tests__/library-routes.test.ts
@@ -1,0 +1,510 @@
+/**
+ * Tests for `server/library-routes.ts`.
+ *
+ * Pattern: in-memory Hono app + an in-memory bridge that records broadcasts,
+ * with `~/.pneuma/libraries/` re-rooted under a per-test tmpdir via the
+ * shared `node:os` homedir mock.
+ */
+
+import { describe, expect, test, beforeEach, afterEach, mock } from "bun:test";
+import {
+  mkdtempSync,
+  rmSync,
+  mkdirSync,
+  writeFileSync,
+  existsSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Hono } from "hono";
+
+// ── Home directory mock (shared pattern with library-registry.test.ts) ──────
+let currentHome = tmpdir();
+mock.module("node:os", () => {
+  const real = require("node:os");
+  return {
+    ...real,
+    homedir: () => currentHome,
+    default: { ...real, homedir: () => currentHome },
+  };
+});
+
+import { registerLibraryRoutes } from "../library-routes.js";
+import {
+  detectRepoShape,
+  linkLibrary,
+  getLibraryDir,
+  getLibrariesDir,
+  readLibrary,
+  setModeActivated,
+} from "../../core/library-registry.js";
+import { initLocalLibrary } from "../../core/library-publish.js";
+import type { InstalledLibrary, LibraryManifest } from "../../core/types/library.js";
+
+// ── Fixture helpers ─────────────────────────────────────────────────────────
+
+function makeMode(dir: string, name: string, version: string): void {
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, "manifest.ts"),
+    `export const manifest = { name: "${name}", version: "${version}" };\n`,
+    "utf-8",
+  );
+}
+
+function makeLibraryJson(repoDir: string, body: LibraryManifest): void {
+  mkdirSync(repoDir, { recursive: true });
+  writeFileSync(
+    join(repoDir, "pneuma.library.json"),
+    JSON.stringify(body, null, 2),
+    "utf-8",
+  );
+}
+
+interface RecordedBroadcast {
+  type: string;
+  [k: string]: unknown;
+}
+
+function makeApp(): {
+  app: Hono;
+  broadcasts: RecordedBroadcast[];
+  projectRoot: string;
+} {
+  const app = new Hono();
+  const broadcasts: RecordedBroadcast[] = [];
+  // projectRoot is only used by /api/libraries/link → resolveModeOrLibrary
+  // for the builtin / cache directory base. Tests that don't hit link
+  // pass any directory; tests that do use a path that exists.
+  const projectRoot = currentHome; // arbitrary; not exercised in most routes
+  registerLibraryRoutes(
+    app,
+    {
+      broadcastAll: (msg: unknown) => {
+        broadcasts.push(msg as RecordedBroadcast);
+      },
+    },
+    { projectRoot },
+  );
+  return { app, broadcasts, projectRoot };
+}
+
+/** Plant a fixture library on disk + register it via linkLibrary. */
+function plantLibraryFixture(
+  id: string,
+  modes: { name: string; version: string }[],
+): InstalledLibrary {
+  const libDir = getLibraryDir(id);
+  mkdirSync(libDir, { recursive: true });
+  makeLibraryJson(libDir, {
+    version: 1,
+    name: id,
+    displayName: id,
+    modes: modes.map((m) => ({ path: m.name })),
+  });
+  for (const m of modes) makeMode(join(libDir, m.name), m.name, m.version);
+  const shape = detectRepoShape(libDir, id);
+  if (shape.kind !== "library") throw new Error("expected library shape");
+  const report = linkLibrary(
+    id,
+    libDir,
+    shape,
+    { type: "local", path: libDir },
+    "sha-fixture",
+  );
+  return report.library;
+}
+
+let tmp: string;
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), "libroutes-"));
+  currentHome = tmp;
+  // Make sure the libraries root exists for listLibraries() readdir.
+  mkdirSync(getLibrariesDir(), { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+// ── GET /api/libraries ──────────────────────────────────────────────────────
+
+describe("GET /api/libraries", () => {
+  test("empty when nothing is linked", async () => {
+    const { app } = makeApp();
+    const res = await app.fetch(new Request("http://x/api/libraries"));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { libraries: InstalledLibrary[] };
+    expect(body.libraries).toEqual([]);
+  });
+
+  test("returns linked fixture libraries", async () => {
+    plantLibraryFixture("lib-a", [{ name: "alpha", version: "0.1.0" }]);
+    plantLibraryFixture("lib-b", [{ name: "beta", version: "0.2.0" }]);
+
+    const { app } = makeApp();
+    const res = await app.fetch(new Request("http://x/api/libraries"));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { libraries: InstalledLibrary[] };
+    const ids = body.libraries.map((l) => l.id).sort();
+    expect(ids).toEqual(["lib-a", "lib-b"]);
+  });
+});
+
+// ── POST /api/libraries/:id/mode/:name/activate + /deactivate ───────────────
+
+describe("POST /api/libraries/:id/mode/:name/activate", () => {
+  test("flips activated to true, broadcasts libraries_updated", async () => {
+    plantLibraryFixture("activ-lib", [{ name: "alpha", version: "0.1.0" }]);
+    // Start by flipping it off so the route's true flip is observable.
+    setModeActivated("activ-lib", "alpha", false);
+    expect(readLibrary("activ-lib")!.modes[0].activated).toBe(false);
+
+    const { app, broadcasts } = makeApp();
+    const res = await app.fetch(
+      new Request("http://x/api/libraries/activ-lib/mode/alpha/activate", {
+        method: "POST",
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { library: InstalledLibrary };
+    expect(body.library.modes[0].activated).toBe(true);
+
+    expect(broadcasts).toHaveLength(1);
+    expect(broadcasts[0].type).toBe("libraries_updated");
+  });
+
+  test("500 when library is unknown", async () => {
+    const { app } = makeApp();
+    const res = await app.fetch(
+      new Request("http://x/api/libraries/ghost/mode/alpha/activate", {
+        method: "POST",
+      }),
+    );
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toMatch(/not found/);
+  });
+});
+
+describe("POST /api/libraries/:id/mode/:name/deactivate", () => {
+  test("flips activated to false, broadcasts", async () => {
+    plantLibraryFixture("deact-lib", [{ name: "alpha", version: "0.1.0" }]);
+
+    const { app, broadcasts } = makeApp();
+    const res = await app.fetch(
+      new Request("http://x/api/libraries/deact-lib/mode/alpha/deactivate", {
+        method: "POST",
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { library: InstalledLibrary };
+    expect(body.library.modes[0].activated).toBe(false);
+    expect(broadcasts.map((b) => b.type)).toContain("libraries_updated");
+  });
+});
+
+// ── POST /api/libraries/:id/mode/:name/accept-update ────────────────────────
+
+describe("POST /api/libraries/:id/mode/:name/accept-update", () => {
+  test("bumps installedVersion to manifestVersion and broadcasts", async () => {
+    plantLibraryFixture("acc-lib", [{ name: "alpha", version: "0.1.0" }]);
+    // Simulate an upstream bump: rewrite the manifest + re-sync.
+    const libDir = getLibraryDir("acc-lib");
+    makeMode(join(libDir, "alpha"), "alpha", "0.3.0");
+    const shape = detectRepoShape(libDir, "acc-lib");
+    if (shape.kind !== "library") throw new Error("library expected");
+    const { syncLibrary } = await import("../../core/library-registry.js");
+    syncLibrary("acc-lib", shape, "sha-2");
+
+    expect(readLibrary("acc-lib")!.modes[0].installedVersion).toBe("0.1.0");
+
+    const { app, broadcasts } = makeApp();
+    const res = await app.fetch(
+      new Request("http://x/api/libraries/acc-lib/mode/alpha/accept-update", {
+        method: "POST",
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { library: InstalledLibrary };
+    expect(body.library.modes[0].installedVersion).toBe("0.3.0");
+    expect(broadcasts.map((b) => b.type)).toContain("libraries_updated");
+  });
+});
+
+// ── DELETE /api/libraries/:id ───────────────────────────────────────────────
+
+describe("DELETE /api/libraries/:id", () => {
+  test("removes a linked library, returns { ok, removed: true }, broadcasts", async () => {
+    plantLibraryFixture("rm-lib", [{ name: "alpha", version: "0.1.0" }]);
+    expect(existsSync(getLibraryDir("rm-lib"))).toBe(true);
+
+    const { app, broadcasts } = makeApp();
+    const res = await app.fetch(
+      new Request("http://x/api/libraries/rm-lib", { method: "DELETE" }),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; removed: boolean };
+    expect(body.ok).toBe(true);
+    expect(body.removed).toBe(true);
+    expect(existsSync(getLibraryDir("rm-lib"))).toBe(false);
+    expect(broadcasts.map((b) => b.type)).toContain("libraries_updated");
+  });
+
+  test("returns { ok, removed: false } when nothing to delete (still broadcasts)", async () => {
+    const { app, broadcasts } = makeApp();
+    const res = await app.fetch(
+      new Request("http://x/api/libraries/never-linked", { method: "DELETE" }),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; removed: boolean };
+    expect(body.removed).toBe(false);
+    expect(broadcasts.map((b) => b.type)).toContain("libraries_updated");
+  });
+});
+
+// ── POST /api/libraries/init ────────────────────────────────────────────────
+
+describe("POST /api/libraries/init", () => {
+  test("scaffolds a new library and broadcasts", async () => {
+    const { app, broadcasts } = makeApp();
+    const res = await app.fetch(
+      new Request("http://x/api/libraries/init", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          name: "new-lib",
+          displayName: "New Library",
+          description: "test",
+        }),
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      library: InstalledLibrary;
+      githubUrl?: string;
+    };
+    expect(body.library.id).toBe("new-lib");
+    expect(body.library.name).toBe("new-lib");
+    // No github sub-object was passed, so no githubUrl in response.
+    expect(body.githubUrl).toBeUndefined();
+    expect(broadcasts.map((b) => b.type)).toContain("libraries_updated");
+    expect(existsSync(getLibraryDir("new-lib"))).toBe(true);
+  });
+
+  test("400 when name is missing", async () => {
+    const { app } = makeApp();
+    const res = await app.fetch(
+      new Request("http://x/api/libraries/init", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({}),
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  test("400 when github.visibility is invalid", async () => {
+    const { app } = makeApp();
+    const res = await app.fetch(
+      new Request("http://x/api/libraries/init", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          name: "bad-vis",
+          github: { name: "u/r", visibility: "secret" },
+        }),
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  test("500 when init throws (e.g. duplicate name)", async () => {
+    // Pre-existing library with the same id.
+    initLocalLibrary({ name: "dup-init" });
+    const { app } = makeApp();
+    const res = await app.fetch(
+      new Request("http://x/api/libraries/init", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ name: "dup-init" }),
+      }),
+    );
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toMatch(/already exists/);
+  });
+});
+
+// ── POST /api/libraries/:id/sync ────────────────────────────────────────────
+
+describe("POST /api/libraries/:id/sync", () => {
+  test("local-source library: returns a sync report without doing git fetch", async () => {
+    plantLibraryFixture("sync-lib", [{ name: "alpha", version: "0.1.0" }]);
+
+    const { app, broadcasts } = makeApp();
+    const res = await app.fetch(
+      new Request("http://x/api/libraries/sync-lib/sync", { method: "POST" }),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      report: {
+        library: InstalledLibrary;
+        added: string[];
+        removed: string[];
+        updated: { name: string; from: string; to: string }[];
+        noop: boolean;
+      };
+    };
+    expect(body.report).toBeDefined();
+    expect(body.report.library.id).toBe("sync-lib");
+    expect(Array.isArray(body.report.added)).toBe(true);
+    expect(Array.isArray(body.report.removed)).toBe(true);
+    expect(Array.isArray(body.report.updated)).toBe(true);
+    expect(typeof body.report.noop).toBe("boolean");
+    expect(broadcasts.map((b) => b.type)).toContain("libraries_updated");
+  });
+
+  test("404 when library is unknown", async () => {
+    const { app } = makeApp();
+    const res = await app.fetch(
+      new Request("http://x/api/libraries/ghost-sync/sync", { method: "POST" }),
+    );
+    expect(res.status).toBe(404);
+  });
+});
+
+// ── POST /api/libraries/link ────────────────────────────────────────────────
+
+describe("POST /api/libraries/link", () => {
+  test("500 with error message for an invalid github specifier", async () => {
+    const { app } = makeApp();
+    const res = await app.fetch(
+      new Request("http://x/api/libraries/link", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        // github specifier without "/" → parseModeSpecifier throws.
+        body: JSON.stringify({ specifier: "github:onlyone" }),
+      }),
+    );
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toMatch(/Invalid GitHub mode specifier|github:user/);
+  });
+
+  test("400 when specifier is missing", async () => {
+    const { app } = makeApp();
+    const res = await app.fetch(
+      new Request("http://x/api/libraries/link", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({}),
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+});
+
+// ── POST /api/libraries/:id/publish ─────────────────────────────────────────
+
+describe("POST /api/libraries/:id/publish", () => {
+  test("publishes a fixture source mode into a library, broadcasts", async () => {
+    initLocalLibrary({ name: "pub-routes-lib" });
+    const src = join(tmp, "external-src", "alpha");
+    makeMode(src, "alpha", "0.1.0");
+
+    const { app, broadcasts } = makeApp();
+    const res = await app.fetch(
+      new Request("http://x/api/libraries/pub-routes-lib/publish", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ sourcePath: src }),
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      destDir: string;
+      library: InstalledLibrary;
+      added: boolean;
+    };
+    expect(body.added).toBe(true);
+    expect(body.library.modes.map((m) => m.name)).toContain("alpha");
+    expect(existsSync(join(body.destDir, "manifest.ts"))).toBe(true);
+    expect(broadcasts.map((b) => b.type)).toContain("libraries_updated");
+  });
+
+  test("400 when sourcePath is missing", async () => {
+    initLocalLibrary({ name: "missing-src-routes-lib" });
+    const { app } = makeApp();
+    const res = await app.fetch(
+      new Request("http://x/api/libraries/missing-src-routes-lib/publish", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({}),
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  test("500 when publish hits an underlying error (e.g. unknown library)", async () => {
+    const src = join(tmp, "external-src-2", "alpha");
+    makeMode(src, "alpha", "0.1.0");
+    const { app } = makeApp();
+    const res = await app.fetch(
+      new Request("http://x/api/libraries/ghost-publish-lib/publish", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ sourcePath: src }),
+      }),
+    );
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toMatch(/is not linked/);
+  });
+});
+
+// ── POST /api/libraries/:id/push ────────────────────────────────────────────
+
+describe("POST /api/libraries/:id/push", () => {
+  test("500 when the library has no git repo", async () => {
+    // Plant a library dir with a sidecar but no .git.
+    const id = "no-git-routes-lib";
+    const dir = getLibraryDir(id);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "pneuma.library.json"),
+      JSON.stringify({ version: 1, name: id, modes: [] }, null, 2),
+    );
+    const shape = detectRepoShape(dir, id);
+    if (shape.kind !== "library") throw new Error("library expected");
+    linkLibrary(id, dir, shape, { type: "local", path: dir }, null);
+
+    const { app } = makeApp();
+    const res = await app.fetch(
+      new Request(`http://x/api/libraries/${id}/push`, { method: "POST" }),
+    );
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toMatch(/no git repo|not linked/);
+  });
+});
+
+// ── GET /api/github/status ──────────────────────────────────────────────────
+
+describe("GET /api/github/status", () => {
+  test("returns a well-formed GhStatus shape", async () => {
+    const { app } = makeApp();
+    const res = await app.fetch(new Request("http://x/api/github/status"));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      installed: boolean;
+      authenticated: boolean;
+      version?: string;
+      hint?: string;
+      username?: string;
+    };
+    expect(typeof body.installed).toBe("boolean");
+    expect(typeof body.authenticated).toBe("boolean");
+  });
+});

--- a/server/index.ts
+++ b/server/index.ts
@@ -32,6 +32,7 @@ import { createProxyMiddleware, mergeProxyConfig, type ProxyConfigRef } from "./
 import type { ProxyRoute } from "../core/types/mode-manifest.js";
 import { startProxyWatcher, registerSelfWrite, registerSelfDelete } from "./file-watcher.js";
 import { mountHandoffRoutes } from "./handoff-routes.js";
+import { registerLibraryRoutes } from "./library-routes.js";
 import { mountNativeRoutes } from "./native-bridge.js";
 import { mountProjectsRoutes } from "./projects-routes.js";
 import {
@@ -400,7 +401,26 @@ export async function startServer(options: ServerOptions) {
       inspiredBy?: { name: string; url: string };
     }>;
     published: Array<{ name: string; displayName: string; description?: string; version: string; publishedAt: string; archiveUrl: string; icon?: string }>;
-    local: Array<{ name: string; displayName: string; description?: string; version: string; path: string; icon?: string }>;
+    /**
+     * Locally installed modes. Covers two sources:
+     * - `~/.pneuma/modes/<id>/` — single-mode external installs (legacy).
+     * - `~/.pneuma/libraries/<id>/<mode>/` — modes inside a multi-mode
+     *   library that the user has activated. These entries carry
+     *   `librarySource` so the launcher can group them under a "Mode
+     *   Libraries" section + render a source chip. Deactivated modes
+     *   stay on disk but do not appear here.
+     */
+    local: Array<{
+      name: string;
+      displayName: string;
+      description?: string;
+      version: string;
+      path: string;
+      icon?: string;
+      librarySource?: { id: string; name: string; displayName?: string };
+      /** True when the library's recorded `manifestVersion` is ahead of `installedVersion` */
+      updateAvailable?: boolean;
+    }>;
   }
 
   let registryCache: { value: RegistryResponse; fetchedAt: number } | null = null;
@@ -486,6 +506,47 @@ export async function startServer(options: ServerOptions) {
         }
       }
     } catch { }
+
+    // Library-installed modes — append activated entries with a
+    // `librarySource` tag so the launcher can group them and offer
+    // per-library "Check updates" without a separate API call. The path
+    // is the absolute on-disk mode dir, identical to the single-mode
+    // path, so existing launch logic (`Launcher.tsx` POSTs `specifier:
+    // mode.path` to `/api/launch`) keeps working untouched.
+    try {
+      const { listLibraries, getLibraryModePath } = await import("../core/library-registry.js");
+      for (const lib of listLibraries()) {
+        for (const m of lib.modes) {
+          if (!m.activated) continue;
+          const abs = getLibraryModePath(lib.id, m.name);
+          if (!abs) continue; // skip stale sidecar entries
+          let parsed: ReturnType<typeof parseManifestTs> = {};
+          try {
+            const manifestPath = ["manifest.ts", "manifest.js"]
+              .map((f) => join(abs, f))
+              .find((p) => existsSync(p));
+            if (manifestPath) parsed = parseManifestTs(readFileSync(manifestPath, "utf-8"));
+          } catch { /* tolerate parse failures, fall back to sidecar fields */ }
+          if (parsed.hidden === true) continue;
+          local.push({
+            name: parsed.name || m.name,
+            displayName: parsed.displayName || m.name,
+            description: parsed.description,
+            icon: parsed.icon,
+            version: parsed.version || m.manifestVersion,
+            path: abs,
+            librarySource: {
+              id: lib.id,
+              name: lib.name,
+              ...(lib.displayName ? { displayName: lib.displayName } : {}),
+            },
+            ...(m.installedVersion && m.installedVersion !== m.manifestVersion
+              ? { updateAvailable: true }
+              : {}),
+          });
+        }
+      }
+    } catch { /* library subsystem failure should not break the registry */ }
 
     return { builtins, published, local };
   };
@@ -1477,6 +1538,14 @@ export async function startServer(options: ServerOptions) {
     }
 
     // ── Handoff routes (v2 tool-call protocol) ─────────────────────────
+    // Mount `/api/libraries/*` + `/api/github/status` — launcher-scope only
+    // (libraries are a launcher-wide concern; per-session servers don't
+    // register these). Broadcasts `libraries_updated` on every mutation.
+    registerLibraryRoutes(app, wsBridge, {
+      projectRoot:
+        options.projectRoot || resolve(dirname(import.meta.path), ".."),
+    });
+
     // The launcher mounts these so any project session whose own server
     // hands a request through `/api/handoffs/emit` (e.g. via cross-port
     // proxy) still resolves correctly. The per-session server below also

--- a/server/index.ts
+++ b/server/index.ts
@@ -1554,6 +1554,34 @@ export async function startServer(options: ServerOptions) {
       },
     });
 
+    // ── Favorites (launcher-scope) ─────────────────────────────────────
+    // Persistent user-pinned modes. The launcher reads this list to
+    // order Quick Start tiles and to mark favorited tiles with a small
+    // badge. The project mode-tile picker reads the same list. Sourced
+    // from `~/.pneuma/favorites.json` so it survives browser reset and
+    // is shared across all launcher sessions on this machine.
+    app.get("/api/favorites", async (c) => {
+      try {
+        const { readFavorites, DEFAULT_FAVORITES } = await import("../core/favorites.js");
+        return c.json({ favorites: readFavorites(), defaults: [...DEFAULT_FAVORITES] });
+      } catch (err) {
+        return c.json({ error: err instanceof Error ? err.message : String(err) }, 500);
+      }
+    });
+    app.post("/api/favorites", async (c) => {
+      try {
+        const body = await c.req.json<{ favorites?: unknown }>();
+        if (!Array.isArray(body.favorites)) {
+          return c.json({ error: "favorites must be an array of mode names" }, 400);
+        }
+        const { writeFavorites, readFavorites } = await import("../core/favorites.js");
+        writeFavorites(body.favorites as string[]);
+        return c.json({ favorites: readFavorites() });
+      } catch (err) {
+        return c.json({ error: err instanceof Error ? err.message : String(err) }, 500);
+      }
+    });
+
     // The launcher mounts these so any project session whose own server
     // hands a request through `/api/handoffs/emit` (e.g. via cross-port
     // proxy) still resolves correctly. The per-session server below also

--- a/server/index.ts
+++ b/server/index.ts
@@ -1544,6 +1544,14 @@ export async function startServer(options: ServerOptions) {
     registerLibraryRoutes(app, wsBridge, {
       projectRoot:
         options.projectRoot || resolve(dirname(import.meta.path), ".."),
+      // Library mutations change which modes surface in `/api/registry`
+      // `local[]` (every activated library mode lands there). Dropping the
+      // SWR cache here lets the launcher Quick Start grid see new library
+      // modes on the same tick as the WS `libraries_updated` broadcast,
+      // instead of waiting for the 60s TTL to elapse.
+      invalidateRegistry: () => {
+        registryCache = null;
+      },
     });
 
     // The launcher mounts these so any project session whose own server

--- a/server/library-routes.ts
+++ b/server/library-routes.ts
@@ -58,6 +58,14 @@ export interface LibraryRoutesBridge {
 export interface RegisterLibraryRoutesOptions {
   /** Used by `resolveModeOrLibrary` for builtin resolution + cache dirs. */
   projectRoot: string;
+  /**
+   * Optional hook the launcher passes in to drop its in-memory
+   * `/api/registry` cache. Library mutations change which modes appear
+   * in `local[]` (activated library modes surface there); without this
+   * invalidation the launcher Quick Start grid stays stale for up to
+   * 60 seconds. Tests can omit this — registry caching is launcher-only.
+   */
+  invalidateRegistry?: () => void;
 }
 
 /**
@@ -70,7 +78,20 @@ export function registerLibraryRoutes(
   wsBridge: LibraryRoutesBridge,
   options: RegisterLibraryRoutesOptions,
 ): void {
-  const broadcastLibrariesUpdated = (): void => {
+  /**
+   * Single fan-out for every library mutation: drop the launcher's
+   * registry cache so a follow-up `GET /api/registry` sees the new
+   * mode list, then push a `libraries_updated` WS tick so any open
+   * Launcher tab refetches without polling. Order matters — cache
+   * first, broadcast second — so the tick arrives at a frontend that
+   * will hit a fresh registry on its next call.
+   */
+  const notifyLibrariesChanged = (): void => {
+    try {
+      options.invalidateRegistry?.();
+    } catch (err) {
+      console.warn(`[library-routes] registry invalidate failed: ${err}`);
+    }
     if (typeof wsBridge.broadcastAll !== "function") return;
     try {
       const msg: BrowserIncomingMessage = {
@@ -82,6 +103,9 @@ export function registerLibraryRoutes(
       console.warn(`[library-routes] broadcast failed: ${err}`);
     }
   };
+  // Older name kept as a local alias so route handlers don't all need
+  // re-edit; both invocations route through the new fan-out.
+  const broadcastLibrariesUpdated = notifyLibrariesChanged;
 
   // GET /api/libraries ──────────────────────────────────────────────────
   app.get("/api/libraries", (c) => {

--- a/server/library-routes.ts
+++ b/server/library-routes.ts
@@ -1,0 +1,435 @@
+/**
+ * Library routes — `/api/libraries/*` and `/api/github/status`.
+ *
+ * These are launcher-only endpoints: libraries are a launcher-wide concern,
+ * not a per-session one. Mount once from the launcher block in
+ * `server/index.ts`. Per-session servers do not need (and do not get)
+ * these routes.
+ *
+ * Mutations broadcast `libraries_updated` over the WS bridge so any
+ * connected browser tab can revalidate `GET /api/libraries` without polling.
+ * The broadcast is fire-and-forget — frontends that don't get the tick
+ * (e.g. nothing connected at the moment of the mutation) will see the new
+ * state on their next focus-driven refetch.
+ *
+ * Error contract: every handler wraps its body in try/catch. Schema
+ * validation errors return 400 with `{ error: msg }`; everything else
+ * surfaces the underlying module's `.message` at 500. The library
+ * registry / publish modules throw with already-actionable messages.
+ */
+
+import type { Hono } from "hono";
+import {
+  listLibraries,
+  readLibrary,
+  syncLibrary,
+  setModeActivated,
+  acceptModeUpdate,
+  unlinkLibrary,
+  getLibraryDir,
+  detectRepoShape,
+  type LibrarySyncReport,
+} from "../core/library-registry.js";
+import {
+  initLocalLibrary,
+  publishModeToLibrary,
+  pushLibrary,
+} from "../core/library-publish.js";
+import { resolveModeOrLibrary } from "../core/mode-resolver.js";
+import { detectGh, createRepo } from "../core/github-cli.js";
+import type { WsBridge } from "./ws-bridge.js";
+import type { BrowserIncomingMessage } from "./session-types.js";
+
+/**
+ * Subset of the WS bridge surface library routes touch — typed loosely so
+ * tests can pass an in-memory mock with just `broadcastAll`. The signature
+ * matches `WsBridge.broadcastAll` exactly so the launcher can hand the
+ * concrete bridge in unchanged.
+ */
+export interface LibraryRoutesBridge {
+  /**
+   * System-wide broadcast across every connected browser. The launcher's
+   * Libraries section listens for `libraries_updated` and revalidates.
+   * Optional — if missing (e.g. tests), the helper is a no-op.
+   */
+  broadcastAll?: (msg: BrowserIncomingMessage) => void;
+}
+
+export interface RegisterLibraryRoutesOptions {
+  /** Used by `resolveModeOrLibrary` for builtin resolution + cache dirs. */
+  projectRoot: string;
+}
+
+/**
+ * Mount the library routes on the given Hono app. The launcher calls this
+ * once during boot; per-session servers must not call it (libraries are
+ * launcher-scoped state).
+ */
+export function registerLibraryRoutes(
+  app: Hono,
+  wsBridge: LibraryRoutesBridge,
+  options: RegisterLibraryRoutesOptions,
+): void {
+  const broadcastLibrariesUpdated = (): void => {
+    if (typeof wsBridge.broadcastAll !== "function") return;
+    try {
+      const msg: BrowserIncomingMessage = {
+        type: "libraries_updated",
+        ts: Date.now(),
+      };
+      wsBridge.broadcastAll(msg);
+    } catch (err) {
+      console.warn(`[library-routes] broadcast failed: ${err}`);
+    }
+  };
+
+  // GET /api/libraries ──────────────────────────────────────────────────
+  app.get("/api/libraries", (c) => {
+    try {
+      const libraries = listLibraries();
+      return c.json({ libraries });
+    } catch (err) {
+      return c.json({ error: errMsg(err) }, 500);
+    }
+  });
+
+  // POST /api/libraries/link ────────────────────────────────────────────
+  app.post("/api/libraries/link", async (c) => {
+    let body: { specifier?: unknown };
+    try {
+      body = (await c.req.json().catch(() => ({}))) as { specifier?: unknown };
+    } catch (err) {
+      return c.json({ error: errMsg(err) }, 400);
+    }
+    const specifier = typeof body.specifier === "string" ? body.specifier.trim() : "";
+    if (!specifier) {
+      return c.json({ error: "specifier is required" }, 400);
+    }
+    try {
+      const result = await resolveModeOrLibrary(specifier, options.projectRoot);
+      broadcastLibrariesUpdated();
+      if (result.kind === "library") {
+        return c.json({
+          kind: "library",
+          report: result.report,
+          libraryDir: result.libraryDir,
+        });
+      }
+      return c.json({ kind: "single", resolved: result.resolved });
+    } catch (err) {
+      return c.json({ error: errMsg(err) }, 500);
+    }
+  });
+
+  // POST /api/libraries/:id/sync ────────────────────────────────────────
+  app.post("/api/libraries/:id/sync", async (c) => {
+    const id = c.req.param("id");
+    if (!id) return c.json({ error: "library id is required" }, 400);
+    try {
+      const prev = readLibrary(id);
+      if (!prev) return c.json({ error: `library ${id} not found` }, 404);
+
+      const libDir = getLibraryDir(id);
+
+      if (prev.source.type === "github") {
+        const ref = prev.source.ref || "main";
+        try {
+          await runGit(["fetch", "origin", ref], libDir);
+          await runGit(["checkout", `origin/${ref}`, "--force"], libDir);
+        } catch (gitErr) {
+          return c.json({ error: `git sync failed: ${errMsg(gitErr)}` }, 500);
+        }
+      }
+      // For "local" and "url" sources, we don't advance the repo — local
+      // libraries are author-side and just need a re-scan; url libraries
+      // would require a fresh re-extract through the resolver's link path,
+      // which the user can trigger via `/api/libraries/link` with the
+      // original URL. Plain re-`detectRepoShape` keeps this endpoint
+      // predictable for both.
+
+      const shape = detectRepoShape(libDir, prev.name);
+      if (shape.kind !== "library") {
+        return c.json(
+          { error: `library ${id} no longer looks like a library on disk` },
+          500,
+        );
+      }
+      const newSha =
+        prev.source.type === "github" ? await readGitSha(libDir) : prev.sha;
+      const report: LibrarySyncReport = syncLibrary(id, shape, newSha);
+      broadcastLibrariesUpdated();
+      return c.json({ report });
+    } catch (err) {
+      return c.json({ error: errMsg(err) }, 500);
+    }
+  });
+
+  // POST /api/libraries/:id/mode/:name/activate ─────────────────────────
+  app.post("/api/libraries/:id/mode/:name/activate", (c) => {
+    const id = c.req.param("id");
+    const name = c.req.param("name");
+    if (!id || !name) {
+      return c.json({ error: "library id and mode name are required" }, 400);
+    }
+    try {
+      const library = setModeActivated(id, name, true);
+      broadcastLibrariesUpdated();
+      return c.json({ library });
+    } catch (err) {
+      return c.json({ error: errMsg(err) }, 500);
+    }
+  });
+
+  // POST /api/libraries/:id/mode/:name/deactivate ───────────────────────
+  app.post("/api/libraries/:id/mode/:name/deactivate", (c) => {
+    const id = c.req.param("id");
+    const name = c.req.param("name");
+    if (!id || !name) {
+      return c.json({ error: "library id and mode name are required" }, 400);
+    }
+    try {
+      const library = setModeActivated(id, name, false);
+      broadcastLibrariesUpdated();
+      return c.json({ library });
+    } catch (err) {
+      return c.json({ error: errMsg(err) }, 500);
+    }
+  });
+
+  // POST /api/libraries/:id/mode/:name/accept-update ────────────────────
+  app.post("/api/libraries/:id/mode/:name/accept-update", (c) => {
+    const id = c.req.param("id");
+    const name = c.req.param("name");
+    if (!id || !name) {
+      return c.json({ error: "library id and mode name are required" }, 400);
+    }
+    try {
+      const library = acceptModeUpdate(id, name);
+      broadcastLibrariesUpdated();
+      return c.json({ library });
+    } catch (err) {
+      return c.json({ error: errMsg(err) }, 500);
+    }
+  });
+
+  // POST /api/libraries/:id/publish ─────────────────────────────────────
+  app.post("/api/libraries/:id/publish", async (c) => {
+    const id = c.req.param("id");
+    if (!id) return c.json({ error: "library id is required" }, 400);
+    let body: { sourcePath?: unknown; name?: unknown; push?: unknown };
+    try {
+      body = (await c.req.json().catch(() => ({}))) as typeof body;
+    } catch (err) {
+      return c.json({ error: errMsg(err) }, 400);
+    }
+    const sourcePath =
+      typeof body.sourcePath === "string" ? body.sourcePath.trim() : "";
+    if (!sourcePath) {
+      return c.json({ error: "sourcePath is required" }, 400);
+    }
+    const name = typeof body.name === "string" && body.name ? body.name : undefined;
+    const push = body.push === true;
+    try {
+      const result = publishModeToLibrary({
+        sourceModeDir: sourcePath,
+        libraryId: id,
+        ...(name ? { name } : {}),
+        push,
+      });
+      broadcastLibrariesUpdated();
+      return c.json(result);
+    } catch (err) {
+      return c.json({ error: errMsg(err) }, 500);
+    }
+  });
+
+  // POST /api/libraries/:id/push ────────────────────────────────────────
+  app.post("/api/libraries/:id/push", (c) => {
+    const id = c.req.param("id");
+    if (!id) return c.json({ error: "library id is required" }, 400);
+    try {
+      pushLibrary(id);
+      // No broadcast — push doesn't change local state.
+      return c.json({ ok: true });
+    } catch (err) {
+      return c.json({ error: errMsg(err) }, 500);
+    }
+  });
+
+  // DELETE /api/libraries/:id ───────────────────────────────────────────
+  app.delete("/api/libraries/:id", (c) => {
+    const id = c.req.param("id");
+    if (!id) return c.json({ error: "library id is required" }, 400);
+    try {
+      const removed = unlinkLibrary(id);
+      broadcastLibrariesUpdated();
+      return c.json({ ok: true, removed });
+    } catch (err) {
+      return c.json({ error: errMsg(err) }, 500);
+    }
+  });
+
+  // POST /api/libraries/init ────────────────────────────────────────────
+  app.post("/api/libraries/init", async (c) => {
+    let body: {
+      name?: unknown;
+      displayName?: unknown;
+      description?: unknown;
+      github?: unknown;
+    };
+    try {
+      body = (await c.req.json().catch(() => ({}))) as typeof body;
+    } catch (err) {
+      return c.json({ error: errMsg(err) }, 400);
+    }
+    const name = typeof body.name === "string" ? body.name.trim() : "";
+    if (!name) {
+      return c.json({ error: "name is required" }, 400);
+    }
+    const displayName =
+      typeof body.displayName === "string" && body.displayName
+        ? body.displayName
+        : undefined;
+    const description =
+      typeof body.description === "string" && body.description
+        ? body.description
+        : undefined;
+
+    // Optional github sub-object — validate shape before doing anything
+    // destructive on disk.
+    let githubOpts:
+      | { name: string; visibility?: "public" | "private" }
+      | undefined;
+    if (body.github !== undefined && body.github !== null) {
+      if (typeof body.github !== "object") {
+        return c.json({ error: "github must be an object" }, 400);
+      }
+      const gh = body.github as Record<string, unknown>;
+      const ghName = typeof gh.name === "string" ? gh.name.trim() : "";
+      if (!ghName) {
+        return c.json({ error: "github.name is required when github is set" }, 400);
+      }
+      const visibility = gh.visibility;
+      if (
+        visibility !== undefined &&
+        visibility !== "public" &&
+        visibility !== "private"
+      ) {
+        return c.json(
+          { error: "github.visibility must be 'public' or 'private'" },
+          400,
+        );
+      }
+      githubOpts = {
+        name: ghName,
+        ...(visibility ? { visibility } : {}),
+      };
+    }
+
+    try {
+      const library = initLocalLibrary({
+        name,
+        ...(displayName ? { displayName } : {}),
+        ...(description ? { description } : {}),
+      });
+
+      let githubUrl: string | undefined;
+      if (githubOpts) {
+        try {
+          const repo = await createRepo({
+            name: githubOpts.name,
+            ...(githubOpts.visibility ? { visibility: githubOpts.visibility } : {}),
+            sourcePath: getLibraryDir(library.id),
+            ...(description ? { description } : {}),
+          });
+          githubUrl = repo.url;
+        } catch (err) {
+          // The library exists locally; surface the github failure but
+          // don't roll back the local init — the user can fix gh auth and
+          // retry `pneuma library push`.
+          broadcastLibrariesUpdated();
+          return c.json(
+            {
+              library,
+              error: `library created locally, but GitHub setup failed: ${errMsg(err)}`,
+            },
+            500,
+          );
+        }
+      }
+
+      broadcastLibrariesUpdated();
+      return c.json({
+        library,
+        ...(githubUrl ? { githubUrl } : {}),
+      });
+    } catch (err) {
+      return c.json({ error: errMsg(err) }, 500);
+    }
+  });
+
+  // GET /api/github/status ──────────────────────────────────────────────
+  app.get("/api/github/status", async (c) => {
+    try {
+      const status = await detectGh();
+      return c.json(status);
+    } catch (err) {
+      return c.json({ error: errMsg(err) }, 500);
+    }
+  });
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+const GIT_TIMEOUT_MS = 30_000;
+
+/**
+ * Run a git command and return stdout. Mirrors `mode-resolver.ts`'s helper;
+ * inlined here so the routes module doesn't reach into the resolver's
+ * private surface.
+ */
+async function runGit(args: string[], cwd: string): Promise<string> {
+  const proc = Bun.spawn(["git", ...args], {
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const timeout = new Promise<never>((_, reject) => {
+    setTimeout(() => {
+      try {
+        proc.kill();
+      } catch {
+        /* already exited */
+      }
+      reject(new Error(`git ${args[0]} timed out after ${GIT_TIMEOUT_MS}ms`));
+    }, GIT_TIMEOUT_MS);
+  });
+
+  const exitCode = await Promise.race([proc.exited, timeout]);
+  const stdout = await new Response(proc.stdout).text();
+  const stderr = await new Response(proc.stderr).text();
+
+  if (exitCode !== 0) {
+    throw new Error(`git ${args[0]} failed (code ${exitCode}): ${stderr}`);
+  }
+  return stdout;
+}
+
+async function readGitSha(cwd: string): Promise<string | null> {
+  try {
+    const out = await runGit(["rev-parse", "HEAD"], cwd);
+    const sha = out.trim();
+    return sha || null;
+  } catch {
+    return null;
+  }
+}
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+// Re-export the bridge type for callers — the launcher passes its
+// `WsBridge` directly, which satisfies `LibraryRoutesBridge`.
+export type { WsBridge };

--- a/server/session-types.ts
+++ b/server/session-types.ts
@@ -430,6 +430,16 @@ export type BrowserIncomingMessageBase =
     displayName?: string;
     description?: string;
     refinedAt: number;
+  }
+  | {
+    /**
+     * Emitted after a library mutation (`/api/libraries/*` link, sync,
+     * activate/deactivate, accept-update, publish, init, unlink) so the
+     * launcher's Libraries section can revalidate without polling. No
+     * payload — consumers refetch `GET /api/libraries`.
+     */
+    type: "libraries_updated";
+    ts: number;
   };
 
 export type BrowserIncomingMessage = BrowserIncomingMessageBase & { seq?: number };

--- a/server/ws-bridge.ts
+++ b/server/ws-bridge.ts
@@ -215,6 +215,22 @@ export class WsBridge {
     this.broadcastToBrowsers(session, msg);
   }
 
+  /**
+   * Push a message to every connected browser across all sessions. Used by
+   * system-wide notifications (e.g. `libraries_updated`) where the launcher
+   * UI has no specific session affinity. Quiet no-op when nothing is
+   * connected — callers can fire-and-forget.
+   */
+  broadcastAll(msg: BrowserIncomingMessage): void {
+    for (const session of this.sessions.values()) {
+      try {
+        this.broadcastToBrowsers(session, msg);
+      } catch {
+        // One session's failure must not block the others.
+      }
+    }
+  }
+
   /** Dispatch a viewer action to the active browser session, return the result. */
   async dispatchViewerAction(
     actionId: string,

--- a/src/components/Launcher.tsx
+++ b/src/components/Launcher.tsx
@@ -12,6 +12,7 @@ import { useAnimatedMount } from "../utils/useAnimatedMount.js";
 import { timeAgo, runningDuration } from "../utils/timeAgo.js";
 import { shortenPath } from "../utils/string.js";
 import type { InitParam } from "../../core/types/mode-manifest.js";
+import type { InstalledLibrary } from "../../core/types/library.js";
 
 export type BackendType = "claude-code" | "codex" | "kimi-cli";
 
@@ -86,6 +87,10 @@ interface LocalMode {
   version: string;
   path: string;
   icon?: string;
+  /** Set when this mode comes from an installed library (vs single-mode install). */
+  librarySource?: { id: string; name: string; displayName?: string };
+  /** True when the library's manifestVersion is ahead of installedVersion. */
+  updateAvailable?: boolean;
 }
 
 interface RecentSession {
@@ -143,6 +148,8 @@ type AnyMode = {
   hasInitParams?: boolean;
   showcase?: BuiltinMode["showcase"];
   inspiredBy?: BuiltinMode["inspiredBy"];
+  /** Propagated from LocalMode for library-sourced modes (chip on tiles). */
+  librarySource?: { id: string; name: string; displayName?: string };
 };
 
 // ── Theme ────────────────────────────────────────────────────────────────
@@ -1405,6 +1412,7 @@ function QuickStartTile({
   description,
   icon,
   isModeMaker,
+  librarySource,
   onClick,
 }: {
   name: string;
@@ -1412,17 +1420,27 @@ function QuickStartTile({
   description?: string;
   icon?: string;
   isModeMaker?: boolean;
+  /** When set, a small "from {lib}" chip is rendered at the top-right. */
+  librarySource?: { id: string; name: string; displayName?: string };
   onClick: () => void;
 }) {
   return (
     <button
       onClick={onClick}
-      className={`group flex flex-col items-center gap-3 p-5 rounded-xl transition-all duration-200 cursor-pointer ${
+      className={`group relative flex flex-col items-center gap-3 p-5 rounded-xl transition-all duration-200 cursor-pointer ${
         isModeMaker
           ? "bg-cc-primary/5 border border-cc-primary/15 hover:border-cc-primary/30 hover:bg-cc-primary/8"
           : "bg-cc-surface/30 hover:bg-cc-surface/60 border border-transparent hover:border-cc-border/30"
       }`}
     >
+      {librarySource && (
+        <span
+          className="absolute top-1.5 right-1.5 px-1.5 py-0.5 text-[9px] rounded-full bg-cc-fg/5 text-cc-muted/60 border border-cc-border/30 truncate max-w-[90%]"
+          title={`from library: ${librarySource.displayName || librarySource.name}`}
+        >
+          from {librarySource.displayName || librarySource.name}
+        </span>
+      )}
       <div className={`w-11 h-11 flex items-center justify-center rounded-lg transition-all duration-200 ${
         isModeMaker
           ? "bg-cc-primary/10 text-cc-primary group-hover:scale-105"
@@ -2735,6 +2753,810 @@ function PluginsSection() {
   );
 }
 
+// ── GitHubSection ─────────────────────────────────────────────────────────
+//
+// Surfaces `gh` install + auth status inside the launcher SettingsPanel. The
+// route is read-only — actionable changes (`brew install gh`, `gh auth login`)
+// are copyable snippets the user runs in their own terminal. Polled on mount
+// rather than live-watched: the panel reopens often enough that drift isn't
+// painful, and `detectGh` shells out to several subprocesses we don't want
+// on a timer.
+
+interface GhStatusUI {
+  installed: boolean;
+  authenticated: boolean;
+  username?: string;
+  version?: string;
+  hint?: string;
+}
+
+function CopySnippet({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+  const handleCopy = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    try {
+      navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1200);
+    } catch { /* clipboard blocked — silent */ }
+  };
+  return (
+    <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-cc-fg/5 border border-cc-border/30">
+      <code className="flex-1 text-[11px] text-cc-fg/80 font-mono truncate">{text}</code>
+      <button
+        onClick={handleCopy}
+        className="text-[10px] text-cc-muted/60 hover:text-cc-fg transition-colors cursor-pointer whitespace-nowrap"
+      >
+        {copied ? "Copied" : "Copy"}
+      </button>
+    </div>
+  );
+}
+
+function GitHubSection() {
+  const [status, setStatus] = useState<GhStatusUI | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch(`${getApiBase()}/api/github/status`)
+      .then((r) => r.json())
+      .then((data) => {
+        if (cancelled) return;
+        setStatus(data as GhStatusUI);
+      })
+      .catch(() => { })
+      .finally(() => !cancelled && setLoading(false));
+    return () => { cancelled = true; };
+  }, []);
+
+  return (
+    <div className="space-y-3">
+      <h3 className="text-xs font-semibold text-cc-muted uppercase tracking-wider">GitHub</h3>
+      <p className="text-[10px] text-cc-muted/60 leading-relaxed">
+        Required for creating, syncing, and publishing mode libraries on GitHub.
+      </p>
+      {loading || !status ? (
+        <div className="text-[11px] text-cc-muted/50">Checking gh status…</div>
+      ) : !status.installed ? (
+        <div className="space-y-2">
+          <div className="text-[11px] text-cc-fg/80">GitHub CLI not installed</div>
+          {status.hint && (
+            <div className="text-[10px] text-cc-muted/60">{status.hint}</div>
+          )}
+          <CopySnippet text="brew install gh" />
+          <a
+            href="https://cli.github.com/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-block text-[10px] text-cc-primary hover:opacity-80 transition-opacity"
+          >
+            cli.github.com →
+          </a>
+        </div>
+      ) : !status.authenticated ? (
+        <div className="space-y-2">
+          <div className="text-[11px] text-cc-fg/80">
+            Installed{status.version ? ` (${status.version})` : ""} · Not signed in
+          </div>
+          {status.hint && (
+            <div className="text-[10px] text-cc-muted/60">{status.hint}</div>
+          )}
+          <CopySnippet text="gh auth login" />
+        </div>
+      ) : (
+        <div className="flex items-center gap-2 text-[11px] text-cc-fg/80">
+          <span className="inline-block w-1.5 h-1.5 rounded-full bg-emerald-400 shadow-[0_0_4px_rgba(52,211,153,0.6)]" />
+          <span>
+            Signed in as <span className="text-cc-fg">@{status.username || "?"}</span>
+            {status.version && (
+              <span className="text-cc-muted/40"> · gh {status.version}</span>
+            )}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── LibraryCard ───────────────────────────────────────────────────────────
+//
+// One card per installed library. Shows source, counts, and an updates
+// pill; clicking the card body expands a per-mode list with activate
+// toggles + per-mode update affordances. Action footer: Sync / Publish /
+// Unlink (with inline confirm).
+
+function LibraryIcon({ kind, className }: { kind: "github" | "url" | "local"; className?: string }) {
+  if (kind === "github") {
+    return (
+      <svg viewBox="0 0 16 16" fill="currentColor" className={className}>
+        <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
+      </svg>
+    );
+  }
+  if (kind === "local") {
+    return (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} className={className}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 9.776c.112-.017.227-.026.344-.026h15.812c.117 0 .232.009.344.026m-16.5 0a2.25 2.25 0 00-1.883 2.542l.857 6a2.25 2.25 0 002.227 1.932H19.05a2.25 2.25 0 002.227-1.932l.857-6a2.25 2.25 0 00-1.883-2.542m-16.5 0V6A2.25 2.25 0 016 3.75h3.879a1.5 1.5 0 011.06.44l2.122 2.12a1.5 1.5 0 001.06.44H18A2.25 2.25 0 0120.25 9v.776" />
+      </svg>
+    );
+  }
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} className={className}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M13.19 8.688a4.5 4.5 0 011.242 7.244l-4.5 4.5a4.5 4.5 0 01-6.364-6.364l1.757-1.757m13.35-.622l1.757-1.757a4.5 4.5 0 00-6.364-6.364l-4.5 4.5a4.5 4.5 0 001.242 7.244" />
+    </svg>
+  );
+}
+
+function LibraryCard({
+  library,
+  onPublish,
+}: {
+  library: InstalledLibrary;
+  onPublish: () => void;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const [syncing, setSyncing] = useState(false);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const modeCount = library.modes.length;
+  const activatedCount = library.modes.filter((m) => m.activated).length;
+  const updateCount = library.modes.filter(
+    (m) => m.installedVersion !== m.manifestVersion,
+  ).length;
+
+  const sourceKind = library.source.type;
+  const sourceUrl =
+    library.source.type === "github"
+      ? library.source.url
+      : library.source.type === "url"
+        ? library.source.url
+        : "local";
+
+  const handleSync = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setSyncing(true);
+    setError(null);
+    try {
+      const res = await fetch(`${getApiBase()}/api/libraries/${encodeURIComponent(library.id)}/sync`, {
+        method: "POST",
+      });
+      const data = await res.json();
+      if (!res.ok || data.error) throw new Error(data.error || `HTTP ${res.status}`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Sync failed");
+    } finally {
+      setSyncing(false);
+    }
+  };
+
+  const handleUnlink = async () => {
+    setBusy("unlink");
+    setError(null);
+    try {
+      const res = await fetch(`${getApiBase()}/api/libraries/${encodeURIComponent(library.id)}`, {
+        method: "DELETE",
+      });
+      const data = await res.json();
+      if (!res.ok || data.error) throw new Error(data.error || `HTTP ${res.status}`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unlink failed");
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const handleToggle = async (modeName: string, currentlyActive: boolean) => {
+    setBusy(`toggle-${modeName}`);
+    setError(null);
+    try {
+      const action = currentlyActive ? "deactivate" : "activate";
+      const res = await fetch(
+        `${getApiBase()}/api/libraries/${encodeURIComponent(library.id)}/mode/${encodeURIComponent(modeName)}/${action}`,
+        { method: "POST" },
+      );
+      const data = await res.json();
+      if (!res.ok || data.error) throw new Error(data.error || `HTTP ${res.status}`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Toggle failed");
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const handleAcceptUpdate = async (modeName: string) => {
+    setBusy(`update-${modeName}`);
+    setError(null);
+    try {
+      const res = await fetch(
+        `${getApiBase()}/api/libraries/${encodeURIComponent(library.id)}/mode/${encodeURIComponent(modeName)}/accept-update`,
+        { method: "POST" },
+      );
+      const data = await res.json();
+      if (!res.ok || data.error) throw new Error(data.error || `HTTP ${res.status}`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Update failed");
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  return (
+    <div className="rounded-xl bg-cc-surface/30 hover:bg-cc-surface/40 border border-cc-border/20 hover:border-cc-border/40 backdrop-blur-sm transition-all duration-200">
+      <button
+        onClick={() => setExpanded((v) => !v)}
+        className="w-full text-left px-4 py-3 cursor-pointer"
+      >
+        <div className="flex items-start gap-3">
+          <div className="w-9 h-9 flex items-center justify-center rounded-lg bg-cc-fg/5 text-cc-muted/70 shrink-0">
+            <LibraryIcon kind={sourceKind} className="w-4 h-4" />
+          </div>
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2">
+              <h3 className="text-sm font-medium text-cc-fg truncate">
+                {library.displayName || library.name}
+              </h3>
+              {updateCount > 0 && (
+                <span className="inline-flex items-center gap-1 px-1.5 py-0.5 text-[9px] rounded-full bg-cc-primary/15 text-cc-primary border border-cc-primary/25">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} className="w-2.5 h-2.5">
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M12 4.5v15m0 0l-7.5-7.5M12 19.5l7.5-7.5" />
+                  </svg>
+                  {updateCount} update{updateCount === 1 ? "" : "s"}
+                </span>
+              )}
+            </div>
+            <div
+              className="text-[10px] text-cc-muted/50 truncate mt-0.5"
+              title={sourceUrl}
+            >
+              {sourceUrl}
+            </div>
+            <div className="text-[10px] text-cc-muted/60 mt-1">
+              {modeCount} mode{modeCount === 1 ? "" : "s"} · {activatedCount} activated
+            </div>
+          </div>
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={1.5}
+            className={`w-4 h-4 text-cc-muted/40 transition-transform duration-200 shrink-0 ${expanded ? "rotate-180" : ""}`}
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
+          </svg>
+        </div>
+      </button>
+
+      <AnimatePresence initial={false}>
+        {expanded && (
+          <motion.div
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: "auto", opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.2, ease: [0.4, 0, 0.2, 1] }}
+            className="overflow-hidden"
+          >
+            <div className="px-4 pb-3 space-y-1.5 border-t border-cc-border/20 pt-3">
+              {library.modes.length === 0 && (
+                <div className="text-[11px] text-cc-muted/50 px-2 py-1">
+                  No modes in this library.
+                </div>
+              )}
+              {library.modes.map((m) => {
+                const updateAvailable = m.installedVersion !== m.manifestVersion;
+                const toggling = busy === `toggle-${m.name}`;
+                const updating = busy === `update-${m.name}`;
+                return (
+                  <div
+                    key={m.name}
+                    className="flex items-center gap-3 px-2 py-1.5 rounded-lg hover:bg-cc-fg/5 transition-colors"
+                  >
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2">
+                        <span className="text-xs text-cc-fg/85 truncate">{m.name}</span>
+                        <span className="text-[10px] text-cc-muted/40">v{m.manifestVersion}</span>
+                        {updateAvailable && (
+                          <button
+                            disabled={updating}
+                            onClick={(e) => { e.stopPropagation(); void handleAcceptUpdate(m.name); }}
+                            className="text-[9px] px-1.5 py-0.5 rounded-full bg-cc-primary/15 text-cc-primary hover:bg-cc-primary/25 border border-cc-primary/25 transition-colors cursor-pointer disabled:opacity-40"
+                          >
+                            {updating ? "…" : "Update"}
+                          </button>
+                        )}
+                      </div>
+                      <div className="text-[10px] text-cc-muted/40 truncate">{m.path}</div>
+                    </div>
+                    {/* Activate toggle */}
+                    <button
+                      type="button"
+                      role="switch"
+                      aria-checked={m.activated}
+                      disabled={toggling}
+                      onClick={(e) => { e.stopPropagation(); void handleToggle(m.name, m.activated); }}
+                      className={`relative inline-flex h-4 w-7 shrink-0 cursor-pointer rounded-full border transition-colors disabled:opacity-50 ${
+                        m.activated
+                          ? "bg-cc-primary/80 border-cc-primary/40"
+                          : "bg-cc-fg/10 border-cc-border/40"
+                      }`}
+                      title={m.activated ? "Deactivate" : "Activate"}
+                    >
+                      <span
+                        className={`absolute top-0.5 h-3 w-3 rounded-full bg-white shadow transition-all duration-150 ${
+                          m.activated ? "left-[14px]" : "left-0.5"
+                        }`}
+                      />
+                    </button>
+                  </div>
+                );
+              })}
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      {/* Footer actions */}
+      <div className="flex items-center gap-1 px-3 py-2 border-t border-cc-border/20">
+        <button
+          onClick={handleSync}
+          disabled={syncing}
+          className="p-1.5 rounded-lg text-cc-muted/50 hover:text-cc-fg hover:bg-cc-fg/5 transition-colors cursor-pointer disabled:opacity-40"
+          title="Sync library"
+        >
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} className={`w-4 h-4 ${syncing ? "animate-spin" : ""}`}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182m0-4.991v4.99" />
+          </svg>
+        </button>
+        <button
+          onClick={(e) => { e.stopPropagation(); onPublish(); }}
+          className="p-1.5 rounded-lg text-cc-muted/50 hover:text-cc-fg hover:bg-cc-fg/5 transition-colors cursor-pointer"
+          title="Publish a mode to this library"
+        >
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} className="w-4 h-4">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5" />
+          </svg>
+        </button>
+        <div className="flex-1" />
+        {error && (
+          <span className="text-[10px] text-red-400/90 truncate" title={error}>{error}</span>
+        )}
+        <ConfirmButton
+          stopPropagation
+          label="Unlink"
+          onConfirm={handleUnlink}
+          icon={
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} className="w-4 h-4">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0" />
+            </svg>
+          }
+        />
+      </div>
+    </div>
+  );
+}
+
+// ── AddLibraryDialog ──────────────────────────────────────────────────────
+//
+// Two tabs: Link existing (specifier → /api/libraries/link) and Create new
+// (name + optional GitHub-side init → /api/libraries/init). Errors render
+// inline.
+
+function AddLibraryDialog({
+  open,
+  onClose,
+  onLinked,
+}: {
+  open: boolean;
+  onClose: () => void;
+  onLinked: () => void;
+}) {
+  const [mode, setMode] = useState<"link" | "create">("link");
+  const [specifier, setSpecifier] = useState("");
+  const [name, setName] = useState("");
+  const [displayName, setDisplayName] = useState("");
+  const [description, setDescription] = useState("");
+  const [createOnGithub, setCreateOnGithub] = useState(false);
+  const [githubName, setGithubName] = useState("");
+  const [visibility, setVisibility] = useState<"public" | "private">("private");
+  const [status, setStatus] = useState<"idle" | "working" | "done" | "error">("idle");
+  const [error, setError] = useState("");
+  const [result, setResult] = useState<{ kind: "single" | "library"; githubUrl?: string } | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      setMode("link");
+      setSpecifier("");
+      setName("");
+      setDisplayName("");
+      setDescription("");
+      setCreateOnGithub(false);
+      setGithubName("");
+      setVisibility("private");
+      setStatus("idle");
+      setError("");
+      setResult(null);
+    }
+  }, [open]);
+
+  if (!open) return null;
+
+  const handleLink = async () => {
+    if (!specifier.trim()) return;
+    setStatus("working");
+    setError("");
+    try {
+      const res = await fetch(`${getApiBase()}/api/libraries/link`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ specifier: specifier.trim() }),
+      });
+      const data = await res.json();
+      if (!res.ok || data.error) throw new Error(data.error || `HTTP ${res.status}`);
+      setResult({ kind: data.kind });
+      setStatus("done");
+      onLinked();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Link failed");
+      setStatus("error");
+    }
+  };
+
+  const handleCreate = async () => {
+    if (!name.trim()) return;
+    setStatus("working");
+    setError("");
+    try {
+      const body: Record<string, unknown> = { name: name.trim() };
+      if (displayName.trim()) body.displayName = displayName.trim();
+      if (description.trim()) body.description = description.trim();
+      if (createOnGithub && githubName.trim()) {
+        body.github = { name: githubName.trim(), visibility };
+      }
+      const res = await fetch(`${getApiBase()}/api/libraries/init`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      const data = await res.json();
+      if (!res.ok || data.error) throw new Error(data.error || `HTTP ${res.status}`);
+      setResult({ kind: "library", githubUrl: data.githubUrl });
+      setStatus("done");
+      onLinked();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Create failed");
+      setStatus("error");
+    }
+  };
+
+  return (
+    <>
+      <div className="fixed inset-0 z-40 bg-black/40 backdrop-blur-sm" style={{ animation: "overlayFadeIn 200ms ease" }} onClick={onClose} />
+      <div className="fixed inset-0 z-50 flex items-center justify-center pointer-events-none">
+        <div
+          className="bg-cc-bg border border-cc-border rounded-xl shadow-2xl w-[480px] max-w-[90vw] pointer-events-auto"
+          style={{ animation: "warmFadeIn 200ms ease" }}
+        >
+          <div className="px-5 py-4 border-b border-cc-border">
+            <h3 className="text-sm font-semibold text-cc-fg">Add Mode Library</h3>
+            <p className="text-[10px] text-cc-muted mt-1">
+              Link a multi-mode GitHub repo, or scaffold a new library locally and optionally publish it.
+            </p>
+            <div className="mt-3 inline-flex rounded-lg border border-cc-border overflow-hidden text-[10px]">
+              {(["link", "create"] as const).map((m) => (
+                <button
+                  key={m}
+                  onClick={() => { setMode(m); setStatus("idle"); setError(""); setResult(null); }}
+                  className={`px-3 py-1 transition-colors cursor-pointer ${mode === m ? "bg-cc-primary/15 text-cc-primary" : "text-cc-muted hover:text-cc-fg"}`}
+                >
+                  {m === "link" ? "Link existing" : "Create new"}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="px-5 py-4 space-y-3">
+            {status === "done" && result && (
+              <div className="px-3 py-2 rounded-lg bg-emerald-500/10 border border-emerald-500/20 text-[11px] text-emerald-300/90">
+                {result.kind === "single"
+                  ? "Linked single-mode repo. It appears under Local Modes."
+                  : "Library linked. Activate modes in the card below."}
+                {result.githubUrl && (
+                  <>
+                    {" "}
+                    <a href={result.githubUrl} target="_blank" rel="noopener noreferrer" className="text-cc-primary hover:opacity-80 underline underline-offset-2">
+                      Open on GitHub →
+                    </a>
+                  </>
+                )}
+              </div>
+            )}
+
+            {mode === "link" && status !== "done" && (
+              <>
+                <div>
+                  <label className="text-[10px] text-cc-muted block mb-1">Specifier</label>
+                  <input
+                    autoFocus
+                    placeholder="github:user/repo  or  https://.../repo.tar.gz"
+                    value={specifier}
+                    onChange={(e) => setSpecifier(e.target.value)}
+                    onKeyDown={(e) => e.key === "Enter" && handleLink()}
+                    className="w-full px-3 py-2.5 text-sm bg-cc-input-bg border border-cc-border rounded-lg text-cc-fg placeholder-cc-muted/40 outline-none focus:border-cc-primary/50 transition-colors"
+                  />
+                  <p className="text-[10px] text-cc-muted/60 mt-1.5">
+                    A repo with a <code className="text-cc-muted">pneuma.library.json</code> at its root (or N mode dirs) installs as a multi-mode library; otherwise it falls back to a single-mode install.
+                  </p>
+                </div>
+              </>
+            )}
+
+            {mode === "create" && status !== "done" && (
+              <>
+                <div>
+                  <label className="text-[10px] text-cc-muted block mb-1">Library name (slug)</label>
+                  <input
+                    autoFocus
+                    placeholder="my-modes"
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                    className="w-full px-3 py-2 text-xs bg-cc-input-bg border border-cc-border rounded-lg text-cc-fg placeholder-cc-muted/40 outline-none focus:border-cc-primary/50 transition-colors"
+                  />
+                </div>
+                <div>
+                  <label className="text-[10px] text-cc-muted block mb-1">Display name (optional)</label>
+                  <input
+                    placeholder="My Modes"
+                    value={displayName}
+                    onChange={(e) => setDisplayName(e.target.value)}
+                    className="w-full px-3 py-2 text-xs bg-cc-input-bg border border-cc-border rounded-lg text-cc-fg placeholder-cc-muted/40 outline-none focus:border-cc-primary/50 transition-colors"
+                  />
+                </div>
+                <div>
+                  <label className="text-[10px] text-cc-muted block mb-1">Description (optional)</label>
+                  <input
+                    placeholder="A collection of Pneuma modes for…"
+                    value={description}
+                    onChange={(e) => setDescription(e.target.value)}
+                    className="w-full px-3 py-2 text-xs bg-cc-input-bg border border-cc-border rounded-lg text-cc-fg placeholder-cc-muted/40 outline-none focus:border-cc-primary/50 transition-colors"
+                  />
+                </div>
+                <label className="flex items-center gap-2 text-[11px] text-cc-muted hover:text-cc-fg transition-colors cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={createOnGithub}
+                    onChange={(e) => setCreateOnGithub(e.target.checked)}
+                    className="w-3.5 h-3.5 accent-[#f97316]"
+                  />
+                  Create on GitHub (requires <code>gh</code> auth)
+                </label>
+                {createOnGithub && (
+                  <div className="pl-5 space-y-2">
+                    <div>
+                      <label className="text-[10px] text-cc-muted block mb-1">Repo name</label>
+                      <input
+                        placeholder={name || "my-modes"}
+                        value={githubName}
+                        onChange={(e) => setGithubName(e.target.value)}
+                        className="w-full px-3 py-2 text-xs bg-cc-input-bg border border-cc-border rounded-lg text-cc-fg placeholder-cc-muted/40 outline-none focus:border-cc-primary/50 transition-colors"
+                      />
+                    </div>
+                    <div>
+                      <label className="text-[10px] text-cc-muted block mb-1">Visibility</label>
+                      <div className="inline-flex rounded-lg border border-cc-border overflow-hidden text-[10px]">
+                        {(["private", "public"] as const).map((v) => (
+                          <button
+                            key={v}
+                            type="button"
+                            onClick={() => setVisibility(v)}
+                            className={`px-3 py-1 transition-colors cursor-pointer ${visibility === v ? "bg-cc-primary/15 text-cc-primary" : "text-cc-muted hover:text-cc-fg"}`}
+                          >
+                            {v}
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+                  </div>
+                )}
+              </>
+            )}
+
+            {status === "error" && error && (
+              <div className="px-3 py-2 rounded-lg bg-red-500/10 border border-red-500/20 text-[11px] text-red-300/90">
+                {error}
+              </div>
+            )}
+
+            <div className="flex justify-end gap-2 pt-1">
+              <button
+                onClick={onClose}
+                className="px-4 py-2 text-xs rounded-lg border border-cc-border text-cc-muted hover:text-cc-fg transition-colors cursor-pointer"
+              >
+                {status === "done" ? "Close" : "Cancel"}
+              </button>
+              {status !== "done" && (
+                <button
+                  onClick={mode === "link" ? handleLink : handleCreate}
+                  disabled={
+                    status === "working" ||
+                    (mode === "link" ? !specifier.trim() : !name.trim() || (createOnGithub && !githubName.trim() && !name.trim()))
+                  }
+                  className="px-4 py-2 text-xs rounded-lg bg-cc-primary text-white font-medium hover:brightness-110 disabled:opacity-40 transition-all cursor-pointer"
+                >
+                  {status === "working" ? "…" : mode === "link" ? "Link" : "Create"}
+                </button>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}
+
+// ── PublishToLibraryDialog ────────────────────────────────────────────────
+//
+// Picks a source mode from the currently installed Local Modes (excluding
+// modes that already live in this library) and POSTs to
+// /api/libraries/:id/publish. Optional `push: true` triggers a `git push`
+// follow-up on the library side.
+
+function PublishToLibraryDialog({
+  library,
+  localModes,
+  onClose,
+  onPublished,
+}: {
+  library: InstalledLibrary | null;
+  localModes: LocalMode[];
+  onClose: () => void;
+  onPublished: () => void;
+}) {
+  const [sourceName, setSourceName] = useState("");
+  const [overrideName, setOverrideName] = useState("");
+  const [pushAfter, setPushAfter] = useState(false);
+  const [status, setStatus] = useState<"idle" | "working" | "done" | "error">("idle");
+  const [error, setError] = useState("");
+  const [pushed, setPushed] = useState<boolean | null>(null);
+
+  // Filter: drop modes that already belong to *this* library — publishing
+  // them back to the same library is a no-op + likely user confusion.
+  const eligible = (library
+    ? localModes.filter((m) => m.librarySource?.id !== library.id)
+    : []);
+
+  useEffect(() => {
+    if (library) {
+      setSourceName("");
+      setOverrideName("");
+      setPushAfter(false);
+      setStatus("idle");
+      setError("");
+      setPushed(null);
+    }
+  }, [library?.id]);
+
+  if (!library) return null;
+
+  const selected = eligible.find((m) => m.name === sourceName);
+
+  const handlePublish = async () => {
+    if (!selected) return;
+    setStatus("working");
+    setError("");
+    try {
+      const body: Record<string, unknown> = {
+        sourcePath: selected.path,
+        push: pushAfter,
+      };
+      if (overrideName.trim()) body.name = overrideName.trim();
+      const res = await fetch(`${getApiBase()}/api/libraries/${encodeURIComponent(library.id)}/publish`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      const data = await res.json();
+      if (!res.ok || data.error) throw new Error(data.error || `HTTP ${res.status}`);
+      setPushed(data.pushed === true);
+      setStatus("done");
+      onPublished();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Publish failed");
+      setStatus("error");
+    }
+  };
+
+  return (
+    <>
+      <div className="fixed inset-0 z-40 bg-black/40 backdrop-blur-sm" style={{ animation: "overlayFadeIn 200ms ease" }} onClick={onClose} />
+      <div className="fixed inset-0 z-50 flex items-center justify-center pointer-events-none">
+        <div
+          className="bg-cc-bg border border-cc-border rounded-xl shadow-2xl w-[440px] max-w-[90vw] pointer-events-auto"
+          style={{ animation: "warmFadeIn 200ms ease" }}
+        >
+          <div className="px-5 py-4 border-b border-cc-border">
+            <h3 className="text-sm font-semibold text-cc-fg">Publish to {library.displayName || library.name}</h3>
+            <p className="text-[10px] text-cc-muted mt-1">
+              Copy an installed local mode into this library and stage it for commit.
+            </p>
+          </div>
+          <div className="px-5 py-4 space-y-3">
+            {status === "done" ? (
+              <div className="px-3 py-2 rounded-lg bg-emerald-500/10 border border-emerald-500/20 text-[11px] text-emerald-300/90">
+                Published.{pushed ? " Pushed to GitHub." : pushed === false ? " (Not pushed.)" : ""}
+              </div>
+            ) : (
+              <>
+                <div>
+                  <label className="text-[10px] text-cc-muted block mb-1">Source mode</label>
+                  {eligible.length === 0 ? (
+                    <div className="text-[11px] text-cc-muted/60">
+                      No eligible local modes. Install a mode (or create one with Mode Maker) first.
+                    </div>
+                  ) : (
+                    <select
+                      value={sourceName}
+                      onChange={(e) => setSourceName(e.target.value)}
+                      className="w-full px-3 py-2 text-xs bg-cc-input-bg border border-cc-border rounded-lg text-cc-fg outline-none focus:border-cc-primary/50 transition-colors"
+                    >
+                      <option value="">— pick a mode —</option>
+                      {eligible.map((m) => (
+                        <option key={m.path} value={m.name}>
+                          {m.displayName} ({m.name})
+                        </option>
+                      ))}
+                    </select>
+                  )}
+                </div>
+                <div>
+                  <label className="text-[10px] text-cc-muted block mb-1">Name override (optional)</label>
+                  <input
+                    placeholder={selected?.name || "(use source name)"}
+                    value={overrideName}
+                    onChange={(e) => setOverrideName(e.target.value)}
+                    className="w-full px-3 py-2 text-xs bg-cc-input-bg border border-cc-border rounded-lg text-cc-fg placeholder-cc-muted/40 outline-none focus:border-cc-primary/50 transition-colors"
+                  />
+                </div>
+                <label className="flex items-center gap-2 text-[11px] text-cc-muted hover:text-cc-fg transition-colors cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={pushAfter}
+                    onChange={(e) => setPushAfter(e.target.checked)}
+                    className="w-3.5 h-3.5 accent-[#f97316]"
+                  />
+                  Push to GitHub after commit
+                </label>
+              </>
+            )}
+            {status === "error" && error && (
+              <div className="px-3 py-2 rounded-lg bg-red-500/10 border border-red-500/20 text-[11px] text-red-300/90">
+                {error}
+              </div>
+            )}
+            <div className="flex justify-end gap-2 pt-1">
+              <button
+                onClick={onClose}
+                className="px-4 py-2 text-xs rounded-lg border border-cc-border text-cc-muted hover:text-cc-fg transition-colors cursor-pointer"
+              >
+                {status === "done" ? "Close" : "Cancel"}
+              </button>
+              {status !== "done" && (
+                <button
+                  onClick={handlePublish}
+                  disabled={!selected || status === "working"}
+                  className="px-4 py-2 text-xs rounded-lg bg-cc-primary text-white font-medium hover:brightness-110 disabled:opacity-40 transition-all cursor-pointer"
+                >
+                  {status === "working" ? "…" : "Publish"}
+                </button>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}
+
 function SettingsPanel({ open, onClose }: { open: boolean; onClose: () => void }) {
   if (!open) return null;
 
@@ -2766,6 +3588,7 @@ function SettingsPanel({ open, onClose }: { open: boolean; onClose: () => void }
           <BackendsSection />
           <ApiKeysSection />
           <CloudStorageSection />
+          <GitHubSection />
           <PluginsSection />
         </div>
       </div>
@@ -3075,6 +3898,9 @@ export default function Launcher() {
   const [sessions, setSessions] = useState<RecentSession[]>([]);
   const [running, setRunning] = useState<ChildProcess[]>([]);
   const [projects, setProjects] = useState<ProjectListEntry[]>([]);
+  const [libraries, setLibraries] = useState<InstalledLibrary[]>([]);
+  const [addLibraryOpen, setAddLibraryOpen] = useState(false);
+  const [publishTarget, setPublishTarget] = useState<InstalledLibrary | null>(null);
   // Phase 4 — archived bucket. Fetched once on mount and after a restore;
   // NOT refetched on every render. Toggled open by the inline "Archived"
   // header link, which only appears when `archivedProjects.length > 0`.
@@ -3180,6 +4006,22 @@ export default function Launcher() {
       })
       .catch(() => { });
   }, []);
+
+  const refreshLibraries = useCallback(() => {
+    fetch(`${getApiBase()}/api/libraries`)
+      .then((r) => r.json())
+      .then((data) => setLibraries(data.libraries || []))
+      .catch(() => { });
+  }, []);
+
+  // Refresh libraries on mount + whenever the server broadcasts a
+  // `libraries_updated` event (dispatched as a window event by ws.ts).
+  useEffect(() => {
+    refreshLibraries();
+    const handler = () => refreshLibraries();
+    window.addEventListener("pneuma:libraries-updated", handler);
+    return () => window.removeEventListener("pneuma:libraries-updated", handler);
+  }, [refreshLibraries]);
 
   const refreshRunning = useCallback(() => {
     // `/api/running` = all running `pneuma <mode>` sessions system-wide (read
@@ -3908,6 +4750,7 @@ export default function Launcher() {
                   displayName={mode.displayName}
                   description={mode.description}
                   icon={mode.icon}
+                  librarySource={mode.librarySource}
                   onClick={() => setLaunchTarget({
                     specifier: mode.specifier,
                     displayName: mode.displayName,
@@ -3929,6 +4772,57 @@ export default function Launcher() {
                 })}
               />
             </div>
+          </section>
+
+          {/* Mode Libraries */}
+          <section
+            className="pt-12"
+            style={{ animation: "launcherFadeIn 0.5s cubic-bezier(0.16, 1, 0.3, 1) 0.25s both" }}
+          >
+            <div className="flex items-baseline justify-between mb-5">
+              <div>
+                <h2 className="text-sm font-medium text-cc-fg/70 tracking-wide">Mode Libraries</h2>
+                <p className="text-xs text-cc-muted/50 mt-1">Shared mode collections from GitHub</p>
+              </div>
+              <button
+                onClick={() => setAddLibraryOpen(true)}
+                className="text-xs text-cc-primary hover:opacity-80 transition-opacity cursor-pointer"
+              >
+                + Add library
+              </button>
+            </div>
+            {libraries.length === 0 ? (
+              <div className="text-xs text-cc-muted/50">
+                No libraries linked yet.{" "}
+                <button
+                  onClick={() => setAddLibraryOpen(true)}
+                  className="text-cc-primary hover:opacity-80 transition-opacity cursor-pointer underline underline-offset-2"
+                >
+                  Link one
+                </button>
+                .
+              </div>
+            ) : (
+              <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
+                <AnimatePresence mode="popLayout">
+                  {libraries.map((lib) => (
+                    <motion.div
+                      key={lib.id}
+                      layout
+                      initial={{ opacity: 0, y: 8 }}
+                      animate={{ opacity: 1, y: 0 }}
+                      exit={{ opacity: 0, y: -8, transition: { duration: 0.15 } }}
+                      transition={{ duration: 0.25, ease: [0.4, 0, 0.2, 1] }}
+                    >
+                      <LibraryCard
+                        library={lib}
+                        onPublish={() => setPublishTarget(lib)}
+                      />
+                    </motion.div>
+                  ))}
+                </AnimatePresence>
+              </div>
+            )}
           </section>
 
           {/* (Import & R2 moved to SettingsPanel + ImportDialog) */}
@@ -4061,6 +4955,21 @@ export default function Launcher() {
           // joins the grid via reloadProjects().
         }}
         homeDir={homeDir}
+      />
+
+      {/* Add Library dialog — link existing or create new */}
+      <AddLibraryDialog
+        open={addLibraryOpen}
+        onClose={() => setAddLibraryOpen(false)}
+        onLinked={() => { refreshLibraries(); refreshModes(); }}
+      />
+
+      {/* Publish Mode dialog — pick a source mode from local list */}
+      <PublishToLibraryDialog
+        library={publishTarget}
+        localModes={local}
+        onClose={() => setPublishTarget(null)}
+        onPublished={() => { refreshLibraries(); refreshModes(); }}
       />
     </div>
   );

--- a/src/components/Launcher.tsx
+++ b/src/components/Launcher.tsx
@@ -2914,6 +2914,19 @@ function LibraryCard({
         ? library.source.url
         : "local";
 
+  // Mutations rely on a refetch driven by the `pneuma:libraries-updated`
+  // DOM event. The WS-based path (`ws.ts` → broadcastAll → event dispatch)
+  // only fires for connected sessions, and the launcher has no session ID
+  // so it never registers a WS browser socket — meaning the WS event
+  // never reaches it. We dispatch the same event locally after every
+  // successful POST so the launcher's own listener refetches; a second
+  // browser tab on a real session still gets the WS-driven path
+  // independently. Keeping the trigger paths converged on one event name
+  // means components don't need to learn a second refresh signal.
+  const fireUpdated = () => {
+    window.dispatchEvent(new Event("pneuma:libraries-updated"));
+  };
+
   const handleSync = async (e: React.MouseEvent) => {
     e.stopPropagation();
     setSyncing(true);
@@ -2924,6 +2937,7 @@ function LibraryCard({
       });
       const data = await res.json();
       if (!res.ok || data.error) throw new Error(data.error || `HTTP ${res.status}`);
+      fireUpdated();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Sync failed");
     } finally {
@@ -2940,6 +2954,7 @@ function LibraryCard({
       });
       const data = await res.json();
       if (!res.ok || data.error) throw new Error(data.error || `HTTP ${res.status}`);
+      fireUpdated();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Unlink failed");
     } finally {
@@ -2958,6 +2973,7 @@ function LibraryCard({
       );
       const data = await res.json();
       if (!res.ok || data.error) throw new Error(data.error || `HTTP ${res.status}`);
+      fireUpdated();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Toggle failed");
     } finally {
@@ -2975,6 +2991,7 @@ function LibraryCard({
       );
       const data = await res.json();
       if (!res.ok || data.error) throw new Error(data.error || `HTTP ${res.status}`);
+      fireUpdated();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Update failed");
     } finally {
@@ -4015,13 +4032,21 @@ export default function Launcher() {
   }, []);
 
   // Refresh libraries on mount + whenever the server broadcasts a
-  // `libraries_updated` event (dispatched as a window event by ws.ts).
+  // `libraries_updated` event (dispatched as a window event by ws.ts,
+  // or fired locally by LibraryCard / dialog handlers after a
+  // mutation — see the "trigger paths converged on one event name"
+  // comment in LibraryCard). Also re-runs `refreshModes` because
+  // activated library modes surface in `/api/registry` `local[]` —
+  // toggle one off and the Quick Start tile has to disappear.
   useEffect(() => {
     refreshLibraries();
-    const handler = () => refreshLibraries();
+    const handler = () => {
+      refreshLibraries();
+      refreshModes();
+    };
     window.addEventListener("pneuma:libraries-updated", handler);
     return () => window.removeEventListener("pneuma:libraries-updated", handler);
-  }, [refreshLibraries]);
+  }, [refreshLibraries, refreshModes]);
 
   const refreshRunning = useCallback(() => {
     // `/api/running` = all running `pneuma <mode>` sessions system-wide (read

--- a/src/components/Launcher.tsx
+++ b/src/components/Launcher.tsx
@@ -1735,6 +1735,7 @@ function ModeGallery({
                             onEdit={onEdit ? () => onEdit(mode) : undefined}
                             onEvolve={onEvolve ? () => onEvolve(mode) : undefined}
                             isLight={isLight}
+                            library={lib}
                           />
                         );
                       })}
@@ -1989,6 +1990,7 @@ function GalleryModeCard({
   onEvolve,
   onDelete,
   isLight,
+  library,
 }: {
   mode: AnyMode;
   expanded: boolean;
@@ -1998,6 +2000,15 @@ function GalleryModeCard({
   onEvolve?: () => void;
   onDelete?: () => void;
   isLight?: boolean;
+  /**
+   * Resolved source library when this mode came from one. The header stays
+   * clean (the small corner glyph + tooltip in QuickStartTile already
+   * signals origin); inside the expanded body we have room to show the
+   * full provenance — display name, source URL, last-synced timestamp —
+   * so users investigating a library mode don't have to scroll back to
+   * its library's group header to remember what it came from.
+   */
+  library?: InstalledLibrary;
 }) {
   const [activeHighlight, setActiveHighlight] = useState(0);
   const [evolveHovered, setEvolveHovered] = useState(false);
@@ -2188,6 +2199,42 @@ function GalleryModeCard({
                     <p className="text-[11px] text-cc-muted/40 font-mono mt-1">{mode.path}</p>
                   )}
                 </div>
+              </div>
+            )}
+            {/* Library provenance — only when the mode came from a linked
+                library. Lives at the bottom of the expanded body where the
+                showcase column has plenty of room; quiet styling so it
+                informs without competing with the highlight content. */}
+            {library && (
+              <div className="mt-5 pt-4 border-t border-cc-border/15 flex items-center gap-3 text-[11px] text-cc-muted/60">
+                <span className="text-cc-muted/40 shrink-0">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.6} strokeLinecap="round" strokeLinejoin="round" className="w-3.5 h-3.5" aria-hidden="true">
+                    <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+                    <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+                  </svg>
+                </span>
+                <span className="text-cc-fg/70 font-medium">
+                  From {library.displayName || library.name}
+                </span>
+                <span className="text-cc-muted/30">·</span>
+                <code className="font-mono text-cc-muted/70 truncate">
+                  {library.source.type === "github" || library.source.type === "url"
+                    ? library.source.url
+                    : "local"}
+                </code>
+                {library.lastSync && (
+                  <>
+                    <span className="text-cc-muted/30">·</span>
+                    <span className="shrink-0">
+                      synced {new Date(library.lastSync).toLocaleString(undefined, {
+                        month: "short",
+                        day: "numeric",
+                        hour: "numeric",
+                        minute: "2-digit",
+                      })}
+                    </span>
+                  </>
+                )}
               </div>
             )}
           </div>

--- a/src/components/Launcher.tsx
+++ b/src/components/Launcher.tsx
@@ -7,6 +7,7 @@ import { CreateProjectDialog } from "./CreateProjectDialog.js";
 import { DirBrowser } from "./DirBrowser.js";
 import { ProjectCard, type ProjectCardEntry } from "./ProjectCard.js";
 import { ModeIcon } from "./ModeIcon.js";
+import { useFavorites, sortFavoritesFirst } from "../hooks/useFavorites.js";
 import { InitParamForm, type InitParamWithAutoFill } from "./InitParamForm.js";
 import { useAnimatedMount } from "../utils/useAnimatedMount.js";
 import { timeAgo, runningDuration } from "../utils/timeAgo.js";
@@ -1413,6 +1414,7 @@ function QuickStartTile({
   icon,
   isModeMaker,
   librarySource,
+  isFavorite,
   onClick,
 }: {
   name: string;
@@ -1422,6 +1424,8 @@ function QuickStartTile({
   isModeMaker?: boolean;
   /** When set, a small "from {lib}" chip is rendered at the top-right. */
   librarySource?: { id: string; name: string; displayName?: string };
+  /** When true, a small filled star sits in the top-left to mark this tile as pinned. */
+  isFavorite?: boolean;
   onClick: () => void;
 }) {
   return (
@@ -1433,6 +1437,20 @@ function QuickStartTile({
           : "bg-cc-surface/30 hover:bg-cc-surface/60 border border-transparent hover:border-cc-border/30"
       }`}
     >
+      {isFavorite && (
+        // Favorite marker — sits top-left so it pairs with the library
+        // link glyph (top-right) without colliding. Filled orange star
+        // at low opacity; brightens on tile hover. Toggling happens in
+        // the gallery card, not here — Quick Start is for fast launch.
+        <span
+          className="absolute top-2 left-2 w-3 h-3 text-cc-primary/60 group-hover:text-cc-primary transition-colors pointer-events-none"
+          aria-label="Favorite"
+        >
+          <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path d="M12 17.27l5.18 3.73-1.64-6.81L21 9.74l-7.19-.61L12 2 10.19 9.13 3 9.74l5.46 4.45L6.82 21z" />
+          </svg>
+        </span>
+      )}
       {librarySource && (
         // Origin mark: signal "from external library" without competing
         // with the tile's title. A tiny link glyph sits in the corner;
@@ -1540,6 +1558,8 @@ function ModeGallery({
   onAddFromUrl,
   onAddLibrary,
   onPublishLibrary,
+  isFavorite,
+  onToggleFavorite,
   className,
   closing,
   headerHeight = 0,
@@ -1564,6 +1584,10 @@ function ModeGallery({
   onAddLibrary?: () => void;
   /** Open the PublishToLibraryDialog targeted at a specific library. */
   onPublishLibrary?: (library: InstalledLibrary) => void;
+  /** Membership check for the star toggle on each card. */
+  isFavorite?: (modeName: string) => boolean;
+  /** Toggle the favorite state for a mode. */
+  onToggleFavorite?: (modeName: string) => void;
   className?: string;
   closing?: boolean;
   headerHeight?: number;
@@ -1676,6 +1700,8 @@ function ModeGallery({
                       onEvolve={!isToolMode && onEvolve ? () => onEvolve(mode) : undefined}
                       onDelete={mode.source === "local" && onDeleteLocal ? () => onDeleteLocal(mode.name) : undefined}
                       isLight={isLight}
+                      isFavorite={!isToolMode && isFavorite ? isFavorite(mode.name) : undefined}
+                      onToggleFavorite={!isToolMode && onToggleFavorite ? () => onToggleFavorite(mode.name) : undefined}
                     />
                   );
                 })}
@@ -1736,6 +1762,8 @@ function ModeGallery({
                             onEvolve={onEvolve ? () => onEvolve(mode) : undefined}
                             isLight={isLight}
                             library={lib}
+                            isFavorite={isFavorite ? isFavorite(mode.name) : undefined}
+                            onToggleFavorite={onToggleFavorite ? () => onToggleFavorite(mode.name) : undefined}
                           />
                         );
                       })}
@@ -1991,6 +2019,8 @@ function GalleryModeCard({
   onDelete,
   isLight,
   library,
+  isFavorite,
+  onToggleFavorite,
 }: {
   mode: AnyMode;
   expanded: boolean;
@@ -2009,6 +2039,10 @@ function GalleryModeCard({
    * its library's group header to remember what it came from.
    */
   library?: InstalledLibrary;
+  /** When true, the star toggle shows its filled state. */
+  isFavorite?: boolean;
+  /** Toggle this mode in the user's favorites list. Optional — when omitted, the star button hides entirely. */
+  onToggleFavorite?: () => void;
 }) {
   const [activeHighlight, setActiveHighlight] = useState(0);
   const [evolveHovered, setEvolveHovered] = useState(false);
@@ -2091,6 +2125,37 @@ function GalleryModeCard({
         </div>
         <div className="flex items-center gap-2 shrink-0">
           <span className="text-[11px] text-cc-muted/40 font-mono">{mode.source !== "builtin" ? mode.version : ""}</span>
+
+          {/* Favorite toggle — primary pinning surface. The Quick Start
+              tile shows a static badge but doesn't toggle there; users
+              come here to manage their pins. Filled orange when active,
+              outline muted when inactive. */}
+          {onToggleFavorite && (
+            <button
+              onClick={(e) => { e.stopPropagation(); onToggleFavorite(); }}
+              className={`p-1.5 rounded-md transition-colors cursor-pointer ${
+                isFavorite
+                  ? "text-cc-primary hover:text-cc-primary/80"
+                  : "text-cc-muted/40 hover:text-cc-primary"
+              }`}
+              title={isFavorite ? "Unpin from Quick Start" : "Pin to Quick Start"}
+              aria-label={isFavorite ? "Unpin from favorites" : "Pin to favorites"}
+              aria-pressed={isFavorite ? true : false}
+            >
+              <svg
+                className="w-3.5 h-3.5"
+                viewBox="0 0 24 24"
+                fill={isFavorite ? "currentColor" : "none"}
+                stroke="currentColor"
+                strokeWidth={1.6}
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M12 17.27l5.18 3.73-1.64-6.81L21 9.74l-7.19-.61L12 2 10.19 9.13 3 9.74l5.46 4.45L6.82 21z" />
+              </svg>
+            </button>
+          )}
 
           {/* Evolve button */}
           {onEvolve && (
@@ -4458,11 +4523,16 @@ export default function Launcher() {
     ...published.map((m) => ({ ...m, source: "published" as const, specifier: m.archiveUrl })),
   ], [builtins, local, published]);
 
-  // All modes for quick start (exclude featured, add mode-maker at end)
+  const { favorites, isFavorite, toggle: toggleFavorite } = useFavorites();
+
+  // All modes for quick start (exclude featured, add mode-maker at end).
+  // Favorites bubble to the front of the grid in their persisted order;
+  // everything else preserves the original allModes ordering. mode-maker
+  // and evolve are filtered out — they live in the hero / settings flows.
   const quickStartModes = React.useMemo(() => {
     const modes = allModes.filter((m) => m.name !== "mode-maker" && m.name !== "evolve");
-    return modes;
-  }, [allModes, featuredMode]);
+    return sortFavoritesFirst(modes, favorites, (m) => m.name);
+  }, [allModes, favorites]);
 
   const handleGalleryLaunch = (mode: AnyMode) => {
     setShowGallery(false);
@@ -4863,12 +4933,21 @@ export default function Launcher() {
             <WarmSpotlightWrap gridClass="grid grid-cols-3 sm:grid-cols-4 lg:grid-cols-5 gap-3" radius={160}>
               {quickStartModes.map((mode) => (
                 <QuickStartTile
-                  key={mode.name}
+                  // Multiple modes can share a manifest `name` (e.g. a
+                  // builtin and its locally-evolved fork both manifest
+                  // as `slide`). Composing the React key from source +
+                  // path keeps each tile distinct even when names
+                  // collide, eliminating the "two children with the
+                  // same key" warning and the resulting render
+                  // ambiguity that made favorite badges appear on
+                  // only some of the colliding tiles.
+                  key={`${mode.source}::${mode.path || mode.name}`}
                   name={mode.name}
                   displayName={mode.displayName}
                   description={mode.description}
                   icon={mode.icon}
                   librarySource={mode.librarySource}
+                  isFavorite={isFavorite(mode.name)}
                   onClick={() => setLaunchTarget({
                     specifier: mode.specifier,
                     displayName: mode.displayName,
@@ -4910,6 +4989,8 @@ export default function Launcher() {
           onLaunch={handleGalleryLaunch}
           onAddLibrary={() => setAddLibraryOpen(true)}
           onPublishLibrary={(lib) => setPublishTarget(lib)}
+          isFavorite={isFavorite}
+          onToggleFavorite={toggleFavorite}
           onEdit={(mode) => {
             setShowGallery(false);
             // "Edit" on a mode = start a mode-maker session seeded from that

--- a/src/components/Launcher.tsx
+++ b/src/components/Launcher.tsx
@@ -1434,11 +1434,20 @@ function QuickStartTile({
       }`}
     >
       {librarySource && (
+        // Origin mark: signal "from external library" without competing
+        // with the tile's title. A tiny link glyph sits in the corner;
+        // the library name lives in the `title` tooltip so users can
+        // discover provenance on hover without it dominating the scan.
+        // Quiet by default (muted/40), warms on tile hover.
         <span
-          className="absolute top-1.5 right-1.5 px-1.5 py-0.5 text-[9px] rounded-full bg-cc-fg/5 text-cc-muted/60 border border-cc-border/30 truncate max-w-[90%]"
-          title={`from library: ${librarySource.displayName || librarySource.name}`}
+          className="absolute top-2 right-2 w-3 h-3 text-cc-muted/40 group-hover:text-cc-muted/70 transition-colors pointer-events-auto"
+          title={`From library: ${librarySource.displayName || librarySource.name}`}
+          aria-label={`From library: ${librarySource.displayName || librarySource.name}`}
         >
-          from {librarySource.displayName || librarySource.name}
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.2} strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+            <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+            <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+          </svg>
         </span>
       )}
       <div className={`w-11 h-11 flex items-center justify-center rounded-lg transition-all duration-200 ${
@@ -1457,7 +1466,12 @@ function QuickStartTile({
           {displayName}
         </span>
         {description && (
-          <span className="text-[10px] text-cc-muted/40 mt-0.5 block leading-tight line-clamp-2">{description}</span>
+          // line-clamp-2 sets `display: -webkit-box` — pairing it with the
+          // `block` utility overrode the box display in source order and
+          // disabled the clamp, letting Guizang Ppt's marathon description
+          // push the tile to ~10 lines while neighbors sat at 2. The clamp
+          // is the display now; tile heights stay even across the grid.
+          <span className="text-[10px] text-cc-muted/40 mt-0.5 leading-tight line-clamp-2">{description}</span>
         )}
       </div>
     </button>

--- a/src/components/Launcher.tsx
+++ b/src/components/Launcher.tsx
@@ -1517,23 +1517,39 @@ function ModeMakerHero({ onClick }: { onClick: () => void }) {
 
 function ModeGallery({
   modes,
+  libraries,
   onClose,
   onLaunch,
   onEdit,
   onEvolve,
   onDeleteLocal,
   onAddFromUrl,
+  onAddLibrary,
+  onPublishLibrary,
   className,
   closing,
   headerHeight = 0,
 }: {
   modes: AnyMode[];
+  /**
+   * All installed mode libraries. Each library renders a sub-group inside the
+   * gallery's "Libraries" section: a header strip with sync / publish / unlink
+   * controls, then GalleryModeCards for its activated modes. Inactive modes
+   * collapse behind a "N inactive" toggle. Library-sourced modes also appear
+   * in the launcher's Quick Start grid via `/api/registry` `local[]`; the
+   * gallery is where they're organised + managed.
+   */
+  libraries: InstalledLibrary[];
   onClose: () => void;
   onLaunch: (mode: AnyMode) => void;
   onEdit?: (mode: AnyMode) => void;
   onEvolve?: (mode: AnyMode) => void;
   onDeleteLocal?: (name: string) => void;
   onAddFromUrl?: () => void;
+  /** Open the AddLibraryDialog (state lives on the Launcher). */
+  onAddLibrary?: () => void;
+  /** Open the PublishToLibraryDialog targeted at a specific library. */
+  onPublishLibrary?: (library: InstalledLibrary) => void;
   className?: string;
   closing?: boolean;
   headerHeight?: number;
@@ -1552,10 +1568,31 @@ function ModeGallery({
       )
     : modes;
 
-  // Group by source
+  // Source taxonomy:
+  //   Built-in    — modes shipped with Pneuma
+  //   Local       — single-mode external installs in ~/.pneuma/modes/
+  //                 (NO `librarySource` — library-sourced modes are split out)
+  //   Libraries   — multi-mode repos under ~/.pneuma/libraries/<id>/.
+  //                 One sub-group per linked library, with management controls.
+  //   Published   — community R2 marketplace
+  // The split between Local and Libraries makes management surface obvious:
+  // single-mode installs have no peers, libraries have N modes sharing a source.
   const builtin = filtered.filter((m) => m.source === "builtin");
-  const local = filtered.filter((m) => m.source === "local");
+  const local = filtered.filter((m) => m.source === "local" && !m.librarySource);
+  const libraryModes = filtered.filter((m) => m.source === "local" && m.librarySource);
   const published = filtered.filter((m) => m.source === "published");
+
+  // Group library-sourced modes by library id. We keep the launcher-side
+  // library list (with its source URL + last-sync ts) as the source of
+  // truth for ordering and metadata — gallery just renders activated
+  // modes underneath each library's header strip.
+  const modesByLibrary = new Map<string, AnyMode[]>();
+  for (const m of libraryModes) {
+    const id = m.librarySource!.id;
+    const arr = modesByLibrary.get(id) ?? [];
+    arr.push(m);
+    modesByLibrary.set(id, arr);
+  }
 
   return (
     <div
@@ -1632,10 +1669,299 @@ function ModeGallery({
             </div>
           ))}
 
-        {filtered.length === 0 && (
+        {/* Libraries group — peers with Built-in / Local / Published. Rendered
+            before Published so the "your stuff" rhythm (Built-in → Local →
+            Libraries → Published) flows from most-trusted/most-yours to
+            most-public. Empty state still shows the section header + "+ Add
+            library" so first-time users have a discoverable entry point. */}
+        {(libraries.length > 0 || onAddLibrary) && (
+          <div className="mb-12">
+            <div className="flex items-center justify-between mb-6">
+              <h2 className="text-xs font-medium text-cc-muted/60 uppercase tracking-widest">Libraries</h2>
+              {onAddLibrary && (
+                <button
+                  onClick={onAddLibrary}
+                  className="text-[10px] text-cc-muted hover:text-cc-primary transition-colors cursor-pointer flex items-center gap-1"
+                  title="Link a GitHub repo containing one or more Pneuma modes"
+                >
+                  <span className="text-sm leading-none">+</span>
+                  <span>Add library</span>
+                </button>
+              )}
+            </div>
+            {libraries.length === 0 ? (
+              <p className="text-[11px] text-cc-muted/50 italic">
+                No libraries linked yet — paste a <code className="text-cc-muted/70">github:user/repo</code> above to install a multi-mode collection.
+              </p>
+            ) : (
+              <div className="space-y-10">
+                {libraries.map((lib) => {
+                  const activeModes = modesByLibrary.get(lib.id) ?? [];
+                  const inactiveCount = lib.modes.length - lib.modes.filter((m) => m.activated).length;
+                  // When the gallery is filtered by search, hide libraries
+                  // whose modes don't match — but always show empty libraries
+                  // (0 modes) so the user can still see + manage them.
+                  if (search && activeModes.length === 0 && lib.modes.length > 0) return null;
+                  return (
+                    <LibraryGalleryGroup
+                      key={lib.id}
+                      library={lib}
+                      inactiveCount={inactiveCount}
+                      onPublish={onPublishLibrary ? () => onPublishLibrary(lib) : undefined}
+                    >
+                      {activeModes.map((mode) => {
+                        const modeKey = `${mode.source}::lib:${lib.id}::${mode.name}`;
+                        return (
+                          <GalleryModeCard
+                            key={modeKey}
+                            mode={mode}
+                            expanded={expandedMode === modeKey}
+                            onToggle={() => setExpandedMode(expandedMode === modeKey ? null : modeKey)}
+                            onLaunch={() => onLaunch(mode)}
+                            onEdit={onEdit ? () => onEdit(mode) : undefined}
+                            onEvolve={onEvolve ? () => onEvolve(mode) : undefined}
+                            isLight={isLight}
+                          />
+                        );
+                      })}
+                    </LibraryGalleryGroup>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        )}
+
+        {filtered.length === 0 && libraries.length === 0 && (
           <p className="text-center text-cc-muted/60 py-20">No modes match your search.</p>
         )}
       </div>
+    </div>
+  );
+}
+
+/**
+ * Library sub-group inside the gallery's Libraries section. Renders the
+ * library identity strip (name, source URL chip, sync timestamp) and
+ * inline management actions (Sync / Publish / Unlink) above the
+ * `GalleryModeCard` children for activated modes.
+ *
+ * Visual rhythm mirrors the gallery's group headers (uppercase tracking-
+ * widest small caps) but adds a second metadata row and a quiet action
+ * cluster. Inactive modes collapse behind a small footer toggle that
+ * stays muted until expanded — keeps the gallery scan-friendly when
+ * users only care about activated content.
+ *
+ * Match the design constraint: GalleryModeCard is rendered verbatim,
+ * only the surrounding chrome is new. No card visual is altered for
+ * library-sourced modes.
+ */
+function LibraryGalleryGroup({
+  library,
+  inactiveCount,
+  onPublish,
+  children,
+}: {
+  library: InstalledLibrary;
+  inactiveCount: number;
+  onPublish?: () => void;
+  children: React.ReactNode;
+}) {
+  const [syncing, setSyncing] = useState(false);
+  const [unlinkConfirm, setUnlinkConfirm] = useState(false);
+  const [showInactive, setShowInactive] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState<string | null>(null);
+  const inactive = library.modes.filter((m) => !m.activated);
+
+  const fireUpdated = () =>
+    window.dispatchEvent(new Event("pneuma:libraries-updated"));
+
+  const sourceLabel =
+    library.source.type === "github"
+      ? library.source.url
+      : library.source.type === "url"
+        ? library.source.url
+        : "local";
+
+  const handleSync = async () => {
+    setSyncing(true);
+    setError(null);
+    try {
+      const res = await fetch(
+        `${getApiBase()}/api/libraries/${encodeURIComponent(library.id)}/sync`,
+        { method: "POST" },
+      );
+      const data = await res.json();
+      if (!res.ok || data.error) throw new Error(data.error || `HTTP ${res.status}`);
+      fireUpdated();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Sync failed");
+    } finally {
+      setSyncing(false);
+    }
+  };
+
+  const handleUnlink = async () => {
+    setError(null);
+    try {
+      const res = await fetch(
+        `${getApiBase()}/api/libraries/${encodeURIComponent(library.id)}`,
+        { method: "DELETE" },
+      );
+      const data = await res.json();
+      if (!res.ok || data.error) throw new Error(data.error || `HTTP ${res.status}`);
+      fireUpdated();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unlink failed");
+      setUnlinkConfirm(false);
+    }
+  };
+
+  const handleActivate = async (modeName: string, currentlyActive: boolean) => {
+    setBusy(modeName);
+    setError(null);
+    try {
+      const action = currentlyActive ? "deactivate" : "activate";
+      const res = await fetch(
+        `${getApiBase()}/api/libraries/${encodeURIComponent(library.id)}/mode/${encodeURIComponent(modeName)}/${action}`,
+        { method: "POST" },
+      );
+      const data = await res.json();
+      if (!res.ok || data.error) throw new Error(data.error || `HTTP ${res.status}`);
+      fireUpdated();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Toggle failed");
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const lastSync = library.lastSync
+    ? new Date(library.lastSync).toLocaleString(undefined, {
+        month: "short",
+        day: "numeric",
+        hour: "numeric",
+        minute: "2-digit",
+      })
+    : null;
+
+  return (
+    <div>
+      {/* Library identity + actions strip — sub-header rhythm, not a card */}
+      <div className="mb-4 pb-3 border-b border-cc-border/15">
+        <div className="flex items-start justify-between gap-4 flex-wrap">
+          <div className="min-w-0">
+            <h3 className="text-sm font-medium text-cc-fg">
+              {library.displayName || library.name}
+            </h3>
+            <div className="mt-1 flex items-center gap-2 text-[11px] text-cc-muted/60 flex-wrap">
+              <code className="font-mono text-cc-muted/70">{sourceLabel}</code>
+              {lastSync && (
+                <>
+                  <span className="text-cc-muted/30">·</span>
+                  <span>synced {lastSync}</span>
+                </>
+              )}
+            </div>
+          </div>
+          <div className="flex items-center gap-3 shrink-0 text-[10px]">
+            <button
+              onClick={handleSync}
+              disabled={syncing}
+              className="text-cc-muted hover:text-cc-primary transition-colors cursor-pointer flex items-center gap-1 disabled:opacity-50"
+              title="Refresh from source"
+            >
+              <span>↻</span>
+              <span>{syncing ? "Syncing…" : "Sync"}</span>
+            </button>
+            {onPublish && (
+              <button
+                onClick={onPublish}
+                className="text-cc-muted hover:text-cc-primary transition-colors cursor-pointer flex items-center gap-1"
+                title="Copy a local mode into this library"
+              >
+                <span className="text-sm leading-none">+</span>
+                <span>Publish</span>
+              </button>
+            )}
+            {unlinkConfirm ? (
+              <span className="flex items-center gap-2">
+                <button
+                  onClick={handleUnlink}
+                  className="text-cc-primary hover:opacity-80 transition-opacity cursor-pointer"
+                >
+                  Confirm
+                </button>
+                <button
+                  onClick={() => setUnlinkConfirm(false)}
+                  className="text-cc-muted hover:text-cc-fg transition-colors cursor-pointer"
+                >
+                  Cancel
+                </button>
+              </span>
+            ) : (
+              <button
+                onClick={() => setUnlinkConfirm(true)}
+                className="text-cc-muted hover:text-cc-primary transition-colors cursor-pointer"
+                title="Remove this library"
+              >
+                Unlink
+              </button>
+            )}
+          </div>
+        </div>
+        {error && (
+          <p className="mt-2 text-[11px] text-cc-primary/80">{error}</p>
+        )}
+      </div>
+
+      {/* Activated modes — existing GalleryModeCard, untouched */}
+      {React.Children.count(children) > 0 ? (
+        <div className="space-y-6">{children}</div>
+      ) : library.modes.length > 0 ? (
+        <p className="text-[11px] text-cc-muted/50 italic">
+          All modes in this library are inactive. Activate one below to launch it.
+        </p>
+      ) : (
+        <p className="text-[11px] text-cc-muted/50 italic">
+          This library is empty. Publish a mode into it from a local install.
+        </p>
+      )}
+
+      {/* Inactive modes — muted summary row + collapsible list with Activate */}
+      {inactive.length > 0 && (
+        <div className="mt-5">
+          <button
+            onClick={() => setShowInactive((v) => !v)}
+            className="text-[10px] text-cc-muted/60 hover:text-cc-muted transition-colors cursor-pointer flex items-center gap-1"
+          >
+            <span className={`inline-block transition-transform ${showInactive ? "rotate-90" : ""}`}>›</span>
+            <span>
+              {inactiveCount} inactive {inactiveCount === 1 ? "mode" : "modes"}
+            </span>
+          </button>
+          {showInactive && (
+            <ul className="mt-3 space-y-1.5 pl-3">
+              {inactive.map((m) => (
+                <li key={m.name} className="flex items-center justify-between text-[12px] text-cc-muted/70 py-1">
+                  <span className="font-mono">
+                    {m.name}
+                    <span className="ml-2 text-cc-muted/40">v{m.manifestVersion}</span>
+                  </span>
+                  <button
+                    onClick={() => handleActivate(m.name, false)}
+                    disabled={busy === m.name}
+                    className="text-cc-muted hover:text-cc-primary transition-colors cursor-pointer disabled:opacity-50"
+                  >
+                    {busy === m.name ? "…" : "Activate"}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
     </div>
   );
 }
@@ -2855,300 +3181,6 @@ function GitHubSection() {
           </span>
         </div>
       )}
-    </div>
-  );
-}
-
-// ── LibraryCard ───────────────────────────────────────────────────────────
-//
-// One card per installed library. Shows source, counts, and an updates
-// pill; clicking the card body expands a per-mode list with activate
-// toggles + per-mode update affordances. Action footer: Sync / Publish /
-// Unlink (with inline confirm).
-
-function LibraryIcon({ kind, className }: { kind: "github" | "url" | "local"; className?: string }) {
-  if (kind === "github") {
-    return (
-      <svg viewBox="0 0 16 16" fill="currentColor" className={className}>
-        <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
-      </svg>
-    );
-  }
-  if (kind === "local") {
-    return (
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} className={className}>
-        <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 9.776c.112-.017.227-.026.344-.026h15.812c.117 0 .232.009.344.026m-16.5 0a2.25 2.25 0 00-1.883 2.542l.857 6a2.25 2.25 0 002.227 1.932H19.05a2.25 2.25 0 002.227-1.932l.857-6a2.25 2.25 0 00-1.883-2.542m-16.5 0V6A2.25 2.25 0 016 3.75h3.879a1.5 1.5 0 011.06.44l2.122 2.12a1.5 1.5 0 001.06.44H18A2.25 2.25 0 0120.25 9v.776" />
-      </svg>
-    );
-  }
-  return (
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} className={className}>
-      <path strokeLinecap="round" strokeLinejoin="round" d="M13.19 8.688a4.5 4.5 0 011.242 7.244l-4.5 4.5a4.5 4.5 0 01-6.364-6.364l1.757-1.757m13.35-.622l1.757-1.757a4.5 4.5 0 00-6.364-6.364l-4.5 4.5a4.5 4.5 0 001.242 7.244" />
-    </svg>
-  );
-}
-
-function LibraryCard({
-  library,
-  onPublish,
-}: {
-  library: InstalledLibrary;
-  onPublish: () => void;
-}) {
-  const [expanded, setExpanded] = useState(false);
-  const [syncing, setSyncing] = useState(false);
-  const [busy, setBusy] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
-
-  const modeCount = library.modes.length;
-  const activatedCount = library.modes.filter((m) => m.activated).length;
-  const updateCount = library.modes.filter(
-    (m) => m.installedVersion !== m.manifestVersion,
-  ).length;
-
-  const sourceKind = library.source.type;
-  const sourceUrl =
-    library.source.type === "github"
-      ? library.source.url
-      : library.source.type === "url"
-        ? library.source.url
-        : "local";
-
-  // Mutations rely on a refetch driven by the `pneuma:libraries-updated`
-  // DOM event. The WS-based path (`ws.ts` → broadcastAll → event dispatch)
-  // only fires for connected sessions, and the launcher has no session ID
-  // so it never registers a WS browser socket — meaning the WS event
-  // never reaches it. We dispatch the same event locally after every
-  // successful POST so the launcher's own listener refetches; a second
-  // browser tab on a real session still gets the WS-driven path
-  // independently. Keeping the trigger paths converged on one event name
-  // means components don't need to learn a second refresh signal.
-  const fireUpdated = () => {
-    window.dispatchEvent(new Event("pneuma:libraries-updated"));
-  };
-
-  const handleSync = async (e: React.MouseEvent) => {
-    e.stopPropagation();
-    setSyncing(true);
-    setError(null);
-    try {
-      const res = await fetch(`${getApiBase()}/api/libraries/${encodeURIComponent(library.id)}/sync`, {
-        method: "POST",
-      });
-      const data = await res.json();
-      if (!res.ok || data.error) throw new Error(data.error || `HTTP ${res.status}`);
-      fireUpdated();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Sync failed");
-    } finally {
-      setSyncing(false);
-    }
-  };
-
-  const handleUnlink = async () => {
-    setBusy("unlink");
-    setError(null);
-    try {
-      const res = await fetch(`${getApiBase()}/api/libraries/${encodeURIComponent(library.id)}`, {
-        method: "DELETE",
-      });
-      const data = await res.json();
-      if (!res.ok || data.error) throw new Error(data.error || `HTTP ${res.status}`);
-      fireUpdated();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Unlink failed");
-    } finally {
-      setBusy(null);
-    }
-  };
-
-  const handleToggle = async (modeName: string, currentlyActive: boolean) => {
-    setBusy(`toggle-${modeName}`);
-    setError(null);
-    try {
-      const action = currentlyActive ? "deactivate" : "activate";
-      const res = await fetch(
-        `${getApiBase()}/api/libraries/${encodeURIComponent(library.id)}/mode/${encodeURIComponent(modeName)}/${action}`,
-        { method: "POST" },
-      );
-      const data = await res.json();
-      if (!res.ok || data.error) throw new Error(data.error || `HTTP ${res.status}`);
-      fireUpdated();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Toggle failed");
-    } finally {
-      setBusy(null);
-    }
-  };
-
-  const handleAcceptUpdate = async (modeName: string) => {
-    setBusy(`update-${modeName}`);
-    setError(null);
-    try {
-      const res = await fetch(
-        `${getApiBase()}/api/libraries/${encodeURIComponent(library.id)}/mode/${encodeURIComponent(modeName)}/accept-update`,
-        { method: "POST" },
-      );
-      const data = await res.json();
-      if (!res.ok || data.error) throw new Error(data.error || `HTTP ${res.status}`);
-      fireUpdated();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Update failed");
-    } finally {
-      setBusy(null);
-    }
-  };
-
-  return (
-    <div className="rounded-xl bg-cc-surface/30 hover:bg-cc-surface/40 border border-cc-border/20 hover:border-cc-border/40 backdrop-blur-sm transition-all duration-200">
-      <button
-        onClick={() => setExpanded((v) => !v)}
-        className="w-full text-left px-4 py-3 cursor-pointer"
-      >
-        <div className="flex items-start gap-3">
-          <div className="w-9 h-9 flex items-center justify-center rounded-lg bg-cc-fg/5 text-cc-muted/70 shrink-0">
-            <LibraryIcon kind={sourceKind} className="w-4 h-4" />
-          </div>
-          <div className="flex-1 min-w-0">
-            <div className="flex items-center gap-2">
-              <h3 className="text-sm font-medium text-cc-fg truncate">
-                {library.displayName || library.name}
-              </h3>
-              {updateCount > 0 && (
-                <span className="inline-flex items-center gap-1 px-1.5 py-0.5 text-[9px] rounded-full bg-cc-primary/15 text-cc-primary border border-cc-primary/25">
-                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} className="w-2.5 h-2.5">
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M12 4.5v15m0 0l-7.5-7.5M12 19.5l7.5-7.5" />
-                  </svg>
-                  {updateCount} update{updateCount === 1 ? "" : "s"}
-                </span>
-              )}
-            </div>
-            <div
-              className="text-[10px] text-cc-muted/50 truncate mt-0.5"
-              title={sourceUrl}
-            >
-              {sourceUrl}
-            </div>
-            <div className="text-[10px] text-cc-muted/60 mt-1">
-              {modeCount} mode{modeCount === 1 ? "" : "s"} · {activatedCount} activated
-            </div>
-          </div>
-          <svg
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth={1.5}
-            className={`w-4 h-4 text-cc-muted/40 transition-transform duration-200 shrink-0 ${expanded ? "rotate-180" : ""}`}
-          >
-            <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
-          </svg>
-        </div>
-      </button>
-
-      <AnimatePresence initial={false}>
-        {expanded && (
-          <motion.div
-            initial={{ height: 0, opacity: 0 }}
-            animate={{ height: "auto", opacity: 1 }}
-            exit={{ height: 0, opacity: 0 }}
-            transition={{ duration: 0.2, ease: [0.4, 0, 0.2, 1] }}
-            className="overflow-hidden"
-          >
-            <div className="px-4 pb-3 space-y-1.5 border-t border-cc-border/20 pt-3">
-              {library.modes.length === 0 && (
-                <div className="text-[11px] text-cc-muted/50 px-2 py-1">
-                  No modes in this library.
-                </div>
-              )}
-              {library.modes.map((m) => {
-                const updateAvailable = m.installedVersion !== m.manifestVersion;
-                const toggling = busy === `toggle-${m.name}`;
-                const updating = busy === `update-${m.name}`;
-                return (
-                  <div
-                    key={m.name}
-                    className="flex items-center gap-3 px-2 py-1.5 rounded-lg hover:bg-cc-fg/5 transition-colors"
-                  >
-                    <div className="flex-1 min-w-0">
-                      <div className="flex items-center gap-2">
-                        <span className="text-xs text-cc-fg/85 truncate">{m.name}</span>
-                        <span className="text-[10px] text-cc-muted/40">v{m.manifestVersion}</span>
-                        {updateAvailable && (
-                          <button
-                            disabled={updating}
-                            onClick={(e) => { e.stopPropagation(); void handleAcceptUpdate(m.name); }}
-                            className="text-[9px] px-1.5 py-0.5 rounded-full bg-cc-primary/15 text-cc-primary hover:bg-cc-primary/25 border border-cc-primary/25 transition-colors cursor-pointer disabled:opacity-40"
-                          >
-                            {updating ? "…" : "Update"}
-                          </button>
-                        )}
-                      </div>
-                      <div className="text-[10px] text-cc-muted/40 truncate">{m.path}</div>
-                    </div>
-                    {/* Activate toggle */}
-                    <button
-                      type="button"
-                      role="switch"
-                      aria-checked={m.activated}
-                      disabled={toggling}
-                      onClick={(e) => { e.stopPropagation(); void handleToggle(m.name, m.activated); }}
-                      className={`relative inline-flex h-4 w-7 shrink-0 cursor-pointer rounded-full border transition-colors disabled:opacity-50 ${
-                        m.activated
-                          ? "bg-cc-primary/80 border-cc-primary/40"
-                          : "bg-cc-fg/10 border-cc-border/40"
-                      }`}
-                      title={m.activated ? "Deactivate" : "Activate"}
-                    >
-                      <span
-                        className={`absolute top-0.5 h-3 w-3 rounded-full bg-white shadow transition-all duration-150 ${
-                          m.activated ? "left-[14px]" : "left-0.5"
-                        }`}
-                      />
-                    </button>
-                  </div>
-                );
-              })}
-            </div>
-          </motion.div>
-        )}
-      </AnimatePresence>
-
-      {/* Footer actions */}
-      <div className="flex items-center gap-1 px-3 py-2 border-t border-cc-border/20">
-        <button
-          onClick={handleSync}
-          disabled={syncing}
-          className="p-1.5 rounded-lg text-cc-muted/50 hover:text-cc-fg hover:bg-cc-fg/5 transition-colors cursor-pointer disabled:opacity-40"
-          title="Sync library"
-        >
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} className={`w-4 h-4 ${syncing ? "animate-spin" : ""}`}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182m0-4.991v4.99" />
-          </svg>
-        </button>
-        <button
-          onClick={(e) => { e.stopPropagation(); onPublish(); }}
-          className="p-1.5 rounded-lg text-cc-muted/50 hover:text-cc-fg hover:bg-cc-fg/5 transition-colors cursor-pointer"
-          title="Publish a mode to this library"
-        >
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} className="w-4 h-4">
-            <path strokeLinecap="round" strokeLinejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5" />
-          </svg>
-        </button>
-        <div className="flex-1" />
-        {error && (
-          <span className="text-[10px] text-red-400/90 truncate" title={error}>{error}</span>
-        )}
-        <ConfirmButton
-          stopPropagation
-          label="Unlink"
-          onConfirm={handleUnlink}
-          icon={
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} className="w-4 h-4">
-              <path strokeLinecap="round" strokeLinejoin="round" d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0" />
-            </svg>
-          }
-        />
-      </div>
     </div>
   );
 }
@@ -4799,56 +4831,10 @@ export default function Launcher() {
             </div>
           </section>
 
-          {/* Mode Libraries */}
-          <section
-            className="pt-12"
-            style={{ animation: "launcherFadeIn 0.5s cubic-bezier(0.16, 1, 0.3, 1) 0.25s both" }}
-          >
-            <div className="flex items-baseline justify-between mb-5">
-              <div>
-                <h2 className="text-sm font-medium text-cc-fg/70 tracking-wide">Mode Libraries</h2>
-                <p className="text-xs text-cc-muted/50 mt-1">Shared mode collections from GitHub</p>
-              </div>
-              <button
-                onClick={() => setAddLibraryOpen(true)}
-                className="text-xs text-cc-primary hover:opacity-80 transition-opacity cursor-pointer"
-              >
-                + Add library
-              </button>
-            </div>
-            {libraries.length === 0 ? (
-              <div className="text-xs text-cc-muted/50">
-                No libraries linked yet.{" "}
-                <button
-                  onClick={() => setAddLibraryOpen(true)}
-                  className="text-cc-primary hover:opacity-80 transition-opacity cursor-pointer underline underline-offset-2"
-                >
-                  Link one
-                </button>
-                .
-              </div>
-            ) : (
-              <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
-                <AnimatePresence mode="popLayout">
-                  {libraries.map((lib) => (
-                    <motion.div
-                      key={lib.id}
-                      layout
-                      initial={{ opacity: 0, y: 8 }}
-                      animate={{ opacity: 1, y: 0 }}
-                      exit={{ opacity: 0, y: -8, transition: { duration: 0.15 } }}
-                      transition={{ duration: 0.25, ease: [0.4, 0, 0.2, 1] }}
-                    >
-                      <LibraryCard
-                        library={lib}
-                        onPublish={() => setPublishTarget(lib)}
-                      />
-                    </motion.div>
-                  ))}
-                </AnimatePresence>
-              </div>
-            )}
-          </section>
+          {/* Mode Libraries surface moved into the Mode Gallery overlay
+              (gallery's Libraries group). Launcher main now only carries the
+              fast-path Quick Start grid — full mode catalog + library
+              management live one click away under "All Modes". */}
 
           {/* (Import & R2 moved to SettingsPanel + ImportDialog) */}
         </main>
@@ -4858,8 +4844,11 @@ export default function Launcher() {
       {galleryAnim.mounted && (
         <ModeGallery
           modes={allModes}
+          libraries={libraries}
           onClose={() => setShowGallery(false)}
           onLaunch={handleGalleryLaunch}
+          onAddLibrary={() => setAddLibraryOpen(true)}
+          onPublishLibrary={(lib) => setPublishTarget(lib)}
           onEdit={(mode) => {
             setShowGallery(false);
             // "Edit" on a mode = start a mode-maker session seeded from that

--- a/src/components/ProjectPanel.tsx
+++ b/src/components/ProjectPanel.tsx
@@ -31,6 +31,7 @@ import { sendUserMessage } from "../ws.js";
 import { useAnimatedMount } from "../utils/useAnimatedMount.js";
 import { CoverImage, type ProjectCoverEntry } from "./ProjectCover.js";
 import { ModeIcon } from "./ModeIcon.js";
+import { useFavorites } from "../hooks/useFavorites.js";
 import { InitParamForm, type InitParamWithAutoFill } from "./InitParamForm.js";
 import EditorPickerButton from "./EditorPickerButton.js";
 import {
@@ -433,6 +434,14 @@ export default function ProjectPanel({ projectRoot, onClose }: ProjectPanelProps
     () => ["webcraft", "doc", "slide", "illustrate", "draw", "kami", "diagram", "remotion"],
     [],
   );
+  const { favorites: favoritesList, isFavorite } = useFavorites();
+  // Ordering rules, top to bottom:
+  //   1. Favorites in their persisted order — explicit user pins always
+  //      surface first regardless of project history.
+  //   2. Used modes (non-favorite) ranked by recency in this project.
+  //   3. Unused modes (non-favorite) ranked by BUILTIN_PRIORITY.
+  // This honors the user's "favorites always show at the front" rule
+  // while keeping project-local recency relevant within the rest.
   const orderedModes = useMemo(() => {
     if (modes.length === 0) return [] as ModeInfo[];
     const usedModeRecency = new Map<string, number>();
@@ -440,8 +449,12 @@ export default function ProjectPanel({ projectRoot, onClose }: ProjectPanelProps
       const prev = usedModeRecency.get(s.mode) ?? 0;
       usedModeRecency.set(s.mode, Math.max(prev, s.lastAccessed ?? 0));
     }
+    const favIdx = new Map(favoritesList.map((n, i) => [n, i] as const));
+    const favs = modes
+      .filter((m) => favIdx.has(m.name))
+      .sort((a, b) => (favIdx.get(a.name)! - favIdx.get(b.name)!));
     const used = modes
-      .filter((m) => usedModeRecency.has(m.name))
+      .filter((m) => !favIdx.has(m.name) && usedModeRecency.has(m.name))
       .sort(
         (a, b) =>
           (usedModeRecency.get(b.name) ?? 0) - (usedModeRecency.get(a.name) ?? 0),
@@ -451,10 +464,10 @@ export default function ProjectPanel({ projectRoot, onClose }: ProjectPanelProps
       return idx === -1 ? Number.MAX_SAFE_INTEGER : idx;
     };
     const unused = modes
-      .filter((m) => !usedModeRecency.has(m.name))
+      .filter((m) => !favIdx.has(m.name) && !usedModeRecency.has(m.name))
       .sort((a, b) => priority(a.name) - priority(b.name));
-    return [...used, ...unused];
-  }, [modes, sessions, BUILTIN_PRIORITY]);
+    return [...favs, ...used, ...unused];
+  }, [modes, sessions, BUILTIN_PRIORITY, favoritesList]);
   const visibleModes = showAllModes
     ? orderedModes
     : orderedModes.slice(0, DEFAULT_VISIBLE_MODE_COUNT);
@@ -912,6 +925,20 @@ export default function ProjectPanel({ projectRoot, onClose }: ProjectPanelProps
                             <span className="text-sm text-cc-fg font-medium truncate">
                               {m.displayName ?? m.name}
                             </span>
+                            {isFavorite(m.name) && (
+                              // Matches the QuickStartTile pin badge — same
+                              // glyph, same orange, just inline next to the
+                              // title since project tiles aren't tall enough
+                              // for a corner anchor.
+                              <span
+                                className="w-3 h-3 text-cc-primary/70 shrink-0"
+                                aria-label="Favorite"
+                              >
+                                <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                                  <path d="M12 17.27l5.18 3.73-1.64-6.81L21 9.74l-7.19-.61L12 2 10.19 9.13 3 9.74l5.46 4.45L6.82 21z" />
+                                </svg>
+                              </span>
+                            )}
                             {count > 0 ? (
                               <span className="text-[10px] text-cc-muted/40 ml-auto shrink-0">
                                 · {count}

--- a/src/hooks/useFavorites.ts
+++ b/src/hooks/useFavorites.ts
@@ -1,0 +1,121 @@
+/**
+ * useFavorites — read/write the persistent favorites list.
+ *
+ * Favorites are a flat ordered list of mode names. The launcher uses
+ * them to sort the Quick Start grid and the project mode-tile picker
+ * (favorites always render first, original order preserved within and
+ * across the groups). Server-backed at `~/.pneuma/favorites.json` so
+ * the list survives across browser resets and is shared across all
+ * launcher tabs on the same machine.
+ *
+ * Optimistic UI: `toggle` flips state locally immediately, then POSTs.
+ * On failure we revert and log. Concurrent toggles dedupe via the
+ * latest write (last writer wins — fine for a personal preference
+ * file with no contention).
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { getApiBase } from "../utils/api.js";
+
+interface FavoritesResponse {
+  favorites: string[];
+  defaults?: string[];
+}
+
+export function useFavorites(): {
+  /** Ordered list — render in this order when surfacing favorites. */
+  favorites: string[];
+  /** Membership check (O(1)). */
+  isFavorite: (modeName: string) => boolean;
+  /** Add if absent, remove if present. Optimistic + server-backed. */
+  toggle: (modeName: string) => void;
+  /** True until the first fetch resolves (use to avoid flicker). */
+  loading: boolean;
+} {
+  const [favorites, setFavorites] = useState<string[]>([]);
+  const [loading, setLoading] = useState(true);
+  // Tracks the latest write so a slow earlier POST can't clobber a
+  // later state once it lands. Increment per local mutation.
+  const writeSeq = useRef(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch(`${getApiBase()}/api/favorites`)
+      .then((r) => r.json() as Promise<FavoritesResponse>)
+      .then((data) => {
+        if (cancelled) return;
+        if (Array.isArray(data.favorites)) setFavorites(data.favorites);
+      })
+      .catch(() => { /* leave empty; reverts to "no favorites yet" gracefully */ })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, []);
+
+  const favoriteSet = useMemo(() => new Set(favorites), [favorites]);
+  const isFavorite = useCallback(
+    (name: string) => favoriteSet.has(name),
+    [favoriteSet],
+  );
+
+  const toggle = useCallback(
+    (modeName: string) => {
+      const seq = ++writeSeq.current;
+      const next = favoriteSet.has(modeName)
+        ? favorites.filter((n) => n !== modeName)
+        : [...favorites, modeName];
+      setFavorites(next);
+      fetch(`${getApiBase()}/api/favorites`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ favorites: next }),
+      })
+        .then(async (r) => {
+          if (!r.ok) throw new Error(`HTTP ${r.status}`);
+          const data = (await r.json()) as FavoritesResponse;
+          // Only adopt the server response if no newer write has started.
+          // Otherwise the local optimistic state is the more recent truth.
+          if (writeSeq.current === seq && Array.isArray(data.favorites)) {
+            setFavorites(data.favorites);
+          }
+        })
+        .catch((err) => {
+          console.warn(`[favorites] toggle failed: ${err}`);
+          // Revert only if this was the latest write — a later toggle
+          // already moved the state forward.
+          if (writeSeq.current === seq) setFavorites(favorites);
+        });
+    },
+    [favorites, favoriteSet],
+  );
+
+  return { favorites, isFavorite, toggle, loading };
+}
+
+/**
+ * Sort a mode list with favorites first. Preserves the original relative
+ * order WITHIN favorites (matching the persisted file order) and WITHIN
+ * non-favorites. Used by Quick Start + the project mode-tile picker.
+ *
+ * @param modes The list to sort; mutated copy returned, input untouched.
+ * @param favorites Ordered list of favorite mode names.
+ * @param getName Extractor — caller's mode shape may vary (BuiltinMode,
+ *   ResolvedMode, LocalMode, etc.). Falls back to `(m as any).name`.
+ */
+export function sortFavoritesFirst<T>(
+  modes: T[],
+  favorites: string[],
+  getName: (m: T) => string,
+): T[] {
+  if (favorites.length === 0) return modes;
+  const favIndex = new Map(favorites.map((name, i) => [name, i] as const));
+  const sorted = modes.slice();
+  sorted.sort((a, b) => {
+    const ai = favIndex.get(getName(a));
+    const bi = favIndex.get(getName(b));
+    if (ai !== undefined && bi !== undefined) return ai - bi;
+    if (ai !== undefined) return -1;
+    if (bi !== undefined) return 1;
+    return 0; // stable for non-favorites — preserves caller's original order
+  });
+  return sorted;
+}

--- a/src/ws.ts
+++ b/src/ws.ts
@@ -939,6 +939,15 @@ function handleParsedMessage(data: BrowserIncomingMessage) {
       store.bumpSessionMetaTick();
       break;
     }
+    case "libraries_updated": {
+      // The launcher's library-routes mutated something (link / sync /
+      // activate / publish / unlink). Fire a DOM event the Launcher
+      // component listens for to refetch `/api/libraries`. Kept as a
+      // window-level event rather than a store slice because libraries
+      // are launcher-only state — no other component needs them.
+      window.dispatchEvent(new Event("pneuma:libraries-updated"));
+      break;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Three intertwined feature lines, 7 commits, all on one branch since they share UI surface and one couldn't ship without the others.

- **Mode Libraries.** A single GitHub repo can ship N modes; users install the whole library, pick which modes to activate, and sync updates per-library. Author side adds init / publish / push so anyone can run a personal community library on their own GitHub account.
- **Mode Gallery v2.** Library management moved out of the launcher main page into the gallery as a peer of Built-in / Local / Published. The launcher main page is back to "Quick Start grid + Mode Maker hero"; everything browsable lives in the gallery.
- **Favorites.** Defaults (webcraft / slide / diagram / illustrate / remotion / kami) seed first-run, users toggle from the gallery card, favorites pin to the front of Quick Start AND ProjectPanel's mode-tile picker.

## What's new

**Foundation (`feat: mode libraries`)**
- `~/.pneuma/libraries/<id>/` layout with `.library.json` sidecar tracking activation, manifest version, last-synced sha.
- Auto-detect at install: root `manifest.ts` → single (legacy path untouched); root `pneuma.library.json` or subdirs with manifests → library.
- `resolveModeOrLibrary` returns a discriminated result; legacy `resolveMode` throws a friendly error for library specifiers so launch-path stays single-mode-only.
- `pneuma library` CLI: `init [--github user/repo]`, `link`, `list`, `sync`, `publish [--to id] [--push]`, `push`, `unlink`, `activate`, `deactivate`.
- `core/library-publish.ts` (initLocalLibrary / publishModeToLibrary / pushLibrary) + `core/github-cli.ts` (gh detection + repo create, no PAT in v1 — settings UI surfaces install/sign-in hints).
- `/api/libraries/*` routes + `libraries_updated` WS broadcast.
- Launcher gets a GitHub status card in Settings.
- 102 new tests across foundation / publish / github-cli / routes / library-routes.

**Two follow-up fixes caught during E2E**
- Registry SWR cache wasn't invalidated on library mutations → newly activated library modes lagged the Quick Start grid by up to 60s. (`fix: invalidate registry cache`)
- Launcher mutations relied on the WS broadcast, but launcher has no session-scoped WS connection → toggles hit the server but UI didn't refresh. Fixed by dispatching the same DOM event locally on every successful POST + extending the listener to refresh `/api/registry` too. (`fix: library mutations refresh UI immediately`)

**Gallery v2 (`refactor`)**
- ModeGallery gets a Libraries group between Local and Published.
- Each library = a sub-group: identity strip (name / source URL / synced ts / Sync · + Publish · Unlink) on top, existing `GalleryModeCard` for activated modes below, collapsible "N inactive modes" footer with per-mode Activate.
- Launcher main loses its dedicated Mode Libraries section (-50 lines) + the now-unused LibraryCard / LibraryIcon helpers (-280 lines). Library-sourced modes still surface in Quick Start via existing `/api/registry` `local[]` plumbing.

**Polish**
- Quick Start tile origin pill replaced with a tiny corner link glyph (12px, muted → warm on hover); library name lives in the title tooltip. (`fix: simplify library origin chip`)
- `line-clamp-2` repaired — the adjacent `block` utility was overriding `display: -webkit-box` and silently disabling the clamp, so Guizang Ppt's marathon description ballooned to ~10 lines while neighbors sat at 2. (`fix: repair line-clamp on tiles`)
- Expanded library mode cards now show a quiet footer band with display name + source URL + last-sync time. (`feat: library provenance in expanded cards`)

**Favorites (`feat: pin favorites`)**
- Server-backed at `~/.pneuma/favorites.json` (atomic write, defaults fallback).
- `useFavorites()` hook with optimistic-toggle + writeSeq guard.
- Quick Start tile gets a small filled-star top-left when favorited; Gallery card gets a star toggle in the header (next to Evolve/Edit) — the only management surface.
- ProjectPanel mode picker re-orders: favorites first → used-in-project by recency → rest by builtin priority.
- Side fix: Quick Start grid `key={mode.name}` collided whenever multiple modes shared a manifest name (builtin `slide` + each `slide-evolved-*` fork). Composite key `${source}::${path||name}` restores per-tile stability.

## Test plan

- [ ] `bun test` — 1226 pass / 14 skip / 0 fail (confirmed locally)
- [ ] `pneuma mode add github:<user>/<single-mode-repo>` still lands in `~/.pneuma/modes/`
- [ ] `pneuma mode add github:<user>/<multi-mode-repo>` lands in `~/.pneuma/libraries/<id>/` and reports added modes
- [ ] `pneuma library init <name> --github user/repo` creates local + GitHub repo + pushes
- [ ] `pneuma library publish <mode> --to <id> --push` copies + commits + pushes
- [ ] Gallery → Libraries section shows each linked library with Sync / + Publish / Unlink
- [ ] Library mode card expanded → footer band with `From <name> · <source URL> · synced <ts>`
- [ ] Activate / Deactivate toggles update Quick Start immediately (no 60s lag)
- [ ] Settings → GitHub card reflects `gh auth status`
- [ ] Quick Start grid shows defaults pinned (webcraft / slide / diagram / illustrate / remotion / kami)
- [ ] Toggle star in gallery → persists across reload + reflects in ProjectPanel picker

## Open items (post-merge)
- Bump to 3.7.0 on `main` via `/bump` after merge.
- E2E test left a private GH repo `pandazki/pneuma-e2e-library-1778858303`; `gh` CLI lacks `delete_repo` scope. Easiest cleanup: `gh auth refresh -h github.com -s delete_repo && gh repo delete pandazki/pneuma-e2e-library-1778858303 --yes` or delete from github.com.

🤖 Generated with [Claude Code](https://claude.com/claude-code)