### PR TITLE
chore(webcraft): bump tracked impeccable pin to skill-v3.1.1

### DIFF
--- a/modes/webcraft/NOTICE.md
+++ b/modes/webcraft/NOTICE.md
@@ -9,7 +9,7 @@ motion-design, interaction-design, responsive-design, ux-writing) is
 adapted from [pbakaus/impeccable](https://github.com/pbakaus/impeccable)
 ("Impeccable.style") under the Apache 2.0 License.
 
-**Synced against:** impeccable skill-v3.1.0 (May 13, 2026).
+**Synced against:** impeccable skill-v3.1.1 (May 14, 2026).
 
 ### Local adaptations
 

--- a/modes/webcraft/manifest.ts
+++ b/modes/webcraft/manifest.ts
@@ -8,10 +8,13 @@ import { loadSite, saveSite } from "./domain.js";
 
 const webcraftManifest: ModeManifest = {
   name: "webcraft",
-  version: "1.4.0",
+  version: "1.4.1",
   displayName: "WebCraft",
   description: "Web design powered by Impeccable.style — 22 AI design commands, responsive preview, and export",
   changelog: {
+    "1.4.1": [
+      "Tracked Impeccable.style upstream pin moved to skill-v3.1.1 (Windows CLI fix release — no skill content delta)",
+    ],
     "1.4.0": [
       "Synced Impeccable.style guidance to upstream v3.1.0",
       "Craft now enforces four STOP gates between shape and code, plus a mock-fidelity inventory and image gate",

--- a/server/__tests__/webcraft-e2e.test.ts
+++ b/server/__tests__/webcraft-e2e.test.ts
@@ -78,7 +78,7 @@ describe("mode loading", () => {
 describe("manifest validation", () => {
   it("has all required top-level fields", () => {
     expect(webcraftManifest.name).toBe("webcraft");
-    expect(webcraftManifest.version).toBe("1.4.0");
+    expect(webcraftManifest.version).toBe("1.4.1");
     expect(webcraftManifest.displayName).toBe("WebCraft");
     expect(webcraftManifest.description).toContain("Impeccable");
     expect(webcraftManifest.icon).toContain("<svg");


### PR DESCRIPTION
## Summary

Pure bookkeeping sync of the tracked upstream pin. Zero skill content delta.

The 3.1.0 → 3.1.1 upstream diff at [pbakaus/impeccable](https://github.com/pbakaus/impeccable) is entirely:
- A Windows path fix in `cli/.../critique-storage.mjs` (CLI-only — Pneuma doesn't ship the upstream CLI)
- An antipattern-detector tweak in `cli/engine/detect-antipatterns.mjs` (also CLI engine)
- A version-string bump in the SKILL.md frontmatter

The skill body, every `references/cmd-*.md` verb file, every `references/*.md` topic file, and every adaptation in `NOTICE.md` are byte-identical to 3.1.0. Verified via [GitHub compare](https://github.com/pbakaus/impeccable/compare/skill-v3.1.0...skill-v3.1.1).

## Changes

- `modes/webcraft/NOTICE.md` — tracked-version line: `skill-v3.1.0 (May 13, 2026)` → `skill-v3.1.1 (May 14, 2026)`
- `modes/webcraft/manifest.ts` — skill version `1.4.0` → `1.4.1` (patch) + one-line changelog entry
- `server/__tests__/webcraft-e2e.test.ts` — hardcoded version literal follows the manifest

## Test plan

- [x] `bun test server/__tests__/webcraft-e2e.test.ts` → 62 pass, 0 fail
- [x] Local `bun test` — no other hardcoded `"1.4.0"` literals reference webcraft (grep confirmed)
- [ ] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)