### PR TITLE
feat(cosmos): visual anchoring — node drawer + excerpts + source schema

### DIFF
--- a/modes/cosmos/skill/SKILL.md
+++ b/modes/cosmos/skill/SKILL.md
@@ -170,6 +170,11 @@ chip's behaviour depends on `kind`.
 All kinds accept an optional `label` to override the auto-derived
 chip text.
 
+Every kind now also accepts an optional `locator?: string` and
+`excerpt?: { path, caption? }`. See the new *Visual anchoring*
+chapter for what they're for and the shell commands to populate
+them.
+
 ### Per-domain examples
 
 **Codebase node** — typically one or more `file` refs, often with
@@ -235,6 +240,8 @@ appears, with a lifted quote so the user can verify the inference:
   add a range or pick a more specific source.
 - **Order matters.** Put the most authoritative ref first; the
   chip strip preserves order, and the user reads left to right.
+- **Excerpt > chip.** When you can crop a real visual extract from
+  the source, do it — chips are functional, excerpts are persuasive.
 
 ### Legacy schema note
 
@@ -243,6 +250,149 @@ an optional `lineRange: [start, end]`. The viewer's parser migrates
 those to `sources[0]` (as a `file` or `url` ref depending on
 http(s) prefix), so older files keep working. New files should
 write `sources[]` directly and skip the legacy fields.
+
+## Visual anchoring — every node deserves a way home
+
+Users open a cosmos to dive into source. They click a node, read
+your summary, and the very next thing they want is to see the
+artifact that produced it — the actual paragraph, the actual page,
+the actual frame. A node without a visual anchor is a node they
+can't trust. Chips get them there in one click; **excerpts get them
+there in zero**.
+
+So: when the source has a real visual you can lift from it, lift
+it. Crop the PDF page, save the video frame, screenshot the UI
+region. Put the path in `excerpt.path` and the viewer renders it
+inline above the chip strip. The chip remains as the open-the-real-
+thing affordance underneath.
+
+### The excerpt rule — non-negotiable
+
+Every `excerpt.path` MUST be a real extract from the source.
+
+- ✅ Cropped PDF page, figure lifted from a paper, screenshot of a
+  UI region, video frame at a moment, scan of a manuscript page,
+  diagram from the docs.
+- ❌ AI-generated illustrations. Decorative graphics. Stock images.
+  "Conceptual visualisations" of what the node is about.
+
+Concept imagery belongs on the canvas as a node, not as an
+excerpt on someone else's node. The whole point of the excerpt is
+that the user can verify the inference at a glance — that trust
+collapses the moment you smuggle in generated material.
+
+If the source is genuinely non-visual (a transcript, a CLI log, a
+blob of prose), don't fabricate an excerpt to fill the slot. Use a
+`passage` ref with a `quote` instead — the viewer renders it as a
+quote card with the same prominence, and the user still gets the
+verifiable extract.
+
+### Locator everywhere
+
+Every ref kind now accepts `locator?: string`. Open-ended hint
+about *where inside* the artifact this node points. Examples:
+
+- `"p.23"` — PDF page
+- `"5:32"` — moment in audio or video
+- `"figure 3"` / `"§4.2"` — section / figure in a paper
+- `"verse 14"` / `"ch.7 ¶3"` — passage in prose
+- `"slide 7"` — deck
+- `"bottom-left"` / `"nav-header"` — region in an image / UI
+- `"turn 14"` — turn in a transcript
+
+Whatever phrasing lets the user find the spot in five seconds.
+
+(`passage` already has a required `locator` field — same idea,
+already there. The new optional locator covers the other five
+kinds.)
+
+### Shell commands — populate excerpts without leaving the agent
+
+These run on macOS by default; Linux alternatives noted where
+they diverge. Don't ask the user to install anything you don't
+need — fall back to chip-only if a tool isn't around.
+
+- **PDF page → PNG:**
+  `pdftoppm -f N -l N -png -r 150 paper.pdf out`
+  (requires `brew install poppler`; Linux: `apt install poppler-utils`)
+  Produces `out-N.png`. The `-r 150` gives a readable 150-dpi crop.
+  Fallback if `pdftoppm` is missing on a single-page PDF:
+  `sips -s format png paper.pdf --out page.png`.
+- **Image crop:**
+  `sips -c <h> <w> input.png --out cropped.png` (center crop), or
+  `sips --cropToHeightWidth <h> <w> --cropOffset <x> <y> input.png --out cropped.png`
+  for a specific region. Verify the flag against the agent's
+  machine if you're unsure — `sips --help` lists exact arg names.
+  Linux: `convert input.png -crop <w>x<h>+<x>+<y> cropped.png` (ImageMagick).
+- **Video frame at t seconds:**
+  `ffmpeg -ss N -i video.mp4 -frames:v 1 -q:v 2 out.png`
+  (requires `brew install ffmpeg`). Put `-ss` before `-i` for a
+  fast seek.
+- **Web page region:** the agent can't run a headless browser in
+  MVP. If the source is a live URL, fall back to a chip + locator
+  only, or ask the user to paste the screenshot they want as a
+  workspace file and reference its path in `excerpt`.
+
+### Per-domain guidance
+
+- **Research / academic paper** — every claim / evidence / method
+  node gets a PDF page or figure excerpt + `locator` like `"p.N"`
+  or `"figure N"`. Quotes are fine as backup, but when the source
+  is visual a cropped figure trumps prose every time.
+- **Codebase** — primary cite is a `file` ref + range. Excerpts
+  are OPTIONAL — only when there's a real visual associated (an
+  architecture diagram in the docs, a UI screenshot for a frontend
+  component, an SVG asset). **Don't excerpt code as image.** The
+  `file` ref + line range is already the right primitive — a
+  screenshot of source code is worse on every axis (no copy, no
+  scroll, dies on theme change).
+- **Fiction / long-form prose** — `passage` ref with `quote` lifted
+  verbatim (≤80 chars) + `locator` like `"ch.3 ¶12"`. Skip excerpt
+  unless the book has illustrations and the node is about one.
+- **UI / product analysis** — screenshot of the UI region, crop
+  tightly, `locator` naming the area (`"nav-header"`,
+  `"empty-state"`, `"settings: privacy tab"`). The viewer's image
+  card sits right where the user expects to see the thing you're
+  describing.
+- **Video / talk** — frame at the moment in question + `locator`
+  like `"5:32"`. The `video` kind already has an optional `t` —
+  use it alongside `excerpt.path` so the chip click jumps the
+  player to the moment too.
+- **Conversation / transcript** — `passage` ref with `quote` +
+  `locator` like `"turn 14"`. Excerpts only when the conversation
+  includes shared images you want to lift.
+
+### Where excerpts live on disk
+
+Default convention: `.cosmos-assets/<node-id>/` at the workspace
+root. Keeps the cosmos.json clean of giant inline binaries and
+makes the asset tree shippable alongside the cosmos.
+
+Examples: `.cosmos-assets/claim-baseline/p23.png`,
+`.cosmos-assets/c-eliot/manuscript-folio.jpg`. Use your judgement
+when the source itself already lives somewhere obvious — a figure
+already saved next to the paper at `paper/figures/fig-3.png`
+doesn't need to be copied; reference it where it sits.
+
+### Edges with sources
+
+`CosmosEdge.sources?: CosmosSourceRef[]` — same shape nodes use.
+Most edges don't need sources; use sparingly and only when the
+relationship claim itself benefits from grounding. Examples worth
+the citation:
+
+- Codebase: an `imports` edge can cite the import statement's line
+  range — useful when "A imports B" is non-obvious because the
+  import is conditional or aliased.
+- Research: a `supports` edge can cite the section that
+  establishes the support — different from citing the supporting
+  claim's source, which lives on the node.
+- Fiction: a `vanished_near` edge can cite the passage that
+  establishes the disappearance.
+
+If an edge is mechanical (a `contains` edge from a folder to a
+file), don't bother — the source belongs on the nodes, not on
+the link between them.
 
 ## Workflow
 

