### PR TITLE
fix(launcher): hide Local/Libraries sections when search has no matches

### DIFF
--- a/src/components/Launcher.tsx
+++ b/src/components/Launcher.tsx
@@ -1676,8 +1676,11 @@ function ModeGallery({
         {[
           { label: "Built-in", items: builtin, alwaysShow: false },
           // Local always renders its header when an install action exists, so users can
-          // still reach "Add from URL" before they've installed anything.
-          { label: "Local", items: local, alwaysShow: !!onAddFromUrl },
+          // still reach "Add from URL" before they've installed anything. During an
+          // active search we step out of the way: the "暂无本地模式" empty state is
+          // about "no modes installed yet", not "nothing matched" — leaving it on
+          // looks like a stray local item that matches every query.
+          { label: "Local", items: local, alwaysShow: !!onAddFromUrl && !search },
           { label: "Published", items: published, alwaysShow: false },
         ]
           .filter((g) => g.items.length > 0 || g.alwaysShow)
@@ -1729,7 +1732,7 @@ function ModeGallery({
             Libraries → Published) flows from most-trusted/most-yours to
             most-public. Empty state still shows the section header + "+ Add
             library" so first-time users have a discoverable entry point. */}
-        {(libraries.length > 0 || onAddLibrary) && (
+        {(libraries.length > 0 || onAddLibrary) && !(search && libraryModes.length === 0) && (
           <div className="mb-12">
             <div className="flex items-center justify-between mb-6">
               <h2 className="text-xs font-medium text-cc-muted/60 uppercase tracking-widest">Libraries</h2>
@@ -1753,10 +1756,12 @@ function ModeGallery({
                 {libraries.map((lib) => {
                   const activeModes = modesByLibrary.get(lib.id) ?? [];
                   const inactiveCount = lib.modes.length - lib.modes.filter((m) => m.activated).length;
-                  // When the gallery is filtered by search, hide libraries
-                  // whose modes don't match — but always show empty libraries
-                  // (0 modes) so the user can still see + manage them.
-                  if (search && activeModes.length === 0 && lib.modes.length > 0) return null;
+                  // When the gallery is filtered by search, hide libraries with
+                  // no matching activated modes. Empty libraries normally render
+                  // here so users can still see + manage them, but during an
+                  // active search they're just noise — the management surface
+                  // is reachable again the moment the query clears.
+                  if (search && activeModes.length === 0) return null;
                   return (
                     <LibraryGalleryGroup
                       key={lib.id}
@@ -1790,7 +1795,7 @@ function ModeGallery({
           </div>
         )}
 
-        {filtered.length === 0 && libraries.length === 0 && (
+        {search && filtered.length === 0 && (
           <p className="text-center text-cc-muted/60 py-20">No modes match your search.</p>
         )}
       </div>


### PR DESCRIPTION
## Summary

- Mode Gallery search box always rendered a "Local" / "Libraries" header (with their "Add from URL" / "Add library" affordances and a misleading "No local modes yet" empty state) regardless of search input — so typing any non-matching text felt like one local entry kept matching every query, even though the user had local modes installed.
- `alwaysShow: !!onAddFromUrl` and the Libraries outer condition `libraries.length > 0 || onAddLibrary` are now suppressed while a search is active, the per-library hide rule no longer makes an exception for empty libraries during search, and the "No modes match your search." message no longer requires `libraries.length === 0`.

## Test plan

- [x] With local modes + a library installed, open the Mode Gallery, type random non-matching text (e.g. `xyz123zzz`) → gallery shows only "No modes match your search."
- [x] Type a query that matches a built-in / local mode (e.g. `slide`) → built-in Slide + both `Slide (Evolved)` locals render; Local section keeps its "+ Add from URL" affordance.
- [ ] With no search, gallery still shows the empty-state "+ Add from URL" / "+ Add library" affordances for first-time users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)