### PR TITLE
feat: pneumaVersion compat declaration + launcher incompatibility UI

### DIFF
--- a/core/__tests__/version-compat.test.ts
+++ b/core/__tests__/version-compat.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Tests for the version compatibility utility.
+ *
+ * Covers: exact / caret / tilde / range / compound / wildcard / pre-release.
+ * Drift classification: match / minor-drift / major-drift / unknown.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { checkCompat } from "../version-compat.js";
+
+describe("checkCompat — match cases", () => {
+  it("exact match", () => {
+    expect(checkCompat("3.8.0", "3.8.0").level).toBe("match");
+  });
+
+  it("caret allows minor + patch within same major", () => {
+    expect(checkCompat("^3.8.0", "3.8.0").level).toBe("match");
+    expect(checkCompat("^3.8.0", "3.8.2").level).toBe("match");
+    expect(checkCompat("^3.8.0", "3.9.0").level).toBe("match");
+    expect(checkCompat("^3.8.0", "3.99.99").level).toBe("match");
+  });
+
+  it("caret rejects next major", () => {
+    expect(checkCompat("^3.8.0", "4.0.0").level).not.toBe("match");
+  });
+
+  it("tilde allows patch only", () => {
+    expect(checkCompat("~3.8.0", "3.8.0").level).toBe("match");
+    expect(checkCompat("~3.8.0", "3.8.5").level).toBe("match");
+    expect(checkCompat("~3.8.0", "3.9.0").level).not.toBe("match");
+  });
+
+  it("compound range", () => {
+    expect(checkCompat(">=3.7.0 <4.0.0", "3.8.0").level).toBe("match");
+    expect(checkCompat(">=3.7.0 <4.0.0", "3.7.0").level).toBe("match");
+    expect(checkCompat(">=3.7.0 <4.0.0", "3.6.0").level).not.toBe("match");
+    expect(checkCompat(">=3.7.0 <4.0.0", "4.0.0").level).not.toBe("match");
+  });
+
+  it("wildcard always matches", () => {
+    expect(checkCompat("*", "3.8.0").level).toBe("match");
+    expect(checkCompat("x", "0.1.0").level).toBe("match");
+    expect(checkCompat("*", "10.0.0").level).toBe("match");
+  });
+
+  it("v-prefixed runtime tolerated", () => {
+    expect(checkCompat("^3.8.0", "v3.8.0").level).toBe("match");
+  });
+});
+
+describe("checkCompat — drift classification", () => {
+  it("minor-drift when same major but range doesn't admit runtime", () => {
+    // Range targets 3.8 specifically; running 3.7
+    const r = checkCompat(">=3.8.0 <3.9.0", "3.7.5");
+    expect(r.level).toBe("minor-drift");
+    expect(r.reason).toContain("same major");
+  });
+
+  it("minor-drift on tilde mismatch within same major", () => {
+    const r = checkCompat("~3.7.0", "3.8.0");
+    expect(r.level).toBe("minor-drift");
+  });
+
+  it("major-drift across majors", () => {
+    const r = checkCompat("^3.8.0", "4.0.0");
+    expect(r.level).toBe("major-drift");
+    expect(r.reason).toContain("different major");
+  });
+
+  it("major-drift down from runtime", () => {
+    const r = checkCompat("^4.0.0", "3.8.0");
+    expect(r.level).toBe("major-drift");
+  });
+});
+
+describe("checkCompat — unknown cases", () => {
+  it("null declared → unknown", () => {
+    const r = checkCompat(null, "3.8.0");
+    expect(r.level).toBe("unknown");
+    expect(r.declared).toBe(null);
+  });
+
+  it("undefined declared → unknown", () => {
+    expect(checkCompat(undefined, "3.8.0").level).toBe("unknown");
+  });
+
+  it("garbage declared → unknown", () => {
+    expect(checkCompat("not-a-version", "3.8.0").level).toBe("unknown");
+  });
+
+  it("garbage runtime → unknown", () => {
+    expect(checkCompat("^3.8.0", "not-a-version").level).toBe("unknown");
+  });
+});
+
+describe("checkCompat — pre-release versions", () => {
+  it("pre-release treated as < the same M.m.p without pre-release", () => {
+    // 3.8.0-rc.1 should NOT satisfy ^3.8.0 (which requires >=3.8.0)
+    expect(checkCompat("^3.8.0", "3.8.0-rc.1").level).not.toBe("match");
+  });
+
+  it("explicit pre-release-lower range matches pre-release runtime", () => {
+    expect(checkCompat(">=3.8.0-rc.1 <4.0.0", "3.8.0-rc.1").level).toBe("match");
+  });
+});
+
+describe("checkCompat — result shape", () => {
+  it("match returns no reason", () => {
+    const r = checkCompat("^3.8.0", "3.8.1");
+    expect(r.level).toBe("match");
+    expect(r.reason).toBeUndefined();
+  });
+
+  it("drift returns explanatory reason", () => {
+    const r = checkCompat("^3.8.0", "4.0.0");
+    expect(r.reason).toBeDefined();
+    expect(r.declared).toBe("^3.8.0");
+    expect(r.runtime).toBe("4.0.0");
+  });
+});