--- a/modes/cosmos/types.ts
+++ b/modes/cosmos/types.ts
@@ -86,27 +86,111 @@ export type CosmosNodeComplexity = "simple" | "moderate" | "complex";
  * caller; a research node might cite the paper PDF and its source
  * dataset URL.
  */
+/**
+ * Open-ended where-inside hint for a source ref. The viewer renders
+ * it as a small chip beside the kind tag so the user knows the spot
+ * in the source at a glance. Examples: "p.23", "5:32", "bottom-left",
+ * "verse 14", "figure 3", "§4.2", "slide 7". Free-form — whatever
+ * lets the user find the location in five seconds.
+ *
+ * Distinct from `passage.locator` (which is required and identifies
+ * the passage itself). Every other ref kind now also accepts this
+ * optional hint to point inside a single artifact (a page in a PDF,
+ * a region in an image, a moment in audio, a frame in video).
+ */
+type CosmosSourceLocator = string;
+
+/**
+ * A real visual extract from the source — a cropped PDF page, a video
+ * frame, a UI screenshot region, a figure lifted from a paper. The
+ * viewer renders it inline as a visual anchor so the user can verify
+ * or read the origin at a glance, then click through to the full
+ * artifact.
+ *
+ * Workspace-relative or absolute path to the image on disk. NOT for
+ * AI-generated illustrations; concept imagery belongs on the canvas
+ * as a node, not here. Conflating excerpts with generated imagery
+ * destroys the trust signal — the whole point is that the user can
+ * see real source material before they commit to opening it.
+ *
+ * Populated by the agent using shell tools (sips, pdftoppm, ffmpeg)
+ * — see the SKILL's *Visual anchoring* chapter for per-domain
+ * recipes and the hard rule against generative imagery.
+ */
+interface CosmosSourceExcerpt {
+  /**
+   * Workspace-relative or absolute path to a real extract from the
+   * source — a cropped PDF page, video frame, UI screenshot, etc.
+   * The viewer renders it inline as a visual anchor. NOT for
+   * AI-generated illustrations; concept imagery belongs on the
+   * canvas as a node, not here.
+   */
+  path: string;
+  /** Optional short caption shown beneath the excerpt thumbnail. */
+  caption?: string;
+}
+
 export type CosmosSourceRef =
   /** A file on disk. Path is absolute or workspace-relative. Optional
    *  range pinpoints a span — currently informational (shown in the
    *  chip tooltip); editor jumping requires an editor-bridge upgrade
    *  that's deferred to a later phase. */
-  | { kind: "file"; path: string; range?: [number, number]; label?: string }
+  | {
+      kind: "file";
+      path: string;
+      range?: [number, number];
+      label?: string;
+      locator?: CosmosSourceLocator;
+      excerpt?: CosmosSourceExcerpt;
+    }
   /** A web URL. Opened with the OS default browser. */
-  | { kind: "url"; url: string; label?: string }
+  | {
+      kind: "url";
+      url: string;
+      label?: string;
+      locator?: CosmosSourceLocator;
+      excerpt?: CosmosSourceExcerpt;
+    }
   /** A passage inside a long-form document — chapter+paragraph in a
    *  novel, section+paragraph in a paper, slide number in a deck.
    *  `file` is the document, `locator` is the agent-defined address
    *  (e.g. "ch.3 ¶12", "§4.2", "slide 7"); `quote` is the lifted
    *  text the reasoning rests on. Opens the underlying file; the
    *  user navigates inside it using the locator (no automatic jump). */
-  | { kind: "passage"; file: string; locator: string; quote?: string; label?: string }
+  | {
+      kind: "passage";
+      file: string;
+      locator: string;
+      quote?: string;
+      label?: string;
+      excerpt?: CosmosSourceExcerpt;
+    }
   /** A bitmap or vector image. */
-  | { kind: "image"; path: string; label?: string }
+  | {
+      kind: "image";
+      path: string;
+      label?: string;
+      locator?: CosmosSourceLocator;
+      excerpt?: CosmosSourceExcerpt;
+    }
   /** An audio file. `t` is an optional timestamp in seconds. */
-  | { kind: "audio"; path: string; t?: number; label?: string }
+  | {
+      kind: "audio";
+      path: string;
+      t?: number;
+      label?: string;
+      locator?: CosmosSourceLocator;
+      excerpt?: CosmosSourceExcerpt;
+    }
   /** A video file. `t` is an optional timestamp in seconds. */
-  | { kind: "video"; path: string; t?: number; label?: string };
+  | {
+      kind: "video";
+      path: string;
+      t?: number;
+      label?: string;
+      locator?: CosmosSourceLocator;
+      excerpt?: CosmosSourceExcerpt;
+    };
 
 /**
  * Optional domain-view metadata. Only relevant when the node represents
@@ -209,6 +293,13 @@ export interface CosmosEdge {
   description?: string;
   /** Optional 0–1 weight for layout / visual emphasis. */
   weight?: number;
