### PR TITLE
feat(launcher): add clear button to Mode Gallery search input

### DIFF
--- a/src/components/Launcher.tsx
+++ b/src/components/Launcher.tsx
@@ -1646,13 +1646,27 @@ function ModeGallery({
         <div className="max-w-6xl mx-auto px-6 py-3 flex items-center gap-4">
           <h1 className="font-display text-lg text-cc-fg">Mode Gallery</h1>
           <div className="ml-auto w-64">
-            <input
-              type="text"
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              placeholder="Search..."
-              className="w-full px-3 py-1.5 bg-transparent border border-cc-border/40 rounded-lg text-sm text-cc-fg placeholder:text-cc-muted/40 outline-none focus:border-cc-muted/50 transition-colors"
-            />
+            <div className="relative">
+              <input
+                type="text"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder="Search..."
+                className={`w-full pl-3 ${search ? "pr-8" : "pr-3"} py-1.5 bg-transparent border border-cc-border/40 rounded-lg text-sm text-cc-fg placeholder:text-cc-muted/40 outline-none focus:border-cc-muted/50 transition-colors`}
+              />
+              {search && (
+                <button
+                  type="button"
+                  onClick={() => setSearch("")}
+                  aria-label="Clear search"
+                  className="absolute right-2 top-1/2 -translate-y-1/2 flex items-center justify-center w-5 h-5 rounded text-cc-muted/60 hover:text-cc-fg hover:bg-cc-border/30 transition-colors cursor-pointer"
+                >
+                  <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                  </svg>
+                </button>
+              )}
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- The Mode Gallery search input had no quick way to clear the keyword — users had to select-all then delete.
- Adds an inline X button on the right side of the input that appears whenever the field is non-empty and resets the search on click.
- Padding adapts (`pr-3` ↔ `pr-8`) so the button never overlaps text.

Closes [PNE-2](mention://issue/6652bc79-a1c8-4e2f-bc2d-f7273f02f0a2).

## Test plan
- [ ] Open Mode Gallery, type into the search box → X button appears on the right.
- [ ] Click X → input clears, gallery returns to unfiltered state, X disappears.
- [ ] Empty input does not show the X button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)