### PR TITLE
fix: cosmos card wrap + density relayout + editor-open; collapsible chat status pill

### DIFF
--- a/modes/cosmos/viewer/CosmosPreview.tsx
+++ b/modes/cosmos/viewer/CosmosPreview.tsx
@@ -40,7 +40,9 @@ import type { Source } from "../../../core/types/source.js";
 import { useSource } from "../../../src/hooks/useSource.js";
 import { useStore } from "../../../src/store.js";
 import { getApiBase } from "../../../src/utils/api.js";
-import EditorPickerButton from "../../../src/components/EditorPickerButton.js";
+import EditorPickerButton, {
+  DEFAULT_EDITOR_LS_KEY,
+} from "../../../src/components/EditorPickerButton.js";
 import type {
   Cosmos,
   CosmosEdge,
@@ -215,6 +217,59 @@ function resolveSourcePath(
  *  `sourceRoot` is `cosmos.project.sourceRoot`; `projectRoot` is the
  *  project session's root (from store.projectContext). Either can
  *  rescue an agent-authored relative path — see resolveSourcePath. */
+/**
+ * Resolve which code editor to open files in. Prefers the user's saved
+ * default (shared with EditorPickerButton via DEFAULT_EDITOR_LS_KEY), and
+ * falls back to the first detected editor so files land in a code editor
+ * rather than the OS default handler (which sends e.g. .swift / .h / .c
+ * files to Xcode). Returns null when no editor is detected — caller then
+ * falls back to `/api/system/open`. */
+async function resolvePreferredEditorId(base: string): Promise<string | null> {
+  let stored: string | null = null;
+  try {
+    stored =
+      typeof window !== "undefined"
+        ? window.localStorage.getItem(DEFAULT_EDITOR_LS_KEY)
+        : null;
+  } catch {
+    stored = null;
+  }
+  try {
+    const res = await fetch(`${base}/api/system/editors`);
+    if (!res.ok) return null;
+    const data = (await res.json()) as { editors?: { id: string }[] };
+    const ids = (data.editors ?? []).map((e) => e.id);
+    if (ids.length === 0) return null;
+    if (stored && ids.includes(stored)) return stored;
+    return ids[0];
+  } catch {
+    return null;
+  }
+}
+
+/** Try to open a workspace file in the preferred code editor; returns
+ *  true on success. Caller falls back to the OS open handler on false. */
+async function tryOpenInEditor(
+  base: string,
+  headers: Record<string, string>,
+  path: string,
+): Promise<boolean> {
+  const editorId = await resolvePreferredEditorId(base);
+  if (!editorId) return false;
+  try {
+    const res = await fetch(`${base}/api/system/open-in-editor`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ editorId, path }),
+    });
+    if (!res.ok) return false;
+    const data = (await res.json().catch(() => ({}))) as { success?: boolean };
+    return data.success !== false;
+  } catch {
+    return false;
+  }
+}
+
 async function openSourceRef(
   ref: CosmosSourceRef,
   sourceRoot: string | undefined,
@@ -223,38 +278,40 @@ async function openSourceRef(
   const base = getApiBase();
   const headers = { "Content-Type": "application/json" };
   try {
-    let res: Response;
     if (ref.kind === "url") {
-      res = await fetch(`${base}/api/system/open-url`, {
+      const res = await fetch(`${base}/api/system/open-url`, {
         method: "POST",
         headers,
         body: JSON.stringify({ url: ref.url }),
       });
-    } else if (ref.kind === "passage") {
-      // Passages live inside files — open the file for now and let
-      // the user navigate to the locator manually. Editor-bridge
-      // upgrade to jump to a line/locator is deferred.
-      const path = resolveSourcePath(ref.file, sourceRoot, projectRoot);
-      res = await fetch(`${base}/api/system/open`, {
-        method: "POST",
-        headers,
-        body: JSON.stringify({ path }),
-      });
-    } else {
-      const path = resolveSourcePath(ref.path, sourceRoot, projectRoot);
-      res = await fetch(`${base}/api/system/open`, {
-        method: "POST",
-        headers,
-        body: JSON.stringify({ path }),
-      });
+      if (!res.ok) return { ok: false, message: `HTTP ${res.status}` };
+      const data = (await res.json().catch(() => ({}))) as { success?: boolean; message?: string };
+      if (data.success === false) return { ok: false, message: data.message ?? "open failed" };
+      return { ok: true };
     }
-    if (!res.ok) {
-      return { ok: false, message: `HTTP ${res.status}` };
+
+    // File + passage both resolve to a file path. Prefer opening in the
+    // user's code editor (Cursor / VS Code / …) so source files don't get
+    // routed to the OS default app (Xcode for .swift/.c/.h, etc.). Fall
+    // back to `/api/system/open` when no editor is detected or the editor
+    // open fails. Passage locator jumps are still deferred.
+    const path =
+      ref.kind === "passage"
+        ? resolveSourcePath(ref.file, sourceRoot, projectRoot)
+        : resolveSourcePath(ref.path, sourceRoot, projectRoot);
+
+    if (await tryOpenInEditor(base, headers, path)) {
+      return { ok: true };
     }
+
+    const res = await fetch(`${base}/api/system/open`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ path }),
+    });
+    if (!res.ok) return { ok: false, message: `HTTP ${res.status}` };
     const data = (await res.json().catch(() => ({}))) as { success?: boolean; message?: string };
-    if (data.success === false) {
-      return { ok: false, message: data.message ?? "open failed" };
-    }
+    if (data.success === false) return { ok: false, message: data.message ?? "open failed" };
     return { ok: true };
   } catch (err) {
     return { ok: false, message: err instanceof Error ? err.message : "open failed" };
@@ -337,14 +394,65 @@ function layoutLayerCards(
   return out;
 }
 
+// Content width inside a node card (NODE_W minus the 12px horizontal
+// padding on each side). Used by the height estimator to wrap text.
+const NODE_CONTENT_W = NODE_W - 24;
+
+/**
+ * Rough rendered text width. CJK / full-width glyphs are ~1em wide;
+ * Latin glyphs average ~0.55em. Good enough to estimate how many lines
+ * a string wraps to inside the card — we only need it to decide vertical
+ * spacing so cards don't overlap, not pixel-perfect measurement.
+ */
+function estimateTextWidth(text: string, fontSize: number): number {
+  let w = 0;
+  for (const ch of text) {
+    w += /[⺀-鿿＀-￯　-〿]/.test(ch) ? fontSize : fontSize * 0.55;
+  }
+  return w;
+}
+
+function estimateLines(text: string, fontSize: number, contentW: number): number {
+  return Math.max(1, Math.ceil(estimateTextWidth(text, fontSize) / contentW));
+}
+
+/**
+ * Estimate a node card's rendered height for the given persona. The card
+ * grows with content (wrapped name + optional summary + tags), and the
+ * layout must reserve that vertical space or denser personas overlap.
+ * Mirrors the markup in CosmosNodeCard: 10px top pad, ~14px type line,
+ * wrapped name, optional summary (clamped 2/4 lines), optional tags row,
+ * 10px bottom pad.
+ */
+function estimateNodeHeight(n: CosmosNode, persona: Persona): number {
+  const nameLines = estimateLines(n.name, 14, NODE_CONTENT_W);
+  let h = 10 + (10 + 2) + nameLines * 14 * 1.2 + 10;
+  if (persona !== "overview" && n.summary) {
+    const cap = persona === "deep-dive" ? 4 : 2;
+    const sumLines = Math.min(cap, estimateLines(n.summary, 11, NODE_CONTENT_W));
+    h += 6 + sumLines * 11 * 1.35;
+  }
+  if (persona === "deep-dive" && n.tags && n.tags.length > 0) {
+    // Tag chips wrap; assume ~2 chips per row at this width.
+    h += 6 + Math.ceil(Math.min(n.tags.length, 5) / 2) * 22;
+  }
+  return Math.max(NODE_H, Math.ceil(h));
+}
+
 function layout(
   nodes: CosmosNode[],
   edges: CosmosEdge[],
+  persona: Persona,
 ): Map<string, { x: number; y: number }> {
   const g = new dagre.graphlib.Graph();
   g.setGraph({ rankdir: "LR", ranksep: 80, nodesep: 36 });
   g.setDefaultEdgeLabel(() => ({}));
-  for (const n of nodes) g.setNode(n.id, { width: NODE_W, height: NODE_H });
+  const heights = new Map<string, number>();
+  for (const n of nodes) {
+    const h = estimateNodeHeight(n, persona);
+    heights.set(n.id, h);
+    g.setNode(n.id, { width: NODE_W, height: h });
+  }
   for (const e of edges) {
     // Dagre ignores edges to/from unknown nodes — guard so a malformed
     // cosmos.json doesn't take the whole viewer down.
@@ -356,7 +464,10 @@ function layout(
   const out = new Map<string, { x: number; y: number }>();
   for (const n of nodes) {
     const pos = g.node(n.id);
-    if (pos) out.set(n.id, { x: pos.x - NODE_W / 2, y: pos.y - NODE_H / 2 });
+    if (pos) {
+      const h = heights.get(n.id) ?? NODE_H;
+      out.set(n.id, { x: pos.x - NODE_W / 2, y: pos.y - h / 2 });
+    }
   }
   return out;
 }
@@ -407,7 +518,20 @@ function CosmosNodeCard({ data, selected }: NodeProps<RfNode<NodeData>>) {
       >
         {cosmosNode.type}
       </div>
-      <div style={{ fontSize: 14, fontWeight: 600, lineHeight: 1.2 }}>{cosmosNode.name}</div>
+      <div
+        style={{
+          fontSize: 14,
+          fontWeight: 600,
+          lineHeight: 1.2,
+          // Long unbroken tokens (e.g. FACET_DIFF_APPLY_REGISTRY) must
+          // wrap inside the fixed-width card instead of spilling past
+          // its right edge.
+          overflowWrap: "anywhere",
+          wordBreak: "break-word",
+        }}
+      >
+        {cosmosNode.name}
+      </div>
       {pendingDrill && (
         <div
           style={{
@@ -920,7 +1044,13 @@ function Canvas({
     return m;
   }, [cosmos.layers]);
 
-  const positions = useMemo(() => layout(cosmos.nodes, cosmos.edges), [cosmos.nodes, cosmos.edges]);
+  // Persona drives per-card height (summary lines + tags), so the layout
+  // must recompute when it changes — otherwise denser personas grow the
+  // cards into each other while the dagre spacing stays at overview size.
+  const positions = useMemo(
+    () => layout(cosmos.nodes, cosmos.edges, persona),
+    [cosmos.nodes, cosmos.edges, persona],
+  );
 
   // Set of node ids in the active focus neighborhood — anchors +
   // every node sharing an edge with any anchor. "Anchors" is the
@@ -1143,9 +1273,21 @@ function Canvas({
   // preserve every position (pure drag-preservation case). Otherwise
   // the layout itself changed (added/removed nodes, scope switch) —
   // accept the fresh Dagre positions wholesale.
+  // Track the persona the canvas last laid out under. A persona switch
+  // changes every card's height → the Dagre positions in `combinedNodes`
+  // are freshly recomputed and must win wholesale, even though the node-id
+  // set is unchanged (which would otherwise trigger drag-preservation and
+  // pin cards at their old, overlapping overview spacing).
+  const prevPersonaRef = useRef(persona);
   useEffect(() => {
+    const personaChanged = prevPersonaRef.current !== persona;
+    prevPersonaRef.current = persona;
     setNodes((prev) => {
       if (prev.length === 0) return combinedNodes;
+      if (personaChanged) {
+        // Re-layout for the new density — discard dragged positions.
+        return combinedNodes;
+      }
       const prevIds = new Set(prev.map((n) => n.id));
       const sameIdSet =
         prevIds.size === combinedNodes.length &&

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useStore } from "../store.js";
 import { forceReconnect } from "../ws.js";
@@ -91,7 +91,11 @@ function StatusDot() {
       <span className="text-cc-muted text-xs">{text}</span>
       {isDisconnected && (
         <button
-          onClick={forceReconnect}
+          onClick={(e) => {
+            // Don't let the click bubble to the pill's expand/collapse toggle.
+            e.stopPropagation();
+            forceReconnect();
+          }}
           className="text-cc-muted hover:text-cc-primary text-xs transition-colors cursor-pointer"
           title={t("reconnect")}
         >
@@ -128,6 +132,52 @@ function SessionInfo() {
           <span>ctx {session.context_used_percent}%</span>
         </>
       )}
+    </div>
+  );
+}
+
+const STATUS_EXPANDED_LS_KEY = "pneuma:chat-status-expanded";
+
+/**
+ * Floating status pill. Collapsed by default to just the status dot +
+ * state label (the only thing most glances need); clicking expands it to
+ * also show model / cost / context, and clicking again collapses. The
+ * preference is remembered in localStorage. The inner reconnect button
+ * stops propagation so it doesn't toggle the pill.
+ */
+function AgentStatusBar() {
+  const { t } = useTranslation("chat-panel");
+  const [expanded, setExpanded] = useState(() => {
+    if (typeof window === "undefined") return false;
+    return window.localStorage.getItem(STATUS_EXPANDED_LS_KEY) === "1";
+  });
+  const toggle = () => {
+    setExpanded((prev) => {
+      const next = !prev;
+      try {
+        window.localStorage.setItem(STATUS_EXPANDED_LS_KEY, next ? "1" : "0");
+      } catch {
+        /* localStorage unavailable — non-fatal */
+      }
+      return next;
+    });
+  };
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={toggle}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          toggle();
+        }
+      }}
+      title={expanded ? t("status.collapse") : t("status.expand")}
+      className="absolute top-4 right-4 z-10 flex items-center gap-3 px-4 py-1.5 bg-cc-surface/60 backdrop-blur-md border border-white/5 rounded-full shadow-sm cursor-pointer select-none hover:bg-cc-surface/80 transition-colors"
+    >
+      <StatusDot />
+      {expanded && <SessionInfo />}
     </div>
   );
 }
@@ -184,12 +234,7 @@ export default function ChatPanel() {
   return (
     <div className="flex flex-col h-full relative">
       {/* Agent status bar (floating pill) — hide in replay mode */}
-      {!replayMode && (
-        <div className="absolute top-4 right-4 z-10 flex items-center gap-3 px-4 py-1.5 bg-cc-surface/60 backdrop-blur-md border border-white/5 rounded-full shadow-sm">
-          <StatusDot />
-          <SessionInfo />
-        </div>
-      )}
+      {!replayMode && <AgentStatusBar />}
       <div className="flex-1 overflow-y-auto bg-grid-pattern p-4 pt-16 space-y-4 pb-36">
         {messages.length === 0 && !streaming && !activity && !replayMode && (
           <div className="text-cc-muted text-sm text-center mt-8">

--- a/src/components/EditorPickerButton.tsx
+++ b/src/components/EditorPickerButton.tsx
@@ -81,7 +81,7 @@ interface EditorPickerButtonProps {
   menuPosition?: "above" | "below";
 }
 
-const DEFAULT_EDITOR_LS_KEY = "pneuma:default-editor";
+export const DEFAULT_EDITOR_LS_KEY = "pneuma:default-editor";
 
 export default function EditorPickerButton({
   targetPath,

--- a/src/i18n/locales/de/chat-panel.json
+++ b/src/i18n/locales/de/chat-panel.json
@@ -5,7 +5,9 @@
     "cli_disconnected": "CLI getrennt",
     "running": "Läuft",
     "compacting": "Wird komprimiert",
-    "idle": "Inaktiv"
+    "idle": "Inaktiv",
+    "collapse": "Details ausblenden",
+    "expand": "Details anzeigen"
   },
   "reconnect": "Neu verbinden",
   "no_model": "kein Modell",

--- a/src/i18n/locales/en/chat-panel.json
+++ b/src/i18n/locales/en/chat-panel.json
@@ -5,7 +5,9 @@
     "cli_disconnected": "CLI Disconnected",
     "running": "Running",
     "compacting": "Compacting",
-    "idle": "Idle"
+    "idle": "Idle",
+    "collapse": "Collapse details",
+    "expand": "Show details"
   },
   "reconnect": "Reconnect",
   "no_model": "no model",

--- a/src/i18n/locales/es/chat-panel.json
+++ b/src/i18n/locales/es/chat-panel.json
@@ -5,7 +5,9 @@
     "cli_disconnected": "CLI desconectado",
     "running": "En ejecución",
     "compacting": "Compactando",
-    "idle": "Inactivo"
+    "idle": "Inactivo",
+    "collapse": "Ocultar detalles",
+    "expand": "Mostrar detalles"
   },
   "reconnect": "Reconectar",
   "no_model": "sin modelo",

--- a/src/i18n/locales/ja/chat-panel.json
+++ b/src/i18n/locales/ja/chat-panel.json
@@ -5,7 +5,9 @@
     "cli_disconnected": "CLI 切断",
     "running": "実行中",
     "compacting": "圧縮中",
-    "idle": "アイドル"
+    "idle": "アイドル",
+    "collapse": "詳細を隠す",
+    "expand": "詳細を表示"
   },
   "reconnect": "再接続",
   "no_model": "モデルなし",

--- a/src/i18n/locales/ko/chat-panel.json
+++ b/src/i18n/locales/ko/chat-panel.json
@@ -5,7 +5,9 @@
     "cli_disconnected": "CLI 연결 끊김",
     "running": "실행 중",
     "compacting": "압축 중",
-    "idle": "대기 중"
+    "idle": "대기 중",
+    "collapse": "세부 정보 숨기기",
+    "expand": "세부 정보 표시"
   },
   "reconnect": "재연결",
   "no_model": "모델 없음",

--- a/src/i18n/locales/zh-CN/chat-panel.json
+++ b/src/i18n/locales/zh-CN/chat-panel.json
@@ -5,7 +5,9 @@
     "cli_disconnected": "CLI 已断开",
     "running": "运行中",
     "compacting": "压缩中",
-    "idle": "空闲"
+    "idle": "空闲",
+    "collapse": "收起详情",
+    "expand": "显示详情"
   },
   "reconnect": "重新连接",
   "no_model": "未选择模型",

--- a/src/i18n/locales/zh-TW/chat-panel.json
+++ b/src/i18n/locales/zh-TW/chat-panel.json
@@ -5,7 +5,9 @@
     "cli_disconnected": "CLI 已斷線",
     "running": "執行中",
     "compacting": "壓縮中",
-    "idle": "閒置"
+    "idle": "閒置",
+    "collapse": "收起詳情",
+    "expand": "顯示詳情"
   },
   "reconnect": "重新連線",
   "no_model": "未選擇模型",


### PR DESCRIPTION
Small interaction fixes spotted in cosmos plus a generic chat-panel tweak.

## Cosmos viewer
1. **Long node names overflowing the card** — names had no wrap rule, so unbroken tokens (e.g. `FACET_DIFF_APPLY_REGISTRY`) spilled past the fixed 200px card. Now `overflowWrap: anywhere` + `word-break` so they wrap inside.
2. **Density switch didn't relayout → overlapping cards** — `layout()` reserved a fixed 60px height regardless of persona, while cards grow with summary lines + tags. Added `estimateNodeHeight(node, persona)` (wrapped name + clamped summary + tag rows; CJK ~1em, Latin ~0.55em) feeding real heights into dagre, and recompute positions on persona change. The position-sync effect previously preserved old positions whenever the node-id set was unchanged (drag-preservation), which a density switch trips — it now lets the fresh layout win on a persona change (selection/focus changes still preserve drags).
3. **Files opening in Xcode** — `openSourceRef` sent file/passage opens to the OS default handler. Now tries `/api/system/open-in-editor` with the saved default editor (shared `pneuma:default-editor` key with `EditorPickerButton`) / first detected editor, falling back to OS open only when none is detected. URLs still go to the browser.

## Chat panel
4. **Status pill too wide** — the floating top-right pill now collapses to just the status dot + state label (空闲/运行中) by default; click expands model · cost · ctx, click again collapses. Preference persisted in localStorage; reconnect button stops propagation. Added `status.collapse`/`status.expand` to all 7 locales.

## Verification
`bun run typecheck` → 0 errors. User confirmed the behaviour in a running dev session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)