+  /** Multi-formed pointers back to source material — same shape nodes
+   *  use. Most edges don't need sources; use sparingly and only when
+   *  the relationship claim itself benefits from grounding (an
+   *  `imports` edge citing the import statement line, a `supports`
+   *  edge citing the section that establishes the support). See
+   *  `CosmosSourceRef` and the SKILL's *Visual anchoring* chapter. */
+  sources?: CosmosSourceRef[];
 }
 
 export interface CosmosLayer {

--- a/modes/cosmos/viewer/CosmosPreview.tsx
+++ b/modes/cosmos/viewer/CosmosPreview.tsx
@@ -1256,6 +1256,378 @@ function Canvas({
 
 type SidebarTab = "info" | "files" | "tour" | "drills";
 
+/** Build the workspace-relative or absolute path → /api/file URL the
+ *  excerpt thumbnail loads from. The server's /api/file route handles
+ *  both — see server/index.ts. We encode the path because excerpts
+ *  may sit under `.cosmos-assets/<id>/...` with characters that need
+ *  escaping. */
+function excerptSrcUrl(path: string): string {
+  return `${getApiBase()}/api/file?path=${encodeURIComponent(path)}`;
+}
+
+/** Open-ended where-inside hint for a ref. For passages the
+ *  required `locator` field is the natural answer; for other kinds
+ *  we read the new optional `locator?: string`. Returns empty when
+ *  no useful hint exists. */
+function sourceRefLocatorText(ref: CosmosSourceRef): string {
+  if (ref.kind === "passage") return ref.locator;
+  return (ref as { locator?: string }).locator ?? "";
+}
+
+/**
+ * EXCERPTS section — renders the visual-anchor view of a node's
+ * sources. Each ref classifies into one of three shapes:
+ *
+ *   - **Image card** — `excerpt.path` is set on any kind. Thumbnail
+ *     loads via `/api/file?path=…`; on the right, kind chip + locator
+ *     chip + caption + auto-derived path label. The whole card is a
+ *     button that delegates to `openSourceRef(ref)` — same behaviour
+ *     as the chip strip below.
+ *   - **Quote card** — `passage` ref with `quote` and no excerpt.
+ *     Large curly quote glyph in the tint color, italicised body,
+ *     file + locator chips, "open source" affordance.
+ *   - **No card** — neither excerpt nor quote present. The ref still
+ *     surfaces in the chip strip below; nothing renders here.
+ *
+ * If no cards qualify, the whole section (header + body) hides.
+ * Excerpts are *real* extracts (cropped PDF pages, video frames, UI
+ * screenshots) — see SKILL's *Visual anchoring* chapter. The viewer
+ * does not enforce this; the discipline is in the SKILL.
+ */
+function ExcerptsSection({ sources }: { sources: CosmosSourceRef[] }) {
+  const { t } = useTranslation("cosmos");
+  const [error, setError] = useState<string | null>(null);
+  const [pendingIdx, setPendingIdx] = useState<number | null>(null);
+  const [imgFailed, setImgFailed] = useState<Record<number, boolean>>({});
+
+  // Classify each ref once; only "image" / "quote" produce cards.
+  type Card =
+    | { kind: "image"; ref: CosmosSourceRef; excerpt: { path: string; caption?: string }; refIdx: number }
+    | { kind: "quote"; ref: Extract<CosmosSourceRef, { kind: "passage" }>; refIdx: number };
+  const cards: Card[] = [];
+  sources.forEach((ref, refIdx) => {
+    const excerpt = (ref as { excerpt?: { path: string; caption?: string } }).excerpt;
+    if (excerpt && typeof excerpt.path === "string" && excerpt.path) {
+      cards.push({ kind: "image", ref, excerpt, refIdx });
+      return;
+    }
+    if (ref.kind === "passage" && ref.quote) {
+      cards.push({ kind: "quote", ref, refIdx });
+    }
+  });
+
+  if (cards.length === 0) return null;
+
+  const handleOpen = async (ref: CosmosSourceRef, idx: number) => {
+    setError(null);
+    setPendingIdx(idx);
+    const res = await openSourceRef(ref);
+    setPendingIdx(null);
+    if (!res.ok) setError(res.message ?? "Failed to open");
+  };
+
+  return (
+    <div style={{ marginBottom: 12 }}>
+      <div
+        style={{
+          fontSize: 9,
+          letterSpacing: 0.4,
+          textTransform: "uppercase",
+          color: "#71717a",
+          marginBottom: 6,
+        }}
+      >
+        {t("info.excerpts_label")}
+      </div>
+      <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+        {cards.map((card, idx) => {
+          const { ref, refIdx } = card;
+          const tint = SOURCE_KIND_TINT[ref.kind];
+          const tag = t(`source_kind.${ref.kind}`);
+          const locator = sourceRefLocatorText(ref);
+          const label = sourceRefLabel(ref);
+          const pending = pendingIdx === idx;
+          const failed = imgFailed[idx] === true;
+
+          if (card.kind === "image") {
+            return (
+              <button
+                key={`${refIdx}-img`}
+                type="button"
+                title={sourceRefTooltip(ref)}
+                onClick={() => void handleOpen(ref, idx)}
+                disabled={pending}
+                style={{
+                  display: "flex",
+                  alignItems: "stretch",
+                  gap: 10,
+                  width: "100%",
+                  padding: 8,
+                  borderRadius: 6,
+                  border: `1px solid ${tint}55`,
+                  background: `${tint}0d`,
+                  color: "#d4d4d8",
+                  cursor: pending ? "default" : "pointer",
+                  opacity: pending ? 0.5 : 1,
+                  textAlign: "left",
+                  transition: "all 120ms ease",
+                }}
+                onMouseEnter={(ev) => {
+                  if (pending) return;
+                  ev.currentTarget.style.background = `${tint}1c`;
+                  ev.currentTarget.style.borderColor = `${tint}aa`;
+                }}
+                onMouseLeave={(ev) => {
+                  if (pending) return;
+                  ev.currentTarget.style.background = `${tint}0d`;
+                  ev.currentTarget.style.borderColor = `${tint}55`;
+                }}
+              >
+                <div
+                  style={{
+                    width: 144,
+                    height: 88,
+                    flexShrink: 0,
+                    borderRadius: 4,
+                    border: `1px solid ${tint}66`,
+                    background: "#0a0a0b",
+                    overflow: "hidden",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                  }}
+                >
+                  {failed ? (
+                    <div style={{ fontSize: 10, color: "#71717a", textAlign: "center", padding: 6 }}>
+                      image unavailable
+                    </div>
+                  ) : (
+                    <img
+                      src={excerptSrcUrl(card.excerpt.path)}
+                      alt={card.excerpt.caption ?? label}
+                      onError={() => setImgFailed((m) => ({ ...m, [idx]: true }))}
+                      style={{
+                        width: "100%",
+                        height: "100%",
+                        objectFit: "cover",
+                        display: "block",
+                      }}
+                    />
+                  )}
+                </div>
+                <div
+                  style={{
+                    flex: 1,
+                    minWidth: 0,
+                    display: "flex",
+                    flexDirection: "column",
+                    gap: 4,
+                  }}
+                >
+                  <div style={{ display: "flex", alignItems: "center", gap: 5, flexWrap: "wrap" }}>
+                    <span
+                      style={{
+                        fontFamily: "JetBrains Mono, ui-monospace, monospace",
+                        fontSize: 8.5,
+                        letterSpacing: 0.5,
+                        fontWeight: 700,
+                        color: tint,
+                        padding: "1px 4px",
+                        borderRadius: 2,
+                        background: `${tint}1a`,
+                      }}
+                    >
+                      {tag}
+                    </span>
+                    {locator && (
+                      <span
+                        style={{
+                          fontSize: 9,
+                          color: "#a1a1aa",
+                          padding: "1px 5px",
+                          borderRadius: 2,
+                          background: "rgba(255,255,255,0.05)",
+                          border: "1px solid #2a2a2e",
+                        }}
+                      >
+                        {locator}
+                      </span>
+                    )}
+                  </div>
+                  {card.excerpt.caption ? (
+                    <div
+                      style={{
+                        fontSize: 11.5,
+                        color: "#e4e4e7",
+                        lineHeight: 1.4,
+                        overflow: "hidden",
+                        display: "-webkit-box",
+                        WebkitLineClamp: 3,
+                        WebkitBoxOrient: "vertical",
+                      }}
+                    >
+                      {card.excerpt.caption}
+                    </div>
+                  ) : (
+                    // Caption is the card's "what is this" label. When
+                    // missing, fall back to the auto-derived path label
+                    // so the user still has something to read. Showing
+                    // both is just noise — the caption already names it.
+                    <div
+                      style={{
+                        fontSize: 11.5,
+                        color: "#d4d4d8",
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                        whiteSpace: "nowrap",
+                      }}
+                    >
+                      {label}
+                    </div>
+                  )}
+                </div>
+              </button>
+            );
+          }
+
+          // Quote card — passage ref with a lifted quote, no excerpt.
+          const passage = card.ref;
+          return (
+            <button
+              key={`${refIdx}-quote`}
+              type="button"
+              title={sourceRefTooltip(passage)}
+              onClick={() => void handleOpen(passage, idx)}
+              disabled={pending}
+              style={{
+                position: "relative",
+                display: "flex",
+                flexDirection: "column",
+                gap: 6,
+                width: "100%",
+                padding: "12px 14px 10px 36px",
+                borderRadius: 6,
+                border: `1px solid ${tint}55`,
+                background: `${tint}0d`,
+                color: "#d4d4d8",
+                cursor: pending ? "default" : "pointer",
+                opacity: pending ? 0.5 : 1,
+                textAlign: "left",
+                transition: "all 120ms ease",
+              }}
+              onMouseEnter={(ev) => {
+                if (pending) return;
+                ev.currentTarget.style.background = `${tint}1c`;
+                ev.currentTarget.style.borderColor = `${tint}aa`;
+              }}
+              onMouseLeave={(ev) => {
+                if (pending) return;
+                ev.currentTarget.style.background = `${tint}0d`;
+                ev.currentTarget.style.borderColor = `${tint}55`;
+              }}
+            >
+              <span
+                aria-hidden
+                style={{
+                  position: "absolute",
+                  top: 0,
+                  left: 8,
+                  fontFamily: "Georgia, serif",
+                  fontSize: 32,
+                  lineHeight: 1,
+                  color: tint,
+                  opacity: 0.55,
+                  pointerEvents: "none",
+                }}
+              >
+                &ldquo;
+              </span>
+              <div
+                style={{
+                  fontStyle: "italic",
+                  fontSize: 13,
+                  lineHeight: 1.55,
+                  color: "#e4e4e7",
+                }}
+              >
+                {passage.quote}
+              </div>
+              <div style={{ display: "flex", alignItems: "center", gap: 5, flexWrap: "wrap" }}>
+                <span
+                  style={{
+                    fontFamily: "JetBrains Mono, ui-monospace, monospace",
+                    fontSize: 8.5,
+                    letterSpacing: 0.5,
+                    fontWeight: 700,
+                    color: tint,
+                    padding: "1px 4px",
+                    borderRadius: 2,
+                    background: `${tint}1a`,
+                  }}
+                >
+                  {tag}
+                </span>
+                <span
+                  style={{
+                    fontSize: 10,
+                    color: "#a1a1aa",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                    maxWidth: 220,
+                  }}
+                >
+                  {passage.file}
+                </span>
+                {passage.locator && (
+                  <span
+                    style={{
+                      fontSize: 9,
+                      color: "#a1a1aa",
+                      padding: "1px 5px",
+                      borderRadius: 2,
+                      background: "rgba(255,255,255,0.05)",
+                      border: "1px solid #2a2a2e",
+                    }}
+                  >
+                    {passage.locator}
+                  </span>
+                )}
+                <span
+                  style={{
+                    marginLeft: "auto",
+                    fontSize: 9,
+                    color: "#71717a",
+                    letterSpacing: 0.3,
+                    textTransform: "uppercase",
+                  }}
+                >
+                  open source ›
+                </span>
+              </div>
+            </button>
+          );
+        })}
+      </div>
+      {error && (
+        <div
+          style={{
+            marginTop: 6,
+            fontSize: 10,
+            color: "#fb7185",
+            background: "rgba(239,68,68,0.08)",
+            border: "1px solid rgba(239,68,68,0.3)",
+            borderRadius: 3,
+            padding: "4px 8px",
+          }}
+        >
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}
+
 /**
  * SOURCES chip strip — renders every CosmosSourceRef on a node as a
  * click-to-open chip with kind tag, derived label, and on-hover full
@@ -1383,73 +1755,199 @@ function SourcesStrip({ sources }: { sources: CosmosSourceRef[] }) {
   );
 }
 
-interface InfoTabProps {
+/**
+ * NodeDrawer — right-side slide-out panel that owns per-node detail.
+ *
+ * Visibility is bound to `node !== null`. When `node` becomes null the
+ * drawer slides off; the last node is remembered so the body stays
+ * rendered through the closing animation rather than blanking.
+ *
+ * The drawer overlays the canvas right edge (position: absolute) so
+ * the user's spatial map of the graph doesn't reflow when it opens /
+ * closes. The left-side sidebar holds project-/layer-/tour-level
+ * context; the drawer holds the one-node context — separation of
+ * jobs is the whole point of moving node detail out of the tab.
+ */
+interface NodeDrawerProps {
   cosmos: Cosmos;
-  selectedNode: CosmosNode | null;
-  focusedLayer: string | null;
+  node: CosmosNode | null;
   onSelectNode: (n: CosmosNode | null) => void;
+  onClose: () => void;
 }
 
-function InfoTab({ cosmos, selectedNode, focusedLayer, onSelectNode }: InfoTabProps) {
-  const { t } = useTranslation("cosmos");
-  // Selected concrete node → full detail card
-  if (selectedNode) {
-    const layer = cosmos.layers.find((l) => l.id === selectedNode.layerId);
-    const outboundEdges = cosmos.edges.filter((e) => e.source === selectedNode.id);
-    const inboundEdges = cosmos.edges.filter((e) => e.target === selectedNode.id);
-    return (
-      <div style={{ padding: "0 4px 12px", fontSize: 12 }}>
-        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 4 }}>
+function NodeDrawer({ cosmos, node, onSelectNode, onClose }: NodeDrawerProps) {
+  // Keep the previously-rendered node around while the panel slides
+  // away, so the user sees a clean exit instead of an empty panel mid-
+  // animation.
+  const [lastNode, setLastNode] = useState<CosmosNode | null>(node);
+  useEffect(() => {
+    if (node) setLastNode(node);
+  }, [node]);
+
+  const open = node !== null;
+  const display = node ?? lastNode;
+
+  // Close on Escape, mirroring the canvas's "click pane to deselect"
+  // affordance for keyboard users.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
+  if (!display) return null;
+
+  const layer = cosmos.layers.find((l) => l.id === display.layerId);
+  const outboundEdges = cosmos.edges.filter((e) => e.source === display.id);
+  const inboundEdges = cosmos.edges.filter((e) => e.target === display.id);
+
+  return (
+    <aside
+      aria-hidden={!open}
+      style={{
+        position: "absolute",
+        top: 0,
+        right: 0,
+        bottom: 0,
+        width: 360,
+        maxWidth: "92%",
+        background: "rgba(20,20,23,0.92)",
+        borderLeft: "1px solid #27272a",
+        boxShadow: open ? "-18px 0 32px -18px rgba(0,0,0,0.55)" : "none",
+        backdropFilter: "blur(14px)",
+        WebkitBackdropFilter: "blur(14px)",
+        color: "#d4d4d8",
+        fontFamily: "Inter, sans-serif",
+        fontSize: 12,
+        display: "flex",
+        flexDirection: "column",
+        transform: open ? "translateX(0)" : "translateX(105%)",
+        opacity: open ? 1 : 0,
+        pointerEvents: open ? "auto" : "none",
+        transition:
+          "transform 220ms cubic-bezier(.2,.7,.2,1), opacity 220ms ease, box-shadow 220ms ease",
+        zIndex: 8,
+        minHeight: 0,
+      }}
+    >
+      {/* Header — type chip, complexity, close button */}
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          padding: "12px 14px 10px",
+          borderBottom: "1px solid #27272a",
+          gap: 8,
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: 8, minWidth: 0 }}>
           <div
             style={{
               fontSize: 9,
               letterSpacing: 0.6,
               textTransform: "uppercase",
               color: layer?.color ?? "#71717a",
-              fontWeight: 600,
+              fontWeight: 700,
+              whiteSpace: "nowrap",
             }}
           >
-            {selectedNode.type}
+            {display.type}
           </div>
-          {selectedNode.complexity && (
+          {display.complexity && (
             <div
               style={{
                 fontSize: 9,
                 padding: "2px 7px",
                 borderRadius: 3,
-                background: `${COMPLEXITY_TINT[selectedNode.complexity] ?? "#52525b"}22`,
-                color: COMPLEXITY_TINT[selectedNode.complexity] ?? "#a1a1aa",
+                background: `${COMPLEXITY_TINT[display.complexity] ?? "#52525b"}22`,
+                color: COMPLEXITY_TINT[display.complexity] ?? "#a1a1aa",
               }}
             >
-              {selectedNode.complexity}
+              {display.complexity}
             </div>
           )}
         </div>
-        <div style={{ fontSize: 15, fontWeight: 700, lineHeight: 1.25, color: "#fff", marginBottom: 8 }}>
-          {selectedNode.name}
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close"
+          title="Close (Esc)"
+          style={{
+            width: 24,
+            height: 24,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            borderRadius: 4,
+            border: "1px solid transparent",
+            background: "transparent",
+            color: "#71717a",
+            fontSize: 14,
+            lineHeight: 1,
+            cursor: "pointer",
+            transition: "background 120ms ease, color 120ms ease, border-color 120ms ease",
+          }}
+          onMouseEnter={(ev) => {
+            ev.currentTarget.style.background = "rgba(255,255,255,0.06)";
+            ev.currentTarget.style.color = "#fafafa";
+            ev.currentTarget.style.borderColor = "#3f3f46";
+          }}
+          onMouseLeave={(ev) => {
+            ev.currentTarget.style.background = "transparent";
+            ev.currentTarget.style.color = "#71717a";
+            ev.currentTarget.style.borderColor = "transparent";
+          }}
+        >
+          ×
+        </button>
+      </div>
+
+      {/* Body (scrollable) */}
+      <div style={{ flex: 1, overflowY: "auto", padding: "14px 16px 18px", minHeight: 0 }}>
+        <div style={{ fontSize: 17, fontWeight: 700, lineHeight: 1.25, color: "#fff", marginBottom: 8 }}>
+          {display.name}
         </div>
         {layer && (
-          <div style={{ fontSize: 10, color: "#71717a", marginBottom: 8 }}>
+          <div style={{ fontSize: 10, color: "#71717a", marginBottom: 10 }}>
             <span style={{ color: layer.color ?? "#71717a" }}>●</span> {layer.label}
           </div>
         )}
-        <div style={{ fontSize: 12, color: "#d4d4d8", lineHeight: 1.5, marginBottom: 12 }}>{selectedNode.summary}</div>
-        {selectedNode.sources && selectedNode.sources.length > 0 && (
-          <SourcesStrip sources={selectedNode.sources} />
+        <div style={{ fontSize: 12.5, color: "#e4e4e7", lineHeight: 1.55, marginBottom: 14 }}>
+          {display.summary}
+        </div>
+        {display.sources && display.sources.length > 0 && (
+          <>
+            <ExcerptsSection sources={display.sources} />
+            <SourcesStrip sources={display.sources} />
+          </>
         )}
-        {selectedNode.languageNotes && (
-          <div style={{ marginBottom: 10 }}>
-            <div style={{ fontSize: 9, letterSpacing: 0.4, textTransform: "uppercase", color: "#71717a", marginBottom: 2 }}>
+        {display.languageNotes && (
+          <div style={{ marginBottom: 12 }}>
+            <div
+              style={{
+                fontSize: 9,
+                letterSpacing: 0.4,
+                textTransform: "uppercase",
+                color: "#71717a",
+                marginBottom: 3,
+              }}
+            >
               Stack
             </div>
-            <div style={{ fontSize: 11, color: "#a1a1aa", lineHeight: 1.4 }}>{selectedNode.languageNotes}</div>
+            <div style={{ fontSize: 11, color: "#a1a1aa", lineHeight: 1.5 }}>
+              {display.languageNotes}
+            </div>
           </div>
         )}
-        {selectedNode.tags && selectedNode.tags.length > 0 && (
-          <div style={{ marginBottom: 10, display: "flex", flexWrap: "wrap", gap: 4 }}>
-            {selectedNode.tags.map((t) => (
+        {display.tags && display.tags.length > 0 && (
+          <div style={{ marginBottom: 12, display: "flex", flexWrap: "wrap", gap: 4 }}>
+            {display.tags.map((tag) => (
               <span
-                key={t}
+                key={tag}
                 style={{
                   fontSize: 9,
                   padding: "2px 7px",
@@ -1458,17 +1956,25 @@ function InfoTab({ cosmos, selectedNode, focusedLayer, onSelectNode }: InfoTabPr
                   color: "#a1a1aa",
                 }}
               >
-                {t}
+                {tag}
               </span>
             ))}
           </div>
         )}
         {outboundEdges.length > 0 && (
-          <div style={{ marginBottom: 10 }}>
-            <div style={{ fontSize: 9, letterSpacing: 0.4, textTransform: "uppercase", color: "#71717a", marginBottom: 4 }}>
+          <div style={{ marginBottom: 12 }}>
+            <div
+              style={{
+                fontSize: 9,
+                letterSpacing: 0.4,
+                textTransform: "uppercase",
+                color: "#71717a",
+                marginBottom: 5,
+              }}
+            >
               Outbound · {outboundEdges.length}
             </div>
-            {outboundEdges.slice(0, 5).map((e, i) => {
+            {outboundEdges.slice(0, 8).map((e, i) => {
               const target = cosmos.nodes.find((n) => n.id === e.target);
               if (!target) return null;
               return (
@@ -1480,32 +1986,43 @@ function InfoTab({ cosmos, selectedNode, focusedLayer, onSelectNode }: InfoTabPr
                     display: "block",
                     width: "100%",
                     textAlign: "left",
-                    padding: "3px 6px",
-                    fontSize: 10,
+                    padding: "4px 8px",
+                    fontSize: 11,
                     color: "#d4d4d8",
                     background: "transparent",
                     border: "none",
                     cursor: "pointer",
-                    borderRadius: 3,
+                    borderRadius: 4,
+                    transition: "background 100ms ease",
                   }}
-                  onMouseEnter={(ev) => (ev.currentTarget.style.background = "rgba(255,255,255,0.04)")}
+                  onMouseEnter={(ev) => (ev.currentTarget.style.background = "rgba(255,255,255,0.05)")}
                   onMouseLeave={(ev) => (ev.currentTarget.style.background = "transparent")}
                 >
                   <span style={{ color: "#71717a" }}>{e.type}</span> → {target.name}
                 </button>
               );
             })}
-            {outboundEdges.length > 5 && (
-              <div style={{ fontSize: 9, color: "#52525b", marginTop: 2 }}>+ {outboundEdges.length - 5} more</div>
+            {outboundEdges.length > 8 && (
+              <div style={{ fontSize: 9, color: "#52525b", marginTop: 2, paddingLeft: 8 }}>
+                + {outboundEdges.length - 8} more
+              </div>
             )}
           </div>
         )}
         {inboundEdges.length > 0 && (
-          <div style={{ marginBottom: 10 }}>
-            <div style={{ fontSize: 9, letterSpacing: 0.4, textTransform: "uppercase", color: "#71717a", marginBottom: 4 }}>
+          <div style={{ marginBottom: 12 }}>
+            <div
+              style={{
+                fontSize: 9,
+                letterSpacing: 0.4,
+                textTransform: "uppercase",
+                color: "#71717a",
+                marginBottom: 5,
+              }}
+            >
               Inbound · {inboundEdges.length}
             </div>
-            {inboundEdges.slice(0, 5).map((e, i) => {
+            {inboundEdges.slice(0, 8).map((e, i) => {
               const src = cosmos.nodes.find((n) => n.id === e.source);
               if (!src) return null;
               return (
@@ -1517,33 +2034,45 @@ function InfoTab({ cosmos, selectedNode, focusedLayer, onSelectNode }: InfoTabPr
                     display: "block",
                     width: "100%",
                     textAlign: "left",
-                    padding: "3px 6px",
-                    fontSize: 10,
+                    padding: "4px 8px",
+                    fontSize: 11,
                     color: "#d4d4d8",
                     background: "transparent",
                     border: "none",
                     cursor: "pointer",
-                    borderRadius: 3,
+                    borderRadius: 4,
+                    transition: "background 100ms ease",
                   }}
-                  onMouseEnter={(ev) => (ev.currentTarget.style.background = "rgba(255,255,255,0.04)")}
+                  onMouseEnter={(ev) => (ev.currentTarget.style.background = "rgba(255,255,255,0.05)")}
                   onMouseLeave={(ev) => (ev.currentTarget.style.background = "transparent")}
                 >
                   {src.name} <span style={{ color: "#71717a" }}>← {e.type}</span>
                 </button>
               );
             })}
-            {inboundEdges.length > 5 && (
-              <div style={{ fontSize: 9, color: "#52525b", marginTop: 2 }}>+ {inboundEdges.length - 5} more</div>
+            {inboundEdges.length > 8 && (
+              <div style={{ fontSize: 9, color: "#52525b", marginTop: 2, paddingLeft: 8 }}>
+                + {inboundEdges.length - 8} more
+              </div>
             )}
           </div>
         )}
       </div>
-    );
-  }
+    </aside>
+  );
+}
 
-  // (Perspectives no longer render here — they live in the TOUR tab
-  //  as variant walks. The INFO tab handles concrete-node selection
-  //  and layer focus only.)
+interface InfoTabProps {
+  cosmos: Cosmos;
+  focusedLayer: string | null;
+  onSelectNode: (n: CosmosNode | null) => void;
+}
+
+function InfoTab({ cosmos, focusedLayer, onSelectNode }: InfoTabProps) {
+  // Per-node detail moved to the right-side NodeDrawer. This tab keeps
+  // the project-level view (and the focused-layer summary) so the left
+  // panel and the drawer do different jobs and don't compete.
+  // (Perspectives live in the TOUR tab as variant walks.)
 
   // Focused layer (no node) → layer summary card
   if (focusedLayer) {
@@ -2390,7 +2919,6 @@ interface SidebarProps {
   focusedLayer: string | null;
   onFocusLayer: (id: string | null) => void;
   perspectiveCount: number;
-  selectedNode: CosmosNode | null;
   onSelectNode: (n: CosmosNode | null) => void;
   activeTour: ActiveTour | null;
   onStartOverallTour: () => void;
@@ -2412,7 +2940,6 @@ function Sidebar({
   focusedLayer,
   onFocusLayer,
   perspectiveCount,
-  selectedNode,
   onSelectNode,
   activeTour,
   onStartOverallTour,
@@ -2423,11 +2950,9 @@ function Sidebar({
   const { t } = useTranslation("cosmos");
   const [activeTab, setActiveTab] = useState<SidebarTab>("info");
 
-  // When a node gets selected, auto-switch to INFO tab so the user
-  // sees the detail without having to click the tab.
-  useEffect(() => {
-    if (selectedNode) setActiveTab("info");
-  }, [selectedNode]);
+  // Node selection no longer drives this panel — the right-side
+  // NodeDrawer handles per-node detail. The INFO tab stays on project /
+  // layer context so the two panels do different jobs.
   // When any tour (overall or perspective) starts, auto-switch to TOUR.
   useEffect(() => {
     if (activeTour) setActiveTab("tour");
@@ -2446,7 +2971,7 @@ function Sidebar({
         width: 268,
         flexShrink: 0,
         background: "rgba(24,24,27,0.6)",
-        borderLeft: "1px solid #27272a",
+        borderRight: "1px solid #27272a",
         color: "#d4d4d8",
         fontFamily: "Inter, sans-serif",
         fontSize: 12,
@@ -2573,7 +3098,6 @@ function Sidebar({
         {activeTab === "info" && (
           <InfoTab
             cosmos={cosmos}
-            selectedNode={selectedNode}
             focusedLayer={focusedLayer}
             onSelectNode={onSelectNode}
           />
@@ -3925,9 +4449,56 @@ export function CosmosPreview(props: ViewerPreviewProps) {
           </div>
         )}
       </div>
-      {/* Body: canvas + sidebar */}
+      {/* Body: sidebar (left) + canvas + drawer (right, overlays canvas) */}
       <div style={{ display: "flex", flex: 1, minHeight: 0, position: "relative" }}>
-        <div style={{ flex: 1, minWidth: 0 }}>
+        <Sidebar
+          cosmos={effectiveCosmos}
+          subgraphs={cosmos.subgraphs ?? []}
+          activeSubgraphId={activeSubgraphId}
+          onEnterSubgraph={(id) => {
+            // Entering a subgraph also resets the in-main session
+            // state that doesn't belong inside it: tours (their
+            // step nodes may not exist), the extra-anchor pile,
+            // primary selection. Force `detail` level — subgraphs
+            // are 10–15 nodes typically; project-overview's layer
+            // aggregation collapses them into mostly-empty cards.
+            setActiveTour(null);
+            handleClearExtraAnchors();
+            setSelectedNodeId(null);
+            setNavigationLevel("detail");
+            setActiveSubgraphId(id);
+          }}
+          onExitSubgraph={() => {
+            setActiveTour(null);
+            handleClearExtraAnchors();
+            setSelectedNodeId(null);
+            setActiveSubgraphId(null);
+          }}
+          navigationLevel={navigationLevel}
+          onNavigationLevel={setNavigationLevel}
+          persona={persona}
+          onPersona={setPersona}
+          focusedLayer={focusedLayer}
+          onFocusLayer={setFocusedLayer}
+          perspectiveCount={perspectiveCount}
+          onSelectNode={(n) => {
+            // Selecting from sidebar — auto-drop into detail so the
+            // node is actually visible on the canvas, then center on it.
+            if (n) {
+              setNavigationLevel("detail");
+              handleSelectNode(n);
+              setTimeout(() => navigateRef.current(n.id), 60);
+            } else {
+              handleSelectNode(null);
+            }
+          }}
+          activeTour={activeTour}
+          onStartOverallTour={handleStartOverallTour}
+          onStartPerspectiveTour={handleStartPerspectiveTour}
+          onEndTour={handleEndTour}
+          onTourStep={handleTourStep}
+        />
+        <div style={{ flex: 1, minWidth: 0, position: "relative" }}>
           <ReactFlowProvider>
             <Canvas
               cosmos={effectiveCosmos}
@@ -3990,40 +4561,10 @@ export function CosmosPreview(props: ViewerPreviewProps) {
             </button>
           )}
         </div>
-        <Sidebar
+        <NodeDrawer
           cosmos={effectiveCosmos}
-          subgraphs={cosmos.subgraphs ?? []}
-          activeSubgraphId={activeSubgraphId}
-          onEnterSubgraph={(id) => {
-            // Entering a subgraph also resets the in-main session
-            // state that doesn't belong inside it: tours (their
-            // step nodes may not exist), the extra-anchor pile,
-            // primary selection. Force `detail` level — subgraphs
-            // are 10–15 nodes typically; project-overview's layer
-            // aggregation collapses them into mostly-empty cards.
-            setActiveTour(null);
-            handleClearExtraAnchors();
-            setSelectedNodeId(null);
-            setNavigationLevel("detail");
-            setActiveSubgraphId(id);
-          }}
-          onExitSubgraph={() => {
-            setActiveTour(null);
-            handleClearExtraAnchors();
-            setSelectedNodeId(null);
-            setActiveSubgraphId(null);
-          }}
-          navigationLevel={navigationLevel}
-          onNavigationLevel={setNavigationLevel}
-          persona={persona}
-          onPersona={setPersona}
-          focusedLayer={focusedLayer}
-          onFocusLayer={setFocusedLayer}
-          perspectiveCount={perspectiveCount}
-          selectedNode={selectedNode}
+          node={selectedNode}
           onSelectNode={(n) => {
-            // Selecting from sidebar — auto-drop into detail so the
-            // node is actually visible on the canvas, then center on it.
             if (n) {
               setNavigationLevel("detail");
               handleSelectNode(n);
@@ -4032,11 +4573,7 @@ export function CosmosPreview(props: ViewerPreviewProps) {
               handleSelectNode(null);
             }
           }}
-          activeTour={activeTour}
-          onStartOverallTour={handleStartOverallTour}
-          onStartPerspectiveTour={handleStartPerspectiveTour}
-          onEndTour={handleEndTour}
-          onTourStep={handleTourStep}
+          onClose={() => handleSelectNode(null)}
         />
       </div>
 

--- a/src/i18n/locales/de/cosmos.json
+++ b/src/i18n/locales/de/cosmos.json
@@ -62,6 +62,7 @@
     "layer_focus_title": "Layer focus",
     "layer_focus_nodes": "Nodes in this layer ({{count}})",
     "sources_label": "Sources",
+    "excerpts_label": "Auszüge",
     "stack_label": "Stack",
     "outbound": "Outbound · {{count}}",
     "inbound": "Inbound · {{count}}",
@@ -177,7 +178,7 @@
   "source_kind": {
     "file": "FILE",
     "url": "URL",
-    "passage": "PASS",
+    "passage": "PASSAGE",
     "image": "IMG",
     "audio": "AUD",
     "video": "VID"

--- a/src/i18n/locales/en/cosmos.json
+++ b/src/i18n/locales/en/cosmos.json
@@ -62,6 +62,7 @@
     "layer_focus_title": "Layer focus",
     "layer_focus_nodes": "Nodes in this layer ({{count}})",
     "sources_label": "Sources",
+    "excerpts_label": "Excerpts",
     "stack_label": "Stack",
     "outbound": "Outbound · {{count}}",
     "inbound": "Inbound · {{count}}",
@@ -177,7 +178,7 @@
   "source_kind": {
     "file": "FILE",
     "url": "URL",
-    "passage": "PASS",
+    "passage": "PASSAGE",
     "image": "IMG",
     "audio": "AUD",
     "video": "VID"

--- a/src/i18n/locales/es/cosmos.json
+++ b/src/i18n/locales/es/cosmos.json
@@ -62,6 +62,7 @@
     "layer_focus_title": "Layer focus",
     "layer_focus_nodes": "Nodes in this layer ({{count}})",
     "sources_label": "Sources",
+    "excerpts_label": "Extractos",
     "stack_label": "Stack",
     "outbound": "Outbound · {{count}}",
     "inbound": "Inbound · {{count}}",
@@ -177,7 +178,7 @@
   "source_kind": {
     "file": "FILE",
     "url": "URL",
-    "passage": "PASS",
+    "passage": "PASSAGE",
     "image": "IMG",
     "audio": "AUD",
     "video": "VID"

--- a/src/i18n/locales/ja/cosmos.json
+++ b/src/i18n/locales/ja/cosmos.json
@@ -62,6 +62,7 @@
     "layer_focus_title": "Layer focus",
     "layer_focus_nodes": "Nodes in this layer ({{count}})",
     "sources_label": "Sources",
+    "excerpts_label": "抜粋",
     "stack_label": "Stack",
     "outbound": "Outbound · {{count}}",
     "inbound": "Inbound · {{count}}",
@@ -177,7 +178,7 @@
   "source_kind": {
     "file": "FILE",
     "url": "URL",
-    "passage": "PASS",
+    "passage": "PASSAGE",
     "image": "IMG",
     "audio": "AUD",
     "video": "VID"

--- a/src/i18n/locales/ko/cosmos.json
+++ b/src/i18n/locales/ko/cosmos.json
@@ -62,6 +62,7 @@
     "layer_focus_title": "Layer focus",
     "layer_focus_nodes": "Nodes in this layer ({{count}})",
     "sources_label": "Sources",
+    "excerpts_label": "발췌",
     "stack_label": "Stack",
     "outbound": "Outbound · {{count}}",
     "inbound": "Inbound · {{count}}",
@@ -177,7 +178,7 @@
   "source_kind": {
     "file": "FILE",
     "url": "URL",
-    "passage": "PASS",
+    "passage": "PASSAGE",
     "image": "IMG",
     "audio": "AUD",
     "video": "VID"

--- a/src/i18n/locales/zh-CN/cosmos.json
+++ b/src/i18n/locales/zh-CN/cosmos.json
@@ -62,6 +62,7 @@
     "layer_focus_title": "分层聚焦",
     "layer_focus_nodes": "本层节点（{{count}}）",
     "sources_label": "信源",
+    "excerpts_label": "摘录",
     "stack_label": "技术栈",
     "outbound": "出向 · {{count}}",
     "inbound": "入向 · {{count}}",

--- a/src/i18n/locales/zh-TW/cosmos.json
+++ b/src/i18n/locales/zh-TW/cosmos.json
@@ -62,6 +62,7 @@
     "layer_focus_title": "分层聚焦",
     "layer_focus_nodes": "本层节点（{{count}}）",
     "sources_label": "信源",
+    "excerpts_label": "摘錄",
     "stack_label": "技术栈",
     "outbound": "出向 · {{count}}",
     "inbound": "入向 · {{count}}",


### PR DESCRIPTION
## Summary

- **Right-side `NodeDrawer`** replaces the inline INFO node-detail surface. Left panel keeps project / layer / tour context; the drawer owns one-node context. Slides on selection, slides off on deselect / Escape; previous node stays through the close animation.
- **EXCERPTS section** in the drawer renders **image cards** (real source extracts via `excerpt.path`) and **quote cards** (passage `quote`) above the SOURCES chip strip — the goal is to let users *see and verify the origin* before clicking through. The chip strip remains as the "all refs" index below.
- **Schema additions** (purely additive — `normalizeCosmos` untouched):
  - `CosmosSourceRef` — every kind gains optional `locator?: string` and `excerpt?: { path, caption? }`. Open-ended `locator` covers what existing fields didn't: `p.23`, `5:32`, `bottom-left`, `verse 14`, `slide 7`, `figure 3`, `§4.2`.
  - `CosmosEdge` — gains optional `sources?: CosmosSourceRef[]` so the relationship claim itself can be grounded.
- **SKILL** gets a new "Visual anchoring — every node deserves a way home" chapter with the **hard rule** (`excerpt.path` MUST be a real source extract — cropped PDF page, video frame, UI screenshot — **NOT** AI-generated illustration), per-domain guidance, and shell recipes (`sips` / `pdftoppm` / `ffmpeg`) so the agent populates excerpts without leaving the conversation.
- **i18n** — new `info.excerpts_label` across all 7 locales (`en`, `zh-CN`, `zh-TW`, `ja`, `ko`, `es`, `de`); latin-locale `source_kind.passage` `PASS` → `PASSAGE` so the chip no longer reads as pass/fail. Excerpts header + chip kind tag both route through `t()` so the cards localize alongside the existing SOURCES strip.

## Why

Users open a cosmos to *dive into source*. A node without a way back to the artifact that produced it is a node they can't trust. Chips get them there in one click; excerpts get them there in zero — the user can verify the inference at a glance before committing to opening the underlying file.

The hard rule against generative imagery is load-bearing: concept illustrations belong on the canvas as cosmos nodes, not as excerpts on someone else's node. Conflating the two collapses the trust signal that makes the whole pattern work.

## Test plan

- [x] `bun run -b tsc --noEmit -p tsconfig.json` — no new TS errors under `modes/cosmos/`
- [x] `bun test src/i18n/__tests__/locale-parity.test.ts` — all 7 locales have the new `info.excerpts_label` key
- [x] Local dev server (cosmos mode, viewing mode against a seeded workspace) — sidebar renders on the left, clicking a node slides the drawer in from the right, EXCERPTS section shows image card + quote card when present, hides entirely when neither, SOURCES chip strip remains below
- [x] User screenshot verification — confirmed working; polish pass landed for header / chip / image-card density nits

## Out of scope (deliberate)

- In-viewer capture action (agent uses shell tools per design)
- AI / generative imagery integration (forbidden by design)
- Edge-source rendering in the viewer (schema landed; viewer UI for edge sources deferred)
- `cosmos-snapshot` shell helper (SKILL teaches the raw commands; helper packaging is follow-up if pain emerges)

🤖 Generated with [Claude Code](https://claude.com/claude-code)