--- a/core/library-registry.ts
+++ b/core/library-registry.ts
@@ -77,6 +77,12 @@ export interface ResolvedRepoMode {
   relPath: string;
   /** Version read from the mode's manifest.ts. */
   manifestVersion: string;
+  /**
+   * Pneuma runtime range read from the mode's `manifest.ts.pneumaVersion`.
+   * Undefined when the mode doesn't declare one — the caller may fall
+   * back to the library's library-level `pneumaVersion`.
+   */
+  pneumaVersion?: string;
 }
 
 /**
@@ -166,6 +172,7 @@ function parseLibraryManifest(
   if (typeof obj.displayName === "string") manifest.displayName = obj.displayName;
   if (typeof obj.description === "string") manifest.description = obj.description;
   if (typeof obj.author === "string") manifest.author = obj.author;
+  if (typeof obj.pneumaVersion === "string") manifest.pneumaVersion = obj.pneumaVersion;
   if (Array.isArray(obj.modes)) {
     manifest.modes = obj.modes.map((entry, i) => {
       if (!entry || typeof entry !== "object") {
@@ -210,10 +217,12 @@ function resolveExplicitEntries(
       );
     }
     const name = entry.name ?? basename(safe);
+    const versions = readManifestVersions(safe);
     out.push({
       name,
       relPath: entry.path,
-      manifestVersion: readManifestVersion(safe),
+      manifestVersion: versions.version,
+      ...(versions.pneumaVersion ? { pneumaVersion: versions.pneumaVersion } : {}),
     });
   }
   return out;
@@ -232,10 +241,12 @@ function autoScanModes(repoDir: string): ResolvedRepoMode[] {
     if (ent.name.startsWith(".")) continue; // skip .git, etc.
     const sub = join(repoDir, ent.name);
     if (!hasManifest(sub)) continue;
+    const versions = readManifestVersions(sub);
     out.push({
       name: ent.name,
       relPath: ent.name,
-      manifestVersion: readManifestVersion(sub),
+      manifestVersion: versions.version,
+      ...(versions.pneumaVersion ? { pneumaVersion: versions.pneumaVersion } : {}),
     });
   }
   // Stable ordering for deterministic UI / sidecar.
@@ -244,24 +255,35 @@ function autoScanModes(repoDir: string): ResolvedRepoMode[] {
 }
 
 /**
- * Pull the manifest's `version` field out without evaluating TS.
- * Mirrors the regex extraction in `core/utils/manifest-parser.ts` but
- * scoped to just the version — we don't need the rest here.
- * Falls back to "0.0.0" when missing or unreadable.
+ * Pull the manifest's `version` + `pneumaVersion` fields out without
+ * evaluating TS. Mirrors the regex extraction in `core/utils/manifest-parser.ts`
+ * but scoped to the two fields we cache on `ResolvedRepoMode`.
+ *
+ * Falls back to "0.0.0" for the mode version when missing/unreadable.
+ * pneumaVersion is genuinely optional and returns null when absent.
  */
