### PR TITLE
feat(kami): sync skill references to tw93/kami V1.5.0 (PR-1 of 2-3)

### DIFF
--- a/modes/kami/NOTICE.md
+++ b/modes/kami/NOTICE.md
@@ -50,8 +50,8 @@ single-serif-per-page model (locked since v1.2.0).
 ## Tracked upstream version
 
 Diagrams and reference docs in this mode are synced against
-[tw93/kami **V1.4.1**](https://github.com/tw93/Kami/releases/tag/V1.4.1)
-("Steadier Hand", 2026-05-05). Items intentionally not synced from
+[tw93/kami **V1.5.0**](https://github.com/tw93/Kami/releases/tag/V1.5.0)
+("Live Paper", 2026-05-15). Items intentionally not synced from
 upstream because they don't apply to Pneuma's iframe paper-canvas /
 browser-print model: the WeasyPrint runtime, the `build.py` /
 `ensure-fonts.sh` build pipeline, the Claude Code plugin marketplace

--- a/modes/kami/manifest.ts
+++ b/modes/kami/manifest.ts
@@ -30,10 +30,18 @@ const SAFE_MARGINS_MM: Record<string, { top: number; side: number; bottom: numbe
 
 const kamiManifest: ModeManifest = {
   name: "kami",
-  version: "1.1.0",
+  version: "1.2.0",
   displayName: "Kami",
   description: "Paper-canvas web design with warm parchment aesthetic — design language adapted from tw93/kami (MIT)",
   changelog: {
+    "1.2.0": [
+      "Synced upstream tw93/kami v1.4.1 → V1.5.0 (Live Paper)",
+      "New anti-patterns reference — six-category quality checklist (Emptiness / Fabrication / Mimicry / Excess / Source gaps / Tone)",
+      "New resume-writing reference — three-part bullet structure (Role / Actions / Impact) with per-language char limits",
+      "design.md gains Pygments-style syntax highlighting token map and tightened sparse-slide handling",
+      "writing.md gains Term annotation half-life + English-term density rules",
+      "diagrams.md adds slide-scale SVG sizing rule (>=65% slide area)",
+    ],
     "1.1.0": [
       "Synced upstream tw93/kami v1.2.0 → V1.4.1 (Steadier Hand)",
       "14 SVG diagrams re-normalized: font-weight 500, no italic, solid hex pre-blended on parchment",

--- a/modes/kami/skill/references/anti-patterns.md
+++ b/modes/kami/skill/references/anti-patterns.md
@@ -1,0 +1,67 @@
+<!--
+  Adapted from tw93/kami (MIT) — references/anti-patterns.md.
+  Source: https://github.com/tw93/kami/blob/main/references/anti-patterns.md
+  Credit retained per MIT License; see ../../NOTICE.md.
+-->
+
+# Anti-Patterns: AI Document Quality
+
+Common failures when AI generates professional documents. Organized by failure type, each with a bad example and the fix. Use alongside `writing.md` quality bars.
+
+## Content Emptiness
+
+| # | Pattern | Bad | Fix |
+|---|---------|-----|-----|
+| 1 | Adjective pile-up, no numbers | "Achieved significant growth across key metrics" | State the number: "Revenue grew 34% YoY to $12M" |
+| 2 | Opening-paragraph filler | "In today's rapidly evolving landscape..." | Delete the opener. Start with the first real claim. |
+| 3 | Restating the heading as a sentence | Heading "Revenue Growth", body "Our revenue growth has been notable" | Body must add information the heading does not carry |
+| 4 | Vague time references | "Recently launched", "in the near future" | Pin to a date or quarter: "Launched Q1 2026" |
+| 5 | Synonyms masking repetition | Three paragraphs saying "we are growing" in different words | One claim, one proof, move on |
+
+## Metric Fabrication
+
+| # | Pattern | Bad | Fix |
+|---|---------|-----|-----|
+| 6 | Round numbers implying precision | "Exactly 10,000 users" when the source says "around 10K" | Match the source's precision: "approximately 10,000" |
+| 7 | Fake decimal precision | "Market share: 23.7%" with no cited source | Either cite the source or round to "roughly 24%" |
+| 8 | Metric-narrative disconnect | Chart shows flat revenue, text says "strong momentum" | Text must match what the chart shows |
+| 9 | Invented comparison baselines | "3x faster than alternatives" with no benchmark | Name the alternative and the benchmark method, or remove |
+| 10 | Mixing time periods | YoY growth next to QoQ growth as if comparable | Label every comparison window explicitly |
+
+## Structure Mimicry
+
+| # | Pattern | Bad | Fix |
+|---|---------|-----|-----|
+| 11 | Resume bullet without result | "Managed a cross-functional team" | Action + Scope + Result: "Led 8-person team to ship v2.0, reducing churn 15%" |
+| 12 | Template slots filled with filler | Skills section listing "Communication, Teamwork, Problem-solving" | Name the specific skill and where it was applied, or cut the section |
+| 13 | Equity report without variant perception | "Company is well-positioned for growth" | State what the market gets wrong and why your thesis differs |
+| 14 | One-pager without a clear ask | Three sections of context, no "what we need from you" | The ask belongs above the fold, not implied |
+| 15 | Slide title as label, not assertion | "Q3 Results" | Assertion-evidence: "Q3 revenue beat guidance by 12%" |
+
+## Visual Excess
+
+| # | Pattern | Bad | Fix |
+|---|---------|-----|-----|
+| 16 | More than 3 brand-color accents per page | Four different colored highlights on the same page | One accent color for emphasis; use weight or size for hierarchy |
+| 17 | Chart with no insight title | Chart titled "Revenue by Quarter" | Title states the insight: "Revenue accelerated after Q2 price change" |
+| 18 | Decorative chart that restates the text | Bar chart showing the same three numbers the paragraph just listed | If the text already communicates it, the chart must add a dimension (comparison, trend, distribution) |
+| 19 | Icon or emoji as section marker | Sections led by decorative icons with no semantic value | Use typographic hierarchy (size, weight, spacing) instead |
+
+## Source Gaps
+
+| # | Pattern | Bad | Fix |
+|---|---------|-----|-----|
+| 20 | Unverified version numbers | "Compatible with v4.2" when latest is v5.1 | Check the official source before citing any version |
+| 21 | "Latest" without a date | "Uses the latest framework" | "Uses Next.js 15 (as of 2026-04)" |
+| 22 | Competitor comparison without market data | "Leading solution in the market" | Cite the ranking source, or use "one of the established solutions" |
+| 23 | Assumed availability | "Available on all major platforms" | List the actual platforms verified |
+
+## Tone Contamination
+
+| # | Pattern | Bad | Fix |
+|---|---------|-----|-----|
+| 24 | Chinese AI corporate speak | "赋能企业数字化转型", "打造一站式解决方案" | Say what it does: "帮公司把纸质流程搬到线上" |
+| 25 | English AI corporate speak | "Leverage our platform to unlock synergies" | "Use the platform to share data between teams" |
+| 26 | Caption restates the flow diagram | "六类来源 → 六道过滤 → 配比设计 → 训练分片，四步串联" | Cap 给出图意以外的判断："来源决定知识边界，过滤决定干净程度，配比决定能力侧重" |
+| 27 | AI tone cliches (CN dashes and connectors) | "本质上是模型在做预测——这意味着..." / 大量破折号 | 删元评论框架，直接说结论。破折号换冒号或句号。自检: `grep -nE '本质是\|这意味着\|值得注意的是\|不仅.*而且\|[——–]'` |
+| 28 | Sans font stack missing CJK fallback | `font-family: Inter` 用在含中文的 th / h3 | CJK 回退到系统 sans (PingFang) 跟 serif 主调冲突。任何可能渲染 CJK 的元素用 `var(--serif)` |

--- a/modes/kami/skill/references/design.md
+++ b/modes/kami/skill/references/design.md
@@ -143,6 +143,8 @@ Any font-family that may render Chinese or Japanese must include a CJK fallback,
 **Screen (px)** ≈ pt × 1.33 (9pt ≈ 12px, 18pt ≈ 24px).
 **Minimum floor**: web text >= 12px, PDF text >= 9pt.
 
+**Slide caption floor**: slides 上 caption 至少 24px (不是 12px)。Print 9pt 在投影距离不可读，slide caption 用 pt x 2.67。
+
 ### Weight
 
 - **Serif body**: 400 (W04 font file)
@@ -166,6 +168,7 @@ Print documents are **tighter** than English web body. English web typically run
 | Dense body | 1.40-1.45 | Resume, one-pager, dense information |
 | Reading body | 1.50-1.55 | Long-doc chapters, letters |
 | Label / caption | 1.30-1.40 | Small labels, multi-line metadata |
+| CJK screen body | 1.55-1.65 | 中日文 serif 在 slide scale (27-33px) 下比 print x1.33 更需松行高 |
 
 **Forbidden**:
 - 1.60+ - loose feel, web rhythm, not print
@@ -515,6 +518,26 @@ For displaying pseudocode or code snippets in slides. More structured than a pla
 
 **Content philosophy**: use pseudocode style. Comments should outnumber code lines. The reader sees logic, not syntax.
 
+### Syntax Highlighting
+
+Code blocks with `class="language-*"` on the `<code>` element get tokenized syntax highlighting. The palette uses existing tokens only:
+
+| Token | Hex | Token var |
+|---|---|---|
+| Keyword | `#1B365D` | `--brand` |
+| Comment | `#6b6a64` | `--stone` |
+| String | `#504e49` | `--olive` |
+| Number | `#3d3d3a` | `--dark-warm` |
+| Function/Class | `#141413` | `--near-black` |
+
+```html
+<pre><code class="language-python">def analyze(data):
+    """Transform raw data."""
+    return transform(data)</code></pre>
+```
+
+Blocks without `class="language-*"` stay monochrome. Pneuma renders in a browser, so highlighting runs client-side — load highlight.js or Prism and bind the same five tokens above to the kami CSS vars instead of using the library's default theme.
+
 ### Glance Grid
 
 Four key-number cells, placed after the TOC or on a chapter-opening page of a long-doc / proposal.
@@ -758,6 +781,8 @@ p    { widows: 2; orphans: 2; }
 
 CSS alone cannot prevent "the last two lines of a chapter pushed onto a fresh page". For long-doc / proposal output, follow up with a render-time density check (see production.md "Verify & Debug").
 
+**Cascading break-inside**: when two `break-inside: avoid` blocks sit next to each other and the first would split, both get pushed to the next page together. A chapter with more than two `break-inside: avoid` blocks (quote + table + callout, etc.) near a page boundary is at high risk of leaving 40-80mm of trailing whitespace on the previous page. Fix by splitting the chapter, or downgrade one block (allow the table to break with a repeating header `<thead>`). Browser print engines honor `break-inside: avoid` widely, so the same cascade applies in Pneuma's iframe-to-print path.
+
 ### Force break
 
 ```css
@@ -901,7 +926,8 @@ table.data td:first-child {
 | No section divider slides | Use `.eyebrow` for section numbering instead; saves one slide per section |
 | No CJK parentheses | Replace `（...）` with `·` or `,` |
 | One line per bullet | Trim until each item fits on one line; never let it wrap |
-| Empty space handling | Priority: shrink page size > pin `.co` callout > add content > merge slides |
+| Empty space ≥50% | Draft defect. Order: merge with neighbor slide > pin `.co` callout > add a chart that earns the space. Shrinking page size is a last resort and must apply to the whole deck, not per slide. |
+| Empty space 25-50% | Acceptable if the slide has a pinned `.co` callout. Otherwise add one supporting bullet or a small inline figure. Never pad with filler prose. |
 | Cover | No horizontal rule; title centered `38pt`; subtitle on one line; bottom meta centered |
 
 ### Troubleshooting
@@ -910,7 +936,7 @@ table.data td:first-child {
 |---|---|
 | Content overflows to next page | Add `max-height` or trim content |
 | 2×2 columns misaligned | Switch from CSS Grid to `table.t2x2` |
-| Large blank at slide bottom | Reduce to `280mm 158mm` or pin `.co` callout |
+| Large blank at slide bottom | First check item count (target 3-5 items per slide). If content is genuinely short, pin a `.co` callout. Only reduce page size when the entire deck is uniformly sparse. |
 | CJK text looks tight | Add `letter-spacing: 0.3pt` |
 
 ### Core principles

--- a/modes/kami/skill/references/diagrams.md
+++ b/modes/kami/skill/references/diagrams.md
@@ -252,7 +252,7 @@ Scan for these when drawing or reviewing:
 - **No diagrams.** Resume real-estate costs more than diagrams. Rare exception: a URL to a portfolio diagram when showing system-level capability.
 
 ### Slides
-- One diagram per slide, max. The diagram is the body. Text is caption, not a sidebar.
+- One diagram per slide, max. The diagram is the body. Text is caption, not a sidebar. At slide scale (1920x1080), scale the SVG to fill >=65% of the slide area; print-sized diagram on screen slide leaves ~35% dead space.
 
 ---
 

--- a/modes/kami/skill/references/resume-writing.md
+++ b/modes/kami/skill/references/resume-writing.md
@@ -1,0 +1,164 @@
+<!--
+  Adapted from tw93/kami (MIT) — references/resume-writing.md.
+  Source: https://github.com/tw93/kami/blob/main/references/resume-writing.md
+  Credit retained per MIT License; see ../../NOTICE.md.
+-->
+
+# Resume Writing Guide
+
+Content strategy for kami resume templates (CN and EN). Covers bullet structure, emphasis density, timeline narrative, and open source entries. For general writing quality bars, see `references/writing.md`.
+
+---
+
+## Three-part bullet: Role / Actions / Impact
+
+Each project row uses a fixed three-part structure. The word and character targets below are maximums, not targets; shorter is better when the meaning is complete.
+
+**Chinese (CN)**
+
+| Row | Label | Target | Hard limit |
+|---|---|---|---|
+| 1 | 角色 | 50 characters | 60 characters |
+| 2 | 动作 | 70 characters | 80 characters |
+| 3 | 结果 | 90 characters | 100 characters |
+
+**English (EN)**
+
+| Row | Label | Target | Hard limit |
+|---|---|---|---|
+| 1 | Role | 35 words | 40 words |
+| 2 | Actions | 45 words | 55 words |
+| 3 | Impact | 55 words | 65 words |
+
+**What goes in each row**
+
+- Role: what the project was, why it existed, and your position in it. No verbs yet.
+- Actions: the decisions and techniques you applied. One concrete approach per sentence.
+- Impact: quantified outcomes only. If no number exists, write the magnitude or scope (team size, user count, traffic tier).
+
+**Self-check**: read Impact aloud. If it sounds like a process description ("improved the pipeline") rather than a result ("reduced p95 latency from 800ms to 120ms"), rewrite.
+
+---
+
+## Metrics: horizontal vs vertical layout
+
+Each project card has a `.metrics` row that shows key numbers. Two layout modes are available.
+
+**Horizontal (default, `flex-direction: row`)**: numbers side by side, good for 2-3 short metrics.
+
+**Vertical (`flex-direction: column`)**: metrics stack one per line. Use when:
+- Any single metric label exceeds 18 characters
+- Three or more metrics are present and labels are of unequal length
+- The project card already has long Role / Actions / Impact rows that crowd the line
+
+Use | Avoid
+---|---
+Horizontal for two short metrics: `38% reduce latency · 12k daily users` | Horizontal for long labels: `reduced p95 latency from 820ms to 110ms · 12k active users`
+Vertical when three or more metrics exist | Vertical for exactly two short metrics (wastes space)
+
+To switch to vertical:
+```css
+.metrics { flex-direction: column; gap: 0.8mm; }
+```
+
+Do not add `flex-wrap: wrap`; it causes uneven line splits that look like layout errors.
+
+---
+
+## Key-number highlight density
+
+`.hl` applies brand-blue color to mark the single most important figure or phrase in a line. It is not a general emphasis tool.
+
+**Use:**
+- One `.hl` per project row, maximum two across all three rows of one project
+- Numbers with units: `<span class="hl">120ms</span>`, `<span class="hl">38%</span>`
+- A distinctive noun when no number exists: `<span class="hl">production-first rollout</span>`
+
+**Avoid:**
+- Highlighting adjectives or qualifiers: "significantly", "dramatically", "key"
+- Two `.hl` spans on the same row
+- Highlighting an entire clause
+
+Healthy ratio: one emphasis per 80 to 150 characters of body text.
+
+---
+
+## Timeline: three-step evolution arc
+
+The `.timeline` section shows career judgment, not a job chronology. Three steps, each one sentence.
+
+**Structuring the arc**
+
+Each step should answer: what shifted in how you thought or operated, and why does it matter for the reader?
+
+Use | Avoid
+---|---
+"Shifted from feature delivery to owning the model quality loop end-to-end" | "Joined the AI team as senior engineer"
+"Moved budget approval to the team level, cutting decision lag from weeks to hours" | "Led a team of 8 engineers"
+"Started shipping open-source tools to validate ideas before internal roadmap commits" | "Side projects and open source work"
+
+**Three-step pattern**
+
+1. Foundation: the constraint or context that shaped your thinking in the early phase
+2. Inflection: the moment or decision that changed what you were optimizing for
+3. Present: the operating mode you've settled into and what it produces
+
+Do not list events. List shifts in judgment and scope.
+
+---
+
+## Open source entries
+
+Each `.os-item` has three parts: name, one-line description, and star count. No README summaries, no feature lists.
+
+**Description formula**: `[language or stack] · [what it does] · [platform or audience]`
+
+Use | Avoid
+---|---
+"Rust + Tauri · turns any URL into a lightweight desktop app · macOS / Windows / Linux" | "A lightweight desktop app builder based on Tauri that supports packaging web apps as native applications across multiple platforms"
+"Swift · native Markdown notes · macOS AppKit" | "A beautiful and fast Markdown note-taking app for macOS with syntax highlighting and live preview"
+
+**Star count**: use the `.big` class on the top two entries (your flagship projects). Plain `.os-star` for the rest.
+
+**`.os-highlight`**: one short paragraph, one anecdote. Focus on a specific external validation moment: a notable person who shared it, a community that formed around it, a moment when it reached an audience you didn't target. Not a feature summary.
+
+---
+
+## Density tuning by project count
+
+When page 1 carries 3-6 projects, adjust these three CSS properties. Do not change line-heights on page 2 or touch header typography.
+
+| Projects on page 1 | `body font-size` | `.proj-text line-height` | `.section-title margin-top` |
+|---|---|---|---|
+| 3 | 9.4pt | 1.42 | 6mm |
+| 4 (default) | 9.2pt | 1.40 | 5mm |
+| 5 (dense) | 9pt | 1.38 (CN) / 1.40 (EN) | 3.5mm |
+| 6 | 9pt | 1.36 (CN) / 1.38 (EN) | 3mm |
+
+For 5-project layouts, add `class="resume--dense"` to `<body>` instead of manually adjusting CSS. The `resume--dense` class applies the row-5 values above.
+
+For 6 projects there is no pre-built variant; apply the row-6 values directly and run `--verify` after. Six projects on one page is a strong signal the project list needs editing, not just tightening.
+
+---
+
+## Page 2 rhythm
+
+Page 2 has more space than page 1. Do not compress it to match page 1 density.
+
+- OS intro: one sentence positioning + one sentence with the aggregate GitHub numbers. No more.
+- Convictions: each card is one judgment call + one piece of downstream evidence. Not a project summary.
+- Skills: each row names one capability area and demonstrates it with one concrete example. No abstract claims.
+- Education: one line. If there is a judgment-flavored note (declined grad school, switched majors), include it. That note signals self-direction better than GPA.
+
+**Font size and spacing reference** (5 projects on page 1 + complete page 2):
+
+| Property | Value |
+|---|---|
+| `body font-size` | 9pt (dense) / 9.2pt (default) |
+| `.os-intro` line-height | 1.55 |
+| `.conv-body` line-height | 1.40 |
+| Page 2 top buffer | 4mm minimum between header and first section |
+
+This configuration fits 2 pages when TsangerJinKai02 is available. Font fallback to Source Han Serif adds roughly 0.3pt per line; run `--verify` after any font environment change.
+
+Do not scale page 2 font below 9pt to save space. If page 2 still overflows, cut one Convictions card or reduce Skills to 2 rows.

--- a/modes/kami/skill/references/writing.md
+++ b/modes/kami/skill/references/writing.md
@@ -57,6 +57,19 @@ Branded documents should first make the subject recognizable, then use decoratio
 - If brand color is unknown, keep kami ink-blue rather than inventing a new color
 - **Third-party figures**: when redrawing a paper figure, patent illustration, or official architecture diagram for visual consistency, mark the redraw as `Schematic redrawn` /「示意重绘」in the caption. Do not style a redrawn version to look like the original screenshot. If the figure carries primary evidentiary value (patent, official spec), embed the original with attribution rather than redrawing it
 
+### 7. Term annotation half-life
+
+术语首次出现时注解。注解在 8-10 页或 10 张 slide 后过期。超出半衰期再次使用时，用更短的提示重标，不要假设读者还记得。Cap、卡片副标题、章节摘要这类快速阅读位置尤其严格。
+
+- 首次: "LTV (Lifetime Value, 用户在流失前贡献的总收入)"
+- 超过半衰期后重现: "LTV (用户终身价值)"
+- 半衰期内不要重标，读起来像在解释已知概念
+- 适用于 slides、long-doc、equity report 等超过 8 页的文档。Resume 和 one-pager 太短，不触发
+
+### 8. English term density in CJK text
+
+中日文正文里，单句未注解英文术语 ≤ 1 个。超过就拆句或加 inline 注解。注解优先用动作词 (warmup → 升起来, rollout → 跑一遍生成, credit assignment → 把功劳分到具体哪一步)，不用概念词 (预热, 轨迹生成, 信用分配)。动作词描述发生了什么，概念词只是换个外壳。
+
 ---
 
 ## Per-document strategies
@@ -431,6 +444,8 @@ Run through before every draft:
 - [ ] Number format consistent (commas, percent signs, arrows)?
 - [ ] Chinese punctuation and Chinese / Latin spacing consistent where applicable?
 - [ ] Page count within the document's constraint (resume 2, one-pager 1, letter 1)?
+- [ ] Any AI writing cliches? CN: 本质是 / 这意味着 / 值得注意的是 / 不仅...而且 / 破折号堆砌。EN: em dashes, "It's worth noting", "This means that". See anti-patterns #27.
+- [ ] Multi-page docs (>8 pages / >10 slides): domain terms re-annotated beyond the half-life window? See principle #7.
 
 ---
 


### PR DESCRIPTION
## Summary

First slice of the V1.4.1 → V1.5.0 kami upstream sync. Adopts the drop-in skill reference content with zero WeasyPrint coupling. SKILL.md prose updates (the +371-line upstream diff) and the W05 font / new templates deferred to follow-up PRs.

Upstream release: [tw93/kami V1.5.0 "Live Paper"](https://github.com/tw93/kami/releases/tag/V1.5.0) (2026-05-15).

## What's adopted

**New references (verbatim from upstream V1.5.0)**:
- `anti-patterns.md` — six-category quality checklist (Emptiness / Fabrication / Mimicry / Excess / Source gaps / Tone)
- `resume-writing.md` — three-part bullet structure with per-language char/word limits

**Updated references (additions only, existing text preserved)**:
- `design.md` — Pygments-style syntax highlighting token map reframed for client-side highlighters; slide-caption floor; CJK line-height; cascading-break-inside note; sparse-slide handling refinements (+30/-2)
- `writing.md` — Core principles #7 Term annotation half-life + #8 English-term density in CJK text + two checklist additions (+15)
- `diagrams.md` — SVG slide-area sizing rule (+1/-1)

**NOTICE.md** tracked-version line: V1.4.1 → V1.5.0; non-adoption list unchanged.

**manifest.ts** skill version 1.1.0 → 1.2.0 (minor) with 6-bullet changelog.

## Deferred

Per the analysis port-map:
- **PR-2** (planned): SKILL.md prose sync — Step 2.1 source/material pass, Step 2.7 layout note, Per-page density target rules, new doc-type & diagram-routing rows, "Auto-select charts from data" decision tree. Also the TsangerJinKai02-W05.ttf font shipping + template dual-face conversion.
- **PR-3** (optional follow-up): New seeds + landing-page decision. Whether `landing-page` belongs to kami or webcraft, whether to ship `seed/pneuma-changelog/` and align `nvda-equity-report/` selectors to upstream.

Out of scope per `NOTICE.md` exclusions: WeasyPrint runtime, `build.py` / `ensure-fonts.sh` / `scripts/highlight.py` / `scripts/stabilize.py`, Claude Code plugin marketplace, `llms.txt` / sitemap / JSON-LD landing-page assets, `~/.config/kami/brand.md` profile loader (and the `references/brand-profile.md` + `brand.example.md` docs that explain it — `pneuma-preferences` covers the same intent).

## Drift caught during application

The compare endpoint reported `architecture.html` / `flowchart.html` / `quadrant.html` as churning ~45 lines each between V1.4.1 and V1.5.0, but the actual file contents are byte-identical. No diagram HTML touches needed in this PR; our seeds already match upstream.

`writing.md` density-bar checklist additions that cross-reference the upstream "SKILL.md Step 4.1" structure are deliberately held back — would create dangling refs until PR-2 introduces that structure.

## Test plan

- [x] `bun test` — 1226 pass / 14 skip / 0 fail
- [x] `bunx tsc --noEmit | grep modes/kami` — zero output (no new type errors in kami)
- [x] `grep '"1.1.0"' ... | grep kami` — only legitimate legacy changelog key in manifest.ts (kept)
- [ ] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)