-function readManifestVersion(modeDir: string): string {
+function readManifestVersions(modeDir: string): { version: string; pneumaVersion: string | null } {
   for (const fname of ["manifest.ts", "manifest.js"]) {
     const full = join(modeDir, fname);
     if (!existsSync(full)) continue;
     try {
       const src = readFileSync(full, "utf-8");
-      const match = src.match(/version\s*:\s*["'`]([^"'`]+)["'`]/);
-      if (match) return match[1];
+      const vMatch = src.match(/version\s*:\s*["'`]([^"'`]+)["'`]/);
+      const pvMatch = src.match(/pneumaVersion\s*:\s*["'`]([^"'`]+)["'`]/);
+      return {
+        version: vMatch ? vMatch[1] : "0.0.0",
+        pneumaVersion: pvMatch ? pvMatch[1] : null,
+      };
     } catch {
       // fall through
     }
   }
-  return "0.0.0";
+  return { version: "0.0.0", pneumaVersion: null };
+}
+
+/** Backwards-compat alias — keep the focused helper but defer to the new one. */
+function readManifestVersion(modeDir: string): string {
+  return readManifestVersions(modeDir).version;
 }
 
 function safeSubpath(root: string, rel: string): string | null {
@@ -386,6 +408,7 @@ export function linkLibrary(
     name: m.name,
     path: m.relPath,
     manifestVersion: m.manifestVersion,
+    ...(m.pneumaVersion ? { pneumaVersion: m.pneumaVersion } : {}),
     activated: true,
     installedVersion: m.manifestVersion,
   }));
@@ -397,6 +420,7 @@ export function linkLibrary(
     ...(shape.manifest.displayName ? { displayName: shape.manifest.displayName } : {}),
     ...(shape.manifest.description ? { description: shape.manifest.description } : {}),
     ...(shape.manifest.author ? { author: shape.manifest.author } : {}),
+    ...(shape.manifest.pneumaVersion ? { pneumaVersion: shape.manifest.pneumaVersion } : {}),
     source,
     sha,
     lastSync: Date.now(),
@@ -459,6 +483,7 @@ export function syncLibrary(
         name: m.name,
         path: m.relPath,
         manifestVersion: m.manifestVersion,
+        ...(m.pneumaVersion ? { pneumaVersion: m.pneumaVersion } : {}),
         activated: true,
         installedVersion: m.manifestVersion,
       });
@@ -475,6 +500,7 @@ export function syncLibrary(
       name: m.name,
       path: m.relPath,
       manifestVersion: m.manifestVersion,
+      ...(m.pneumaVersion ? { pneumaVersion: m.pneumaVersion } : {}),
       activated: prior.activated,
       installedVersion: prior.installedVersion,
     });
@@ -505,6 +531,9 @@ export function syncLibrary(
     ...(shape.manifest.author !== undefined
       ? { author: shape.manifest.author }
       : { author: prev.author }),
+    ...(shape.manifest.pneumaVersion !== undefined
+      ? { pneumaVersion: shape.manifest.pneumaVersion }
+      : { pneumaVersion: prev.pneumaVersion }),
     sha: newSha,
     lastSync: Date.now(),
     modes,

--- a/core/types/library.ts
+++ b/core/types/library.ts
@@ -48,6 +48,14 @@ export interface LibraryManifest {
   description?: string;
   /** Optional author handle (display only). */
   author?: string;
+  /**
+   * Pneuma runtime version range targeted by the library as a whole
+   * (semver range, e.g. `"^3.8.0"`). Acts as fallback when a mode in the
+   * library doesn't declare its own `pneumaVersion`. Optional — when
+   * absent and no per-mode value either, the launcher treats compat as
+   * "unknown" (renders the mode normally, no warning).
+   */
+  pneumaVersion?: string;
   /** Explicit list of modes to ship. Absence falls back to auto-scan. */
   modes?: LibraryModeEntry[];
 }
@@ -86,6 +94,14 @@ export interface InstalledLibraryMode {
    */
   manifestVersion: string;
   /**
+   * Pneuma runtime range declared in the mode's `manifest.ts.pneumaVersion`,
+   * observed on last sync. Cached here so the launcher can render compat
+   * state without re-parsing every manifest. Falls back to the parent
+   * library's `pneumaVersion` (also cached on the InstalledLibrary).
+   * Undefined when neither was declared.
+   */
+  pneumaVersion?: string;
+  /**
    * Whether this mode is visible in the launcher / loadable via
    * `pneuma <name>`. Deactivated modes remain on disk so re-activation
    * is a zero-cost local flip.
@@ -114,6 +130,11 @@ export interface InstalledLibrary {
   description?: string;
   /** Optional author handle (mirrors `LibraryManifest.author`). */
   author?: string;
+  /**
+   * Library-level Pneuma runtime range (mirrors `LibraryManifest.pneumaVersion`).
+   * Used as fallback when a contained mode doesn't declare its own.
+   */
+  pneumaVersion?: string;
   /** Where this library was linked from. */
   source: LibrarySource;
   /**

--- a/core/types/mode-manifest.ts
+++ b/core/types/mode-manifest.ts
@@ -382,6 +382,16 @@ export interface ModeManifest {
   /** Supported agent backends. When omitted, all implemented backends are allowed. */
   supportedBackends?: string[];
 
+  /**
+   * Pneuma runtime version range this mode supports (semver range, e.g.
+   * `"^3.8.0"`, `">=3.7.0 <4.0.0"`). The launcher compares against the
+   * running pneuma-skills version to mark incompatible modes in the
+   * gallery. Omit when authoring against a single in-tree runtime; declare
+   * it for any external/library-distributed mode so consumers can see
+   * compatibility status without launching.
+   */
+  pneumaVersion?: string;
+
   /** Attribution — credit the project or person that inspired this mode (optional) */
   inspiredBy?: {
     /** Display name (e.g. "troyhua/claude-code-remotion") */

--- a/core/utils/manifest-parser.ts
+++ b/core/utils/manifest-parser.ts
@@ -8,6 +8,12 @@
 export interface ParsedManifest {
   name?: string;
   version?: string;
+  /**
+   * Declared Pneuma runtime range (semver), if the manifest sets one.
+   * Used by the launcher to mark incompatible modes. See
+   * `core/version-compat.ts` for matching semantics.
+   */
+  pneumaVersion?: string;
   displayName?: string;
   description?: string;
   icon?: string;
@@ -159,6 +165,7 @@ export function parseManifestTs(content: string, locale: string = "en"): ParsedM
   return {
     name: extractString(content, "name"),
     version: extractString(content, "version"),
+    pneumaVersion: extractString(content, "pneumaVersion"),
     displayName: extractLocalizedString(content, "displayName", locale),
     description: extractLocalizedString(content, "description", locale),
     icon: extractBacktickString(content, "icon") || extractString(content, "icon"),

--- a/core/version-compat.ts
+++ b/core/version-compat.ts
@@ -1,0 +1,205 @@
+/**
+ * Version Compatibility — match a semver range against a concrete runtime version.
+ *
+ * Used by the launcher to mark modes as compatible / drifted / incompatible
+ * against the running pneuma-skills version. Lean implementation; no npm
+ * semver dependency. Handles the dialect Pneuma authors actually use:
+ *
+ *   - exact:     "3.8.0"
+ *   - caret:     "^3.8.0"   = >=3.8.0 <4.0.0
+ *   - tilde:     "~3.8.0"   = >=3.8.0 <3.9.0
+ *   - ranges:    ">=3.8.0", ">=3.8.0 <4.0.0", ">3.7.0", "<=3.8.0"
+ *   - wildcard:  "*"  or  "x"
+ *
+ * Pre-release tags (e.g. "3.8.0-rc.1") are accepted as the runtime version
+ * but treated leniently — we strip the suffix before comparing. Authors
+ * who care about pre-release pinning should be explicit in their range.
+ *
+ * Classification levels feed the UI:
+ *
+ *   - "match"         → mode's declared range admits the runtime version
+ *   - "minor-drift"   → same major, runtime > declared minor (likely fine,
+ *                       worth a soft warning when authoring)
+ *   - "major-drift"   → different major (likely broken, hard warning)
+ *   - "unknown"       → no declared range (or unparseable) — render normally
+ *
+ * Keep the public surface narrow: `checkCompat(declared, runtime)` returns
+ * a `CompatResult` the API and UI both consume.
+ */
+
+export type CompatLevel = "match" | "minor-drift" | "major-drift" | "unknown";
+
+export interface CompatResult {
+  level: CompatLevel;
+  /** The declared range as written in manifest.ts (e.g. `"^3.8.0"`). */
+  declared: string | null;
+  /** The running pneuma-skills version (e.g. `"3.8.0"`). */
+  runtime: string;
+  /** Human-readable explanation when level !== "match" / "unknown". */
+  reason?: string;
+}
+
+interface Version {
+  major: number;
+  minor: number;
+  patch: number;
+  prerelease: string | null;
+}
+
+interface Clause {
+  op: ">" | ">=" | "<" | "<=" | "=";
+  version: Version;
+}
+
+/**
+ * Public entry point. Returns a structured compat result so callers can
+ * render the right UI variant + tooltip text without re-parsing.
+ */
+export function checkCompat(
+  declared: string | null | undefined,
+  runtime: string,
+): CompatResult {
+  const runtimeV = parseVersion(runtime);
+  if (!runtimeV) {
+    return { level: "unknown", declared: declared ?? null, runtime };
+  }
+
+  if (!declared) {
+    return { level: "unknown", declared: null, runtime };
+  }
+
+  const clauses = parseRange(declared);
+  if (!clauses) {
+    // Unparseable range — don't pretend to know
+    return { level: "unknown", declared, runtime };
+  }
+
+  if (clauses.length === 0) {
+    // Wildcard — always matches
+    return { level: "match", declared, runtime };
+  }
+
+  const allMatch = clauses.every((c) => satisfiesClause(runtimeV, c));
+  if (allMatch) {
+    return { level: "match", declared, runtime };
+  }
+
+  // Not a match — classify the drift by looking at the *lower bound* of
+  // the range. That's what the author was targeting; the runtime either
+  // shares a major with it (minor drift) or doesn't (major drift).
+  const lowerBound = inferLowerBound(clauses);
+  if (lowerBound && lowerBound.major === runtimeV.major) {
+    return {
+      level: "minor-drift",
+      declared,
+      runtime,
+      reason: `Targets ${declared}, running ${runtime} — same major, minor/patch drift.`,
+    };
+  }
+  return {
+    level: "major-drift",
+    declared,
+    runtime,
+    reason: `Targets ${declared}, running ${runtime} — different major version, likely incompatible.`,
+  };
+}
+
+// ── Parsing ─────────────────────────────────────────────────────────────────
+
+function parseVersion(raw: string): Version | null {
+  // Tolerate "v3.8.0" and similar prefixes.
+  const stripped = raw.trim().replace(/^v/i, "");
+  const m = stripped.match(/^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?$/);
+  if (!m) return null;
+  return {
+    major: Number(m[1]),
+    minor: Number(m[2]),
+    patch: Number(m[3]),
+    prerelease: m[4] ?? null,
+  };
+}
+
+/**
+ * Parse a range string into a list of clauses. All clauses must hold
+ * (logical AND). Returns:
+ *   - `[]` for an unconditional wildcard
+ *   - non-empty array for a concrete range
+ *   - `null` when the input is unparseable
+ */
+function parseRange(raw: string): Clause[] | null {
+  const r = raw.trim();
+  if (r === "*" || r.toLowerCase() === "x") return [];
+
+  // Caret: ^A.B.C → >=A.B.C <(A+1).0.0
+  if (r.startsWith("^")) {
+    const v = parseVersion(r.slice(1));
+    if (!v) return null;
+    return [
+      { op: ">=", version: v },
+      { op: "<", version: { major: v.major + 1, minor: 0, patch: 0, prerelease: null } },
+    ];
+  }
+
+  // Tilde: ~A.B.C → >=A.B.C <A.(B+1).0
+  if (r.startsWith("~")) {
+    const v = parseVersion(r.slice(1));
+    if (!v) return null;
+    return [
+      { op: ">=", version: v },
+      { op: "<", version: { major: v.major, minor: v.minor + 1, patch: 0, prerelease: null } },
+    ];
+  }
+
+  // Compound: split by whitespace, each part is a clause
+  const parts = r.split(/\s+/).filter((p) => p.length > 0);
+  if (parts.length === 0) return null;
+
+  const out: Clause[] = [];
+  for (const part of parts) {
+    const m = part.match(/^(>=|<=|>|<|=)?\s*(.+)$/);
+    if (!m) return null;
+    const op = (m[1] || "=") as Clause["op"];
+    const v = parseVersion(m[2]);
+    if (!v) return null;
+    out.push({ op, version: v });
+  }
+  return out;
+}
+
+// ── Satisfaction check ──────────────────────────────────────────────────────
+
+function compareVersions(a: Version, b: Version): -1 | 0 | 1 {
+  if (a.major !== b.major) return a.major < b.major ? -1 : 1;
+  if (a.minor !== b.minor) return a.minor < b.minor ? -1 : 1;
+  if (a.patch !== b.patch) return a.patch < b.patch ? -1 : 1;
+  // Treat pre-release as < the same M.m.p without pre-release (npm semver
+  // convention). Don't go deeper — we're not adjudicating rc.1 vs rc.2.
+  if (a.prerelease && !b.prerelease) return -1;
+  if (!a.prerelease && b.prerelease) return 1;
+  return 0;
+}
+
+function satisfiesClause(runtime: Version, clause: Clause): boolean {
+  const cmp = compareVersions(runtime, clause.version);
+  switch (clause.op) {
+    case "=":  return cmp === 0;
+    case ">":  return cmp > 0;
+    case ">=": return cmp >= 0;
+    case "<":  return cmp < 0;
+    case "<=": return cmp <= 0;
+  }
+}
+
+/**
+ * Best effort at recovering the "intended target" of the range — used to
+ * classify drift severity. For `^3.8.0` or `>=3.8.0 <4.0.0` the lower
+ * bound is `3.8.0`. For a bare `<4.0.0` (no lower bound) we hand back the
+ * first parsed version, which may not be a meaningful "target" but at
+ * least lets the UI render a comparison.
+ */
+function inferLowerBound(clauses: Clause[]): Version | null {
+  for (const c of clauses) {
+    if (c.op === ">=" || c.op === ">" || c.op === "=") return c.version;
+  }
+  return clauses[0]?.version ?? null;
+}

--- a/docs/design/pneuma-library-upgrade.md
+++ b/docs/design/pneuma-library-upgrade.md
@@ -1,0 +1,148 @@
+# Design: `pneuma library upgrade`
+
+> **Status:** Design sketch — not implemented. Depends on the `pneumaVersion` data model that ships in [#116](https://github.com/pandazki/pneuma-skills/pull/116).
+>
+> **Audience:** Maintainers of `pneuma-skills` upstream and authors of mode libraries (`pneuma library init` repos) who will eventually need to migrate their modes across Pneuma major versions.
+
+## Problem
+
+Today, when Pneuma releases a breaking-change major version (e.g. 4.0 with a new ViewerContract or a renamed source kind), the burden falls entirely on each library author: open every mode, read the upstream changelog, hand-edit, retest, push. No tooling helps with the diff between "what your mode declares as compatible" and "what the runtime expects now."
+
+The new `pneumaVersion` field (#116) tells us what each mode targets. We can leverage that field to build a guided upgrade flow.
+
+## Goal
+
+```bash
+pneuma library upgrade <library-id>
+```
+
+Walks the author through every mode in their library whose `pneumaVersion` is incompatible with the currently-installed runtime, surfaces the migration steps for the version delta, optionally automates the field bumps, and either applies changes directly or hands off to a mode-authoring session for the agent to do the work.
+
+Designed to be the *iteration* counterpart to `pneuma library init` + `pneuma library publish`. Same data model, same CLI verb family, no new concepts for the author.
+
+## Two strategies (pick one or offer both)
+
+### Strategy A — guided manual
+
+The lightest possible flow. CLI does:
+
+1. Load the library's sidecar; for each activated mode, compare `pneumaVersion` against runtime.
+2. For each incompatible mode, print:
+   - The mode name + declared range + runtime version
+   - A list of relevant migration docs (`docs/migration/<from>-to-<to>-*.md`) for the version delta
+   - A 1-line summary of each migration
+3. Prompt the author per mode:
+   - `[s]kip` — leave as-is, mark in `.library.json.upgradeSkipped[modeName] = "<runtime>"` so the next upgrade run can short-circuit
+   - `[r]ead` — open the migration doc(s) in the system browser (`open <path>`)
+   - `[b]ump` — just change the manifest's `pneumaVersion` field to a new range the author types; useful when the migration is a no-op and they've verified manually
+   - `[a]gent` — hand off to Strategy B for this mode (described below)
+4. After all modes processed, optionally run `pneuma-skills library publish` to commit + push.
+
+**Pros:** simple, no agent involved unless asked. Author keeps full control. Easy to ship: ~150 lines of CLI plus minimal sidecar bookkeeping.
+
+**Cons:** doesn't actually do the work. Bulk migrations across a 30-mode library still require ~30 individual edits.
+
+### Strategy B — agent-driven (per mode)
+
+When the author picks `[a]gent` (or `--mode-agent` for the whole library), the CLI:
+
+1. Locates the migration doc(s) for the version delta — e.g. `docs/migration/3.x-to-4.0-viewer-contract.md`
+2. Spawns a Pneuma session pointing at the mode dir (the actual `.../my-mode/` inside the library repo) with:
+   - The `create-mode` skill from the library's `.claude/skills/create-mode/` (gives the agent full ModeManifest + ViewerContract context — see [`pneuma-mode-gallery`](https://github.com/pandazki/pneuma-mode-gallery))
+   - The relevant migration doc(s) injected into the session's `<pneuma:env>` greeting as a one-shot "here's what changed, apply it" briefing
+   - A clear constraint: edit only this mode's files, bump `manifest.pneumaVersion` when done
+3. Author watches via the regular Pneuma UI, intervenes when needed (same workflow they use to author new modes).
+4. On agent-done signal (a small synthetic tag the agent emits, or just session close), CLI marks the mode as migrated and moves to the next.
+
+**Pros:** actually does the work. Reuses the create-mode skill investment. Author retains review power but doesn't have to type the edits.
+
+**Cons:** more moving parts. Per-version migration docs need to be authored with enough rigor that an agent can apply them mechanically — this raises the bar on upstream's documentation quality (which is probably a good thing anyway).
+
+**Recommendation:** ship Strategy A first (most of the value, smallest surface area). Add Strategy B once we have one full version-bump migration doc as a worked example.
+
+## Migration doc format
+
+Authoring contract for `docs/migration/<from>-to-<to>-<topic>.md`:
+
+```markdown
+---
+fromRange: ^3.x      # semver range this migration covers as INPUT
+toRange: ^4.0        # semver range it produces
+appliesWhen:         # optional — narrow the trigger
+  - "manifest.sources.*.kind === 'aggregate-file'"
+agentReady: true     # whether an agent can run this end-to-end
+estimatedMinutes: 5  # human estimate when running manually
+---
+
+# Migrating from 3.x to 4.0 (Viewer Contract)
+
+> **TL;DR:** <one paragraph an author / agent can act on>
+
+## Why
+<intent + why upstream had to break>
+
+## Decision tree
+<branches by what the mode uses today — same shape as the 2.29 migration doc>
+
+## Mechanical changes
+<exact diff patterns the agent can apply; each pattern has a `match` regex and a `replace` template>
+
+## Verification
+<how to confirm the migration worked — `bun run dev <mode>` + check X, Y, Z>
+```
+
+The existing `docs/migration/2.29-source-abstraction.md` is a near-perfect example of the format we're standardizing. Strategy B requires the `## Mechanical changes` section to be precise enough for an agent to apply; Strategy A can rely on the prose alone.
+
+## Sidecar changes
+
+Add two optional fields to `InstalledLibrary`:
+
+```typescript
+interface InstalledLibrary {
+  // ...existing
+  /** Pneuma version that the last successful `library upgrade` targeted. */
+  lastUpgradedTo?: string;
+  /** Per-mode upgrade-skipped markers — set when the author chose to skip this round. */
+  upgradeSkipped?: Record<string, string>;  // modeName → skipped-at-runtime-version
+}
+```
+
+These are diagnostic only — they don't change resolution. The launcher already uses `pneumaVersion` + cached compat to render state.
+
+## CLI surface
+
+```bash
+pneuma library upgrade <library-id>                     # interactive, Strategy A by default
+pneuma library upgrade <library-id> --mode-agent        # all modes via Strategy B
+pneuma library upgrade <library-id> --mode foo,bar      # only specific modes
+pneuma library upgrade <library-id> --dry-run           # show diffs / steps without applying
+pneuma library upgrade <library-id> --auto-bump-only    # only bump pneumaVersion fields, no other edits
+```
+
+Help text mirrors the existing `library publish` / `library sync` style — short, example-driven.
+
+## Open questions
+
+1. **Migration doc discovery** — should the docs ship in `pneuma-skills/docs/migration/` (what we have today) or in a separate `@pneuma/migrations` npm package the CLI can install on-demand? The first is simpler; the second scales better if migrations grow large.
+2. **Agent backend default** — Strategy B spawns a Pneuma session. Should it default to the library author's last-used backend (read from `~/.pneuma/sessions.json`) or always prompt?
+3. **Rollback** — when an agent-driven migration goes wrong, what's the undo? Git revert is the obvious answer, but the CLI should at least leave a clean commit point per mode.
+4. **Pre-release versions** — should an author be able to declare `pneumaVersion: "^4.0.0-rc.1"` and have `upgrade` honor that? The compat utility (#116) handles pre-release leniently; the upgrade flow should match.
+
+## Rollout phases
+
+1. **Phase 1 (now-ish):** Strategy A only. Authors run it manually, read migration docs themselves, bump fields with `[b]ump`. Establishes the data and the CLI shape.
+2. **Phase 2 (when upstream ships first real breaking change):** Author the first per-version migration doc using the format above as a real worked example. Confirm the doc format works for both human and Strategy A consumption.
+3. **Phase 3:** Add Strategy B (`--mode-agent` flag). Requires the doc format to be locked in.
+4. **Phase 4:** Surface the upgrade flow from the launcher UI — "1 library has 3 incompatible modes — Upgrade" button on the library card.
+
+## Not in scope
+
+- Auto-upgrade on `pneuma mode add` / `pneuma library sync`. Compatibility is information, not coercion — the user decides when to migrate.
+- Cross-library batching. Each library is independent; the CLI walks one at a time.
+- Migrating from external git sources whose upstream maintainer is unreachable. Authors fork in that case.
+
+## See also
+
+- [#116](https://github.com/pandazki/pneuma-skills/pull/116) — pneumaVersion field + launcher incompatibility UI (the data + display this command consumes)
+- [`pneuma-mode-gallery`](https://github.com/pandazki/pneuma-mode-gallery) — reference library with the `create-mode` skill Strategy B reuses
+- `docs/migration/2.29-source-abstraction.md` — format precedent for per-version migration docs

--- a/server/index.ts
+++ b/server/index.ts
@@ -388,7 +388,24 @@ export async function startServer(options: ServerOptions) {
   const REGISTRY_URL = "https://pneuma-storage.vibecoding.icu";
   const REGISTRY_TTL_MS = 60_000;
 
+  /**
+   * Compat status for a mode entry — surfaced to the launcher so the UI
+   * can mark incompatible modes (greyed card, lock badge, tooltip). The
+   * shape matches `core/version-compat.ts`'s `CompatResult` so consumers
+   * can re-use that module's helpers without re-deriving.
+   */
+  interface RegistryCompat {
+    level: "match" | "minor-drift" | "major-drift" | "unknown";
+    /** The declared range as written in the mode's `manifest.ts.pneumaVersion`. */
+    declared: string | null;
+    /** The running pneuma-skills version. Same value for every entry. */
+    runtime: string;
+    reason?: string;
+  }
+
   interface RegistryResponse {
+    /** Pneuma runtime version this server is running. Convenient for UI display. */
+    runtimeVersion: string;
     builtins: Array<{
       name: string;
       displayName: string;
@@ -420,6 +437,22 @@ export async function startServer(options: ServerOptions) {
       librarySource?: { id: string; name: string; displayName?: string };
       /** True when the library's recorded `manifestVersion` is ahead of `installedVersion` */
       updateAvailable?: boolean;
+      /**
+       * Declared `pneumaVersion` range on the mode (or falling back to the
+       * parent library's `pneumaVersion`). Cached for the UI tooltip — the
+       * launcher doesn't have to re-read the manifest just to render the
+       * "Targets ^X.Y.0" line.
+       */
+      pneumaVersion?: string;
+      /**
+       * Pre-computed compat result against the running runtime. UI uses
+       * `compat.level` to pick the rendering variant (incompatible/grey
+       * for "major-drift", warning chip for "minor-drift", normal for
+       * "match", normal for "unknown" — never punish modes that didn't
+       * declare a range, only ones whose declaration disagrees with the
+       * runtime).
+       */
+      compat?: RegistryCompat;
     }>;
   }
 
@@ -463,7 +496,15 @@ export async function startServer(options: ServerOptions) {
 
   const buildRegistry = async (locale: string): Promise<RegistryResponse> => {
     const { parseManifestTs } = await import("../core/utils/manifest-parser.js");
+    const { checkCompat } = await import("../core/version-compat.js");
     const projectRoot = options.projectRoot || resolve(dirname(import.meta.path), "..");
+
+    // Runtime version — read once per build (small, cached upstream).
+    let runtimeVersion = "0.0.0";
+    try {
+      const pkg = JSON.parse(readFileSync(join(projectRoot, "package.json"), "utf-8"));
+      if (typeof pkg.version === "string") runtimeVersion = pkg.version;
+    } catch { /* leave as 0.0.0; UI will fall back to "unknown" compat */ }
 
     // The launcher's user-pickable mode grid is driven from this curated
     // order. Modes that exist on disk but should never be offered as a
@@ -530,6 +571,7 @@ export async function startServer(options: ServerOptions) {
             // onboarding-style helper triggered by another mode) without
             // showing up in the launcher's Local Modes grid.
             if (parsed.hidden === true) continue;
+            const compat = checkCompat(parsed.pneumaVersion ?? null, runtimeVersion);
             local.push({
               name: parsed.name || entry,
               displayName: parsed.displayName || entry,
@@ -537,6 +579,8 @@ export async function startServer(options: ServerOptions) {
               icon: parsed.icon,
               version: parsed.version || "local",
               path: entryPath,
+              ...(parsed.pneumaVersion ? { pneumaVersion: parsed.pneumaVersion } : {}),
+              ...(compat.level !== "unknown" ? { compat } : {}),
             });
           } catch { }
         }
@@ -564,6 +608,11 @@ export async function startServer(options: ServerOptions) {
             if (manifestPath) parsed = parseManifestTs(readFileSync(manifestPath, "utf-8"), locale);
           } catch { /* tolerate parse failures, fall back to sidecar fields */ }
           if (parsed.hidden === true) continue;
+          // Per-mode pneumaVersion takes precedence; fall back to the
+          // library-level declaration so a single library-wide stamp can
+          // cover every mode that doesn't override.
+          const declaredCompat = parsed.pneumaVersion ?? m.pneumaVersion ?? lib.pneumaVersion ?? null;
+          const compat = checkCompat(declaredCompat, runtimeVersion);
           local.push({
             name: parsed.name || m.name,
             displayName: parsed.displayName || m.name,
@@ -579,12 +628,14 @@ export async function startServer(options: ServerOptions) {
             ...(m.installedVersion && m.installedVersion !== m.manifestVersion
               ? { updateAvailable: true }
               : {}),
+            ...(declaredCompat ? { pneumaVersion: declaredCompat } : {}),
+            ...(compat.level !== "unknown" ? { compat } : {}),
           });
         }
       }
     } catch { /* library subsystem failure should not break the registry */ }
 
-    return { builtins, published, local };
+    return { runtimeVersion, builtins, published, local };
   };
 
   /**

--- a/src/components/Launcher.tsx
+++ b/src/components/Launcher.tsx
@@ -91,6 +91,19 @@ interface PublishedMode {
   icon?: string;
 }
 
+/**
+ * Pneuma runtime compat status for a mode entry — surfaced by the server
+ * (`/api/registry`) so the UI can mark incompatible modes without
+ * re-running version math. Shape mirrors `core/version-compat.ts`'s
+ * `CompatResult`.
+ */
+interface ModeCompat {
+  level: "match" | "minor-drift" | "major-drift" | "unknown";
+  declared: string | null;
+  runtime: string;
+  reason?: string;
+}
+
 interface LocalMode {
   name: string;
   displayName: string;
@@ -102,6 +115,10 @@ interface LocalMode {
   librarySource?: { id: string; name: string; displayName?: string };
   /** True when the library's manifestVersion is ahead of installedVersion. */
   updateAvailable?: boolean;
+  /** Declared semver range the mode targets, e.g. `"^3.8.0"`. */
+  pneumaVersion?: string;
+  /** Pre-computed compat against the running runtime. Omitted when unknown. */
+  compat?: ModeCompat;
 }
 
 interface RecentSession {
@@ -161,6 +178,10 @@ type AnyMode = {
   inspiredBy?: BuiltinMode["inspiredBy"];
   /** Propagated from LocalMode for library-sourced modes (chip on tiles). */
   librarySource?: { id: string; name: string; displayName?: string };
+  /** Propagated from LocalMode — declared semver range the mode targets. */
+  pneumaVersion?: string;
+  /** Propagated from LocalMode — pre-computed compat (omitted when unknown). */
+  compat?: ModeCompat;
 };
 
 // ── Theme ────────────────────────────────────────────────────────────────
@@ -1390,6 +1411,7 @@ function QuickStartTile({
   isModeMaker,
   librarySource,
   isFavorite,
+  compat,
   onClick,
 }: {
   name: string;
@@ -1401,18 +1423,44 @@ function QuickStartTile({
   librarySource?: { id: string; name: string; displayName?: string };
   /** When true, a small filled star sits in the top-left to mark this tile as pinned. */
   isFavorite?: boolean;
+  /**
+   * Runtime compat status. When level is "major-drift" the tile dims, gains
+   * a red dot, and the launch confirms before proceeding. Other levels are
+   * not visualized at this scale — they'd dominate the small surface; the
+   * Gallery card carries the full chip + tooltip.
+   */
+  compat?: ModeCompat;
   onClick: () => void;
 }) {
   const { t } = useTranslation("launcher");
+  const incompat = compat?.level === "major-drift";
+  const handleClick = () => {
+    if (incompat) {
+      const msg = compat?.reason ?? "Incompatible with the running pneuma-skills version";
+      if (!confirm(`${msg}\n\nLaunch anyway?`)) return;
+    }
+    onClick();
+  };
   return (
     <button
-      onClick={onClick}
+      onClick={handleClick}
+      title={incompat ? (compat?.reason ?? undefined) : undefined}
       className={`group relative flex flex-col items-center gap-3 p-5 rounded-xl transition-all duration-200 cursor-pointer ${
         isModeMaker
           ? "bg-cc-primary/5 border border-cc-primary/15 hover:border-cc-primary/30 hover:bg-cc-primary/8"
           : "bg-cc-surface/30 hover:bg-cc-surface/60 border border-transparent hover:border-cc-border/30"
-      }`}
+      } ${incompat ? "opacity-60" : ""}`}
     >
+      {incompat && (
+        // Incompatible runtime — small red dot in the bottom-right. The
+        // full reason lives in the button's title attr (set above) and in
+        // the GalleryModeCard's CompatBadge; the dot is just an at-a-glance
+        // "don't bother launching this" marker.
+        <span
+          className="absolute bottom-2 right-2 w-2 h-2 rounded-full bg-red-500/80 ring-1 ring-red-500/30"
+          aria-label="Incompatible with the running pneuma-skills version"
+        />
+      )}
       {isFavorite && (
         // Favorite marker — sits top-left so it pairs with the library
         // link glyph (top-right) without colliding. Filled orange star
@@ -2020,6 +2068,44 @@ function LibraryGalleryGroup({
   );
 }
 
+/**
+ * Small badge surfaced next to a mode's display name when its declared
+ * `pneumaVersion` doesn't match the running runtime. Two intensities:
+ *
+ *   - "major-drift" → red, "Incompatible" — the launcher dims the card and
+ *     blocks the launch button when this fires.
+ *   - "minor-drift" → amber, "Minor drift" — non-blocking, FYI only.
+ *
+ * Returns null for "match", "unknown", or missing compat info, so callers
+ * can drop it inline without conditional wrappers.
+ */
+function CompatBadge({ compat }: { compat?: ModeCompat }) {
+  if (!compat || compat.level === "match" || compat.level === "unknown") return null;
+  const isMajor = compat.level === "major-drift";
+  const label = isMajor ? "Incompatible" : "Minor drift";
+  const tooltip =
+    compat.reason ??
+    `Targets ${compat.declared ?? "(unknown)"} — running ${compat.runtime}`;
+  return (
+    <span
+      title={tooltip}
+      className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium ${
+        isMajor
+          ? "bg-red-500/15 text-red-400 border border-red-500/30"
+          : "bg-amber-500/15 text-amber-400 border border-amber-500/30"
+      }`}
+    >
+      {isMajor && (
+        <svg className="w-2.5 h-2.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
+          <rect x="5" y="11" width="14" height="10" rx="2" />
+          <path d="M7 11V7a5 5 0 0110 0v4" />
+        </svg>
+      )}
+      {label}
+    </span>
+  );
+}
+
 function GalleryModeCard({
   mode,
   expanded,
@@ -2121,13 +2207,16 @@ function GalleryModeCard({
       )}
       {/* Header row — always visible */}
       <div
-        className="relative z-[2] flex items-center gap-4 px-5 py-4 cursor-pointer"
+        className={`relative z-[2] flex items-center gap-4 px-5 py-4 cursor-pointer ${
+          mode.compat?.level === "major-drift" ? "opacity-60" : ""
+        }`}
         onClick={onToggle}
       >
         <ModeIcon svg={mode.icon} className="w-8 h-8 text-cc-primary shrink-0" />
         <div className="flex-1 min-w-0">
-          <div className="flex items-baseline gap-2">
+          <div className="flex items-baseline gap-2 flex-wrap">
             <h3 className="text-base font-medium text-cc-fg">{mode.displayName}</h3>
+            <CompatBadge compat={mode.compat} />
             {mode.showcase?.tagline && (
               <span className="text-xs text-cc-muted/60 hidden sm:inline">{mode.showcase.tagline}</span>
             )}
@@ -2207,12 +2296,31 @@ function GalleryModeCard({
               stopPropagation
             />
           )}
-          <button
-            onClick={(e) => { e.stopPropagation(); onLaunch(); }}
-            className="px-3.5 py-1.5 text-xs font-medium rounded-md bg-cc-primary/10 text-cc-primary hover:bg-cc-primary hover:text-white transition-colors cursor-pointer"
-          >
-            {t("gallery_card.launch")}
-          </button>
+          {(() => {
+            const incompat = mode.compat?.level === "major-drift";
+            const launchTitle = incompat
+              ? (mode.compat?.reason ?? "Incompatible with the running pneuma-skills version")
+              : undefined;
+            return (
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  if (incompat) {
+                    if (!confirm(`${launchTitle}\n\nLaunch anyway?`)) return;
+                  }
+                  onLaunch();
+                }}
+                title={launchTitle}
+                className={`px-3.5 py-1.5 text-xs font-medium rounded-md transition-colors cursor-pointer ${
+                  incompat
+                    ? "bg-red-500/10 text-red-400 hover:bg-red-500/20"
+                    : "bg-cc-primary/10 text-cc-primary hover:bg-cc-primary hover:text-white"
+                }`}
+              >
+                {t("gallery_card.launch")}
+              </button>
+            );
+          })()}
           <svg
             className={`w-4 h-4 text-cc-muted/40 transition-transform duration-200 ${expanded ? "rotate-180" : ""}`}
             fill="none"
@@ -5093,6 +5201,7 @@ export default function Launcher() {
                   description={mode.description}
                   icon={mode.icon}
                   librarySource={mode.librarySource}
+                  compat={mode.compat}
                   isFavorite={isFavorite(favoriteKey(mode))}
                   onClick={() => setLaunchTarget({
                     specifier: mode.specifier,


### PR DESCRIPTION
## Summary

- Adds optional `pneumaVersion` field to `ModeManifest` and `LibraryManifest` (semver range, e.g. `\"^3.8.0\"`)
- New `core/version-compat.ts` utility (`checkCompat` → match/minor-drift/major-drift/unknown) with 19 tests; no npm `semver` dependency
- `/api/registry` enriches each local entry with pre-computed `compat` + carries top-level `runtimeVersion`
- Launcher renders incompatible state: red `Incompatible` badge + dim + destructive launch button on `GalleryModeCard`; small red dot + dim on `QuickStartTile`. Modes without a declared `pneumaVersion` render exactly as before — the check is opt-in by design
- Pairs with the [`pneuma-mode-gallery`](https://github.com/pandazki/pneuma-mode-gallery) library scaffold, which already stamps `pneumaVersion` on every mode template and library-level fallback

## Why now

External mode authors had no way to communicate runtime compatibility to consumers — a mode written for 3.7 would silently load against a 4.x runtime and crash (or worse, look fine until the user hit a removed code path). With this PR, the gallery surfaces the mismatch up-front. `pneuma library upgrade` (separate follow-up) will later consume the same declarations to walk authors through runtime migrations.

## Data model

| Surface | Field | Purpose |
|---|---|---|
| `ModeManifest` | `pneumaVersion?: string` | Per-mode declaration |
| `LibraryManifest` | `pneumaVersion?: string` | Library-level fallback |
| `InstalledLibrary` | `pneumaVersion?: string` | Sidecar cache of library-level value |
| `InstalledLibraryMode` | `pneumaVersion?: string` | Sidecar cache of per-mode value |
| `ResolvedRepoMode` | `pneumaVersion?: string` | Carried through scan paths |
| `ParsedManifest` | `pneumaVersion?: string` | regex extraction |

Resolution precedence at API time: `parsed.pneumaVersion ?? m.pneumaVersion (cache) ?? lib.pneumaVersion (fallback)`. Returns `null` when none — the UI renders that as \"unknown\" (no badge).

## Visual verification

Installed the `pneuma-mode-gallery` library, then faked one mode's sidecar `pneumaVersion` to `\"^99.0.0\"`. Launcher correctly:
- Dimmed the `GalleryModeCard` to 60% opacity, added the red `Incompatible` chip next to display name, switched the launch button to the destructive red variant with a confirm-before-launch dialog
- Dimmed the `QuickStartTile` to 60%, added a small red dot in the bottom-right, attached the warning tooltip + confirm-on-click
- A sibling mode at `\"^3.8.0\"` (compat with the running 3.8.0) rendered with zero changes

## Test plan

- [x] `bun test core/` — 358 pass, 0 regressions
- [x] New 19-test suite for `version-compat.ts` covers match, minor-drift, major-drift, unknown, wildcard, caret, tilde, compound ranges, pre-release versions, result shape
- [x] Manual: install `pneuma-mode-gallery`, fake major-drift sidecar, launcher renders incompat treatment on both `GalleryModeCard` and `QuickStartTile`
- [x] Modes without `pneumaVersion` render identically to before (existing built-ins + invoice-organization + slide-evolved appeared unchanged in the same launcher view)
- [ ] (Follow-up PR) `pneuma library upgrade` command consumes these declarations to walk authors through runtime migrations

🤖 Generated with [Claude Code](https://claude.com/claude-code)