### PR TITLE
feat(cosmos): Workflow-backed verified projection + trust badges

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -51,6 +51,7 @@
         "tailwindcss": "^4.0.0",
         "trash": "^10.1.1",
         "vite": "^7.3.1",
+        "zod": "^4.4.3",
         "zustand": "^5.0.0",
       },
       "devDependencies": {
@@ -1290,6 +1291,8 @@
     "xdg-trashdir": ["xdg-trashdir@3.1.0", "", { "dependencies": { "@sindresorhus/df": "^3.1.1", "mount-point": "^3.0.0", "user-home": "^2.0.0", "xdg-basedir": "^4.0.0" } }, "sha512-N1XQngeqMBoj9wM4ZFadVV2MymImeiFfYD+fJrNlcVcOHsJFFQe7n3b+aBoTPwARuq2HQxukfzVpQmAk1gN4sQ=="],
 
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "zustand": ["zustand@5.0.12", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g=="],
 

--- a/modes/cosmos/__tests__/schema.test.ts
+++ b/modes/cosmos/__tests__/schema.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Cosmos schema guard.
+ *
+ * Locks the three representations together so they can't drift:
+ *   1. `schema.ts` (zod, structured-output truth)
+ *   2. `types.ts`  (TS interfaces + normalizeCosmos, viewer truth)
+ *   3. the shipped seed cosmoses (real data the viewer renders)
+ *
+ * If a future edit changes one without the others, this suite fails.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { normalizeCosmos, type Cosmos } from "../types.js";
+import {
+  NODE_CATEGORIES,
+  NODE_COMPLEXITIES,
+  NODE_TRUST,
+  SOURCE_KINDS,
+  EDGE_DIRECTIONS,
+  allJsonSchemas,
+  toJsonSchema,
+  validateCosmos,
+  zNode,
+  zSourceRef,
+  type CosmosJsonSchemaName,
+} from "../schema.js";
+
+const SEED_DIR = join(import.meta.dir, "..", "seed");
+const SEEDS = ["en", "zh-CN"] as const;
+
+function loadSeed(locale: string): Cosmos {
+  const raw = JSON.parse(readFileSync(join(SEED_DIR, locale, "cosmos.json"), "utf8"));
+  return normalizeCosmos(raw);
+}
+
+describe("seed cosmoses satisfy the contract", () => {
+  for (const locale of SEEDS) {
+    test(`${locale} seed validates against zCosmos`, () => {
+      const cosmos = loadSeed(locale);
+      const { ok, errors } = validateCosmos(cosmos);
+      if (!ok) console.error(`${locale} seed errors:\n` + errors.join("\n"));
+      expect(errors).toEqual([]);
+      expect(ok).toBe(true);
+    });
+
+    test(`${locale} seed has the expected scale`, () => {
+      const cosmos = loadSeed(locale);
+      // Sanity: the seed is the bootstrap projection of pneuma-skills.
+      expect(cosmos.nodes.length).toBeGreaterThan(20);
+      expect(cosmos.layers.length).toBeGreaterThanOrEqual(3);
+      // Every node's layerId must resolve to a declared layer.
+      const layerIds = new Set(cosmos.layers.map((l) => l.id));
+      for (const node of cosmos.nodes) {
+        if (node.layerId) expect(layerIds.has(node.layerId)).toBe(true);
+      }
+      // Every edge endpoint must be a real node.
+      const nodeIds = new Set(cosmos.nodes.map((n) => n.id));
+      for (const edge of cosmos.edges) {
+        expect(nodeIds.has(edge.source)).toBe(true);
+        expect(nodeIds.has(edge.target)).toBe(true);
+      }
+    });
+  }
+});
+
+describe("enums mirror types.ts", () => {
+  // types.ts unions are compile-time only; assert the runtime arrays
+  // here match what the viewer's normalizer + UI expect. These literals
+  // are intentionally duplicated from types.ts so a rename there without
+  // updating schema.ts breaks the build review here.
+  test("node categories", () => {
+    expect([...NODE_CATEGORIES]).toEqual([
+      "code",
+      "config",
+      "docs",
+      "infra",
+      "data",
+      "domain",
+      "knowledge",
+      "other",
+    ]);
+  });
+  test("node complexities", () => {
+    expect([...NODE_COMPLEXITIES]).toEqual(["simple", "moderate", "complex"]);
+  });
+  test("source kinds", () => {
+    expect([...SOURCE_KINDS]).toEqual(["file", "url", "passage", "image", "audio", "video"]);
+  });
+  test("edge directions", () => {
+    expect([...EDGE_DIRECTIONS]).toEqual(["forward", "backward", "bidirectional"]);
+  });
+  test("trust levels", () => {
+    expect([...NODE_TRUST]).toEqual(["verified", "weak", "unverifiable"]);
+  });
+});
+
+describe("zod validators behave", () => {
+  test("a clean node parses", () => {
+    expect(
+      zNode.safeParse({
+        id: "fn-auth-login",
+        type: "function",
+        name: "login",
+        summary: "Authenticates a user.",
+        sources: [{ kind: "file", path: "src/auth.ts", range: [10, 40] }],
+      }).success,
+    ).toBe(true);
+  });
+
+  test("a node missing a required field is rejected", () => {
+    const r = zNode.safeParse({ id: "x", type: "function" });
+    expect(r.success).toBe(false);
+  });
+
+  test("each source kind round-trips", () => {
+    const refs = [
+      { kind: "file", path: "a.ts", range: [1, 2] },
+      { kind: "url", url: "https://example.com" },
+      { kind: "passage", file: "ch.md", locator: "¶12", quote: "..." },
+      { kind: "image", path: "x.png" },
+      { kind: "audio", path: "x.mp3", t: 5 },
+      { kind: "video", path: "x.mp4", t: 5 },
+    ];
+    for (const ref of refs) expect(zSourceRef.safeParse(ref).success).toBe(true);
+  });
+
+  test("an unknown source kind is rejected", () => {
+    expect(zSourceRef.safeParse({ kind: "tweet", url: "x" }).success).toBe(false);
+  });
+
+  test("validateCosmos surfaces flat errors", () => {
+    const r = validateCosmos({ version: "1", project: {}, nodes: "nope", edges: [], layers: [] });
+    expect(r.ok).toBe(false);
+    expect(r.errors.length).toBeGreaterThan(0);
+    expect(r.errors.every((e) => typeof e === "string")).toBe(true);
+  });
+});
+
+describe("derived JSON Schema is workflow-ready", () => {
+  const NAMES: CosmosJsonSchemaName[] = [
+    "cosmos",
+    "node",
+    "edge",
+    "perspective",
+    "partitionExtraction",
+    "crossEdges",
+    "nodeVerdict",
+    "verificationBatch",
+    "completeness",
+    "perspectiveSet",
+    "perspectiveJudgment",
+  ];
+
+  test("every stage schema generates an object schema", () => {
+    const all = allJsonSchemas();
+    for (const name of NAMES) {
+      const js = all[name] as { type?: string; properties?: unknown };
+      expect(js.type).toBe("object");
+      expect(js.properties).toBeDefined();
+    }
+  });
+
+  test("source refs become a oneOf discriminated by kind", () => {
+    const node = toJsonSchema("node") as {
+      properties: { sources: { items: { oneOf?: unknown[] } } };
+    };
+    const oneOf = node.properties.sources.items.oneOf;
+    expect(Array.isArray(oneOf)).toBe(true);
+    expect(oneOf!.length).toBe(SOURCE_KINDS.length);
+  });
+
+  test("the JSON Schema is serializable (no cycles, embeddable in a workflow)", () => {
+    const all = allJsonSchemas();
+    expect(() => JSON.stringify(all)).not.toThrow();
+  });
+});
+
+describe("projection.workflow.js stays in sync with zod", () => {
+  // The workflow runs as sandboxed plain JS and can't import schema.ts,
+  // so it inlines a copy of allJsonSchemas() between markers, regenerated
+  // by scripts/gen-workflow-schemas.ts. This test fails the moment the
+  // inlined literal drifts from the zod truth — run the generator to fix.
+  const WORKFLOW = join(import.meta.dir, "..", "skill", "references", "projection.workflow.js");
+
+  function extractInlinedSchemas(): unknown {
+    const src = readFileSync(WORKFLOW, "utf8");
+    const start = src.indexOf("// pneuma:schemas:start");
+    const end = src.indexOf("// pneuma:schemas:end");
+    expect(start).toBeGreaterThanOrEqual(0);
+    expect(end).toBeGreaterThan(start);
+    const block = src.slice(start, end);
+    const assignIdx = block.indexOf("const SCHEMAS =");
+    expect(assignIdx).toBeGreaterThanOrEqual(0);
+    const json = block.slice(assignIdx + "const SCHEMAS =".length).trim();
+    return JSON.parse(json);
+  }
+
+  test("inlined SCHEMAS equals allJsonSchemas() — regenerate if this fails", () => {
+    const inlined = extractInlinedSchemas();
+    expect(inlined).toEqual(allJsonSchemas());
+  });
+
+  test("the placeholder was actually replaced", () => {
+    const src = readFileSync(WORKFLOW, "utf8");
+    expect(src).not.toContain("__SCHEMAS__");
+  });
+});

--- a/modes/cosmos/manifest.ts
+++ b/modes/cosmos/manifest.ts
@@ -12,8 +12,14 @@ import { normalizeCosmos, type Cosmos } from "./types.js";
 
 const cosmosManifest: ModeManifest = {
   name: "cosmos",
-  version: "0.3.0",
+  version: "0.4.0",
   changelog: {
+    "0.4.0": [
+      "Workflow-backed projection (Path A, Claude Code): parallel per-partition extraction in fresh contexts → cross-edge merge → adversarial per-node verify → completeness loop → perspective judge-panel",
+      "Every node now carries a `trust` verdict (verified / weak / unverifiable); viewer renders a trust badge in the NodeDrawer header + hover tooltip",
+      "Graceful degradation: Codex / Kimi or small inputs fall back to the existing in-context passes (Path B)",
+      "schema.ts — zod is the structured-output truth; projection.workflow.js inlines derived JSON Schemas (drift-guarded by tests)",
+    ],
     "0.3.0": [
       "Source-chip clicks now resolve relative paths against project.sourceRoot or the project root",
       "SKILL: relative path + missing sourceRoot pitfall called out as a non-negotiable",

--- a/modes/cosmos/schema.ts
+++ b/modes/cosmos/schema.ts
@@ -1,0 +1,414 @@
+/**
+ * Cosmos schema — the single structured-output truth (zod-defined).
+ *
+ * `types.ts` is the TypeScript truth the viewer consumes at runtime
+ * (rich doc-comments, `normalizeCosmos`, deprecated-field migration).
+ * This module is the *validation + structured-output* truth:
+ *
+ *   - The zod schemas below are the source. `validateCosmos(value)`
+ *     and `safeParse` give the main agent a pre-write gate and the
+ *     tests a real validator (no hand-rolled checker).
+ *   - `jsonSchemas.*` are derived via `z.toJSONSchema` — plain JSON
+ *     Schema objects the projection Workflow inlines into its
+ *     `agent({ schema })` calls so every extracted node / edge /
+ *     perspective is validated at the tool-call layer.
+ *
+ * Why two representations (zod here, interfaces in `types.ts`)? The
+ * viewer wants documented interfaces + the legacy normalizer; the
+ * workflow wants JSON Schema literals it can embed (its sandbox has no
+ * imports). `__tests__/schema.test.ts` locks the two together by
+ * validating the shipped seed cosmoses (post-`normalizeCosmos`) against
+ * `zCosmos` and asserting the derived JSON Schema generates cleanly.
+ *
+ * The projection workflow (next step) cannot import this file — it runs
+ * as sandboxed plain JS. It will inline copies of `jsonSchemas.*`; a
+ * test compares the inlined literals against what `z.toJSONSchema`
+ * produces here, so drift turns the suite red.
+ */
+
+import { z } from "zod";
+
+/** Bump only on a breaking shape change; additive optional fields do not. */
+export const COSMOS_SCHEMA_VERSION = "0.1.0";
+
+// ── Enums (exported for reuse + the types.ts cross-check) ─────────────
+
+/** `CosmosNodeCategory` — the domain-agnostic chip-filter axis. */
+export const NODE_CATEGORIES = [
+  "code",
+  "config",
+  "docs",
+  "infra",
+  "data",
+  "domain",
+  "knowledge",
+  "other",
+] as const;
+
+/** `CosmosNodeComplexity`. */
+export const NODE_COMPLEXITIES = ["simple", "moderate", "complex"] as const;
+
+/**
+ * `node.trust` — verification verdict from the workflow's adversarial
+ * verify pass. Reserved now so the contract is stable from day one; the
+ * viewer's trust badge lands in a later step. `verified` = sources
+ * exist and substantiate the summary; `weak` = sourced but the cited
+ * material only partially supports the claim; `unverifiable` = no
+ * citable source could be confirmed (an inference).
+ */
+export const NODE_TRUST = ["verified", "weak", "unverifiable"] as const;
+
+/** `CosmosSourceRef` discriminants. */
+export const SOURCE_KINDS = ["file", "url", "passage", "image", "audio", "video"] as const;
+
+/** `CosmosEdge.direction`. */
+export const EDGE_DIRECTIONS = ["forward", "backward", "bidirectional"] as const;
+
+// ── Building blocks ──────────────────────────────────────────────────
+
+/** A real visual extract cropped from the source (never AI-generated). */
+export const zExcerpt = z.object({
+  path: z
+    .string()
+    .describe(
+      "Workspace-relative or absolute path to a REAL extract from the source (cropped PDF page, video frame, UI screenshot). Never an AI-generated illustration.",
+    ),
+  caption: z.string().optional().describe("Optional caption under the thumbnail."),
+});
+
+// Modelled as a 2-item number array (not a tuple) so the derived JSON
+// Schema uses minItems/maxItems rather than the draft-2020 `prefixItems`
+// keyword — the Workflow agent's validator runs an older draft.
+const zRange = z
+  .array(z.number())
+  .min(2)
+  .max(2)
+  .describe("Inclusive [start, end] line numbers.");
+
+const zLocator = z
+  .string()
+  .describe('Where-inside hint ("p.23", "5:32", "figure 3", "ch.3 ¶12", "nav-header").');
+
+/**
+ * `CosmosSourceRef` — the six-kind pointer back to a node's origin.
+ * A discriminated union on `kind`: each branch carries exactly its
+ * required fields. This is the spine of cosmos's trust model — every
+ * node cites where it came from, and the verify pass confirms the
+ * citation resolves.
+ */
+export const zSourceRef = z.discriminatedUnion("kind", [
+  z.object({
+    kind: z.literal("file"),
+    path: z.string(),
+    range: zRange.optional(),
+    label: z.string().optional(),
+    locator: zLocator.optional(),
+    excerpt: zExcerpt.optional(),
+  }),
+  z.object({
+    kind: z.literal("url"),
+    url: z.string(),
+    label: z.string().optional(),
+    locator: zLocator.optional(),
+    excerpt: zExcerpt.optional(),
+  }),
+  z.object({
+    kind: z.literal("passage"),
+    file: z.string(),
+    locator: z.string().describe("Required passage address — e.g. 'ch.3 ¶12', '§4.2', 'slide 7'."),
+    quote: z.string().optional().describe("Lifted text the inference rests on (≤80 chars)."),
+    label: z.string().optional(),
+    excerpt: zExcerpt.optional(),
+  }),
+  z.object({
+    kind: z.literal("image"),
+    path: z.string(),
+    label: z.string().optional(),
+    locator: zLocator.optional(),
+    excerpt: zExcerpt.optional(),
+  }),
+  z.object({
+    kind: z.literal("audio"),
+    path: z.string(),
+    t: z.number().optional().describe("Optional timestamp in seconds."),
+    label: z.string().optional(),
+    locator: zLocator.optional(),
+    excerpt: zExcerpt.optional(),
+  }),
+  z.object({
+    kind: z.literal("video"),
+    path: z.string(),
+    t: z.number().optional().describe("Optional timestamp in seconds."),
+    label: z.string().optional(),
+    locator: zLocator.optional(),
+    excerpt: zExcerpt.optional(),
+  }),
+]);
+
+/** `CosmosLayer` — drives node color + grouping. */
+export const zLayer = z.object({
+  id: z.string().describe("Stable id referenced by node.layerId."),
+  label: z.string(),
+  color: z.string().optional().describe("CSS color (hex / hsl)."),
+  description: z.string().optional(),
+});
+
+const zDomainMeta = z.object({
+  entities: z.array(z.string()).optional(),
+  businessRules: z.array(z.string()).optional(),
+  crossDomainInteractions: z.array(z.string()).optional(),
+  entryPoint: z.string().optional(),
+  entryType: z.string().optional(),
+});
+
+const zKnowledgeMeta = z.object({
+  wikilinks: z.array(z.string()).optional(),
+  backlinks: z.array(z.string()).optional(),
+  category: z.string().optional(),
+  content: z.string().optional(),
+});
+
+/** `CosmosNode` — a typed referent in the projection. */
+export const zNode = z.object({
+  id: z
+    .string()
+    .describe("Stable kebab-case id, short layer-hint prefix encouraged (c-eliot, fn-auth-login)."),
+  type: z
+    .string()
+    .describe("Open vocabulary for the content domain (file, character, claim, …). English kebab-case."),
+  name: z.string().describe("Display noun the user reads."),
+  summary: z.string().describe("One sentence, two at most."),
+  layerId: z.string().optional().describe("Must reference a layers[].id."),
+  category: z.enum(NODE_CATEGORIES).optional().describe("Domain-agnostic chip-filter axis."),
+  complexity: z.enum(NODE_COMPLEXITIES).optional(),
+  sources: z
+    .array(zSourceRef)
+    .optional()
+    .describe("Pointers back to the artifacts that produced this node. Most real nodes have 1–3."),
+  trust: z
+    .enum(NODE_TRUST)
+    .optional()
+    .describe("Verification verdict from the workflow's verify pass. Omit when unverified."),
+  languageNotes: z.string().optional(),
+  tags: z.array(z.string()).optional(),
+  domainMeta: zDomainMeta.optional(),
+  knowledgeMeta: zKnowledgeMeta.optional(),
+  meta: z.record(z.string(), z.unknown()).optional().describe("Opaque agent bag; framework ignores it."),
+});
+
+/** `CosmosEdge` — a labelled relationship. */
+export const zEdge = z.object({
+  source: z.string().describe("Source node id."),
+  target: z.string().describe("Target node id."),
+  type: z
+    .string()
+    .describe("Relationship verb (calls, imports, discovers, supports, …). Prefer specific over generic."),
+  direction: z.enum(EDGE_DIRECTIONS).optional().describe("Defaults to forward."),
+  description: z.string().optional(),
+  weight: z.number().optional().describe("Optional 0–1 emphasis."),
+  sources: z.array(zSourceRef).optional(),
+});
+
+/** `CosmosTourStep` — one beat of the canonical overall tour. */
+export const zTourStep = z.object({
+  step: z.number().int(),
+  nodeId: z.string(),
+  narrative: z.string(),
+});
+
+/** `CosmosPerspectiveStep` — one beat of a variant walk. */
+export const zPerspectiveStep = z.object({
+  focus: z
+    .array(z.string())
+    .min(1)
+    .describe("Node ids lit on this beat. First is the primary anchor."),
+  narrative: z.string().describe("THIS step's paragraph — not the perspective's thesis."),
+});
+
+/** `CosmosPerspective` — a variant tour framed by one design lens. */
+export const zPerspective = z.object({
+  id: z.string().describe("Stable id, prefix perspective-."),
+  name: z.string().describe("The lens phrased as a noun, in user language."),
+  lens: z.string().describe("Open vocabulary, English kebab-case (cybernetic-loop, tension, …)."),
+  insight: z.string().describe("One-paragraph thesis."),
+  steps: z.array(zPerspectiveStep).min(1),
+  evidence: z.string().optional(),
+  tags: z.array(z.string()).optional(),
+});
+
+/** `CosmosProject` — metadata about the projected work. */
+export const zProject = z.object({
+  name: z.string(),
+  kind: z.string().optional(),
+  description: z.string().optional(),
+  analyzedAt: z.string().optional(),
+  source: z.string().optional(),
+  sourceRoot: z
+    .string()
+    .optional()
+    .describe("Absolute path to the source root; relative refs resolve against it."),
+});
+
+/**
+ * Full `cosmos.json` schema — validates a complete (normalized)
+ * projection. `subgraphs[]` is deliberately omitted: drill-down is a
+ * runtime, user-driven concern, not something the projection workflow
+ * produces. Validate the main graph; let subgraphs ride the looser
+ * runtime path.
+ */
+export const zCosmos = z.object({
+  version: z.string(),
+  kind: z.enum(["codebase", "knowledge", "general"]).optional(),
+  project: zProject,
+  nodes: z.array(zNode),
+  edges: z.array(zEdge),
+  layers: z.array(zLayer),
+  tour: z.array(zTourStep).optional(),
+  perspectives: z.array(zPerspective).optional(),
+});
+
+// ── Workflow stage schemas ───────────────────────────────────────────
+// What each phase of the projection workflow forces its subagents to
+// return. They compose the building blocks above, so workflow output
+// and the cosmos the viewer renders share one contract.
+
+/** Phase "Extract" — one subagent per partition returns its slice. */
+export const zPartitionExtraction = z.object({
+  nodes: z.array(zNode),
+  edges: z.array(zEdge),
+  layers: z.array(zLayer).optional().describe("Layers this partition discovered; merge phase reconciles."),
+});
+
+/** Phase "Merge" — resolve edges that cross partition boundaries. */
+export const zCrossEdges = z.object({
+  edges: z.array(zEdge),
+});
+
+/** Phase "Verify" — one adversarial verdict on one node. */
+export const zNodeVerdict = z.object({
+  nodeId: z.string(),
+  trust: z.enum(NODE_TRUST),
+  reason: z.string().describe("Why this verdict — what the source did or did not substantiate."),
+  issues: z
+    .array(z.string())
+    .optional()
+    .describe("Concrete problems: missing file, range without the claimed content, fabricated excerpt."),
+});
+
+/**
+ * Phase "Verify" (batched) — one skeptic re-reads a partition's files
+ * and returns a verdict for every node that partition produced. Batching
+ * by partition re-grounds each node against its real sources at a
+ * fraction of the cost of a per-node skeptic; a future intensification
+ * can fan out N independent skeptics per node for the high-value graph.
+ */
+export const zVerificationBatch = z.object({
+  verdicts: z.array(zNodeVerdict),
+});
+
+/** Phase "Complete" — empty `gaps` is the loop-until-dry signal. */
+export const zCompleteness = z.object({
+  gaps: z.array(
+    z.object({
+      area: z.string().describe("The under-covered partition / concern / entrypoint."),
+      why: z.string().describe("What signal says it is under-covered."),
+      suggestedFocus: z.array(z.string()).optional().describe("Paths / symbols to re-extract."),
+    }),
+  ),
+});
+
+/**
+ * Phase "Perspectives" (generation) — one agent surveys the finished
+ * graph and proposes the perspectives whose lens actually fits, each
+ * grounded in concrete node ids. A judge panel then refutes the
+ * ungrounded ones (see `zPerspectiveJudgment`).
+ */
+export const zPerspectiveSet = z.object({
+  perspectives: z.array(zPerspective),
+});
+
+/** Phase "Perspectives" — a judge's verdict on one candidate. */
+export const zPerspectiveJudgment = z.object({
+  grounded: z.boolean(),
+  reason: z.string(),
+  weakSteps: z
+    .array(z.number().int())
+    .optional()
+    .describe("Indices of steps whose narrative just repeats the thesis or lacks concrete focus."),
+});
+
+// ── Derived JSON Schema (for the projection workflow) ─────────────────
+// The workflow inlines these literals into `agent({ schema })`. Kept as
+// a lazily-built map so importing this module stays cheap for the
+// viewer, which only needs the zod validators.
+
+export type CosmosJsonSchemaName =
+  | "cosmos"
+  | "node"
+  | "edge"
+  | "perspective"
+  | "partitionExtraction"
+  | "crossEdges"
+  | "nodeVerdict"
+  | "verificationBatch"
+  | "completeness"
+  | "perspectiveSet"
+  | "perspectiveJudgment";
+
+const ZOD_BY_NAME = {
+  cosmos: zCosmos,
+  node: zNode,
+  edge: zEdge,
+  perspective: zPerspective,
+  partitionExtraction: zPartitionExtraction,
+  crossEdges: zCrossEdges,
+  nodeVerdict: zNodeVerdict,
+  verificationBatch: zVerificationBatch,
+  completeness: zCompleteness,
+  perspectiveSet: zPerspectiveSet,
+  perspectiveJudgment: zPerspectiveJudgment,
+} satisfies Record<CosmosJsonSchemaName, z.ZodType>;
+
+/**
+ * Build the JSON Schema for one stage. The root `$schema` dialect
+ * declaration is stripped: the Workflow agent's validator (ajv) runs an
+ * older draft and rejects an unregistered 2020-12 meta-schema ref. The
+ * schemas themselves use only draft-07-compatible keywords.
+ */
+export function toJsonSchema(name: CosmosJsonSchemaName): Record<string, unknown> {
+  const js = z.toJSONSchema(ZOD_BY_NAME[name]) as Record<string, unknown>;
+  delete js.$schema;
+  return js;
+}
+
+/** All stage JSON Schemas, built on demand. */
+export function allJsonSchemas(): Record<CosmosJsonSchemaName, Record<string, unknown>> {
+  const out = {} as Record<CosmosJsonSchemaName, Record<string, unknown>>;
+  for (const name of Object.keys(ZOD_BY_NAME) as CosmosJsonSchemaName[]) {
+    out[name] = toJsonSchema(name);
+  }
+  return out;
+}
+
+// ── Validation helper ────────────────────────────────────────────────
+
+export interface CosmosValidation {
+  ok: boolean;
+  /** Flattened `path: message` issues; empty when ok. */
+  errors: string[];
+}
+
+/**
+ * Validate a full cosmos object (already normalized — run
+ * `normalizeCosmos` from types.ts first for legacy files). Returns a
+ * flat error list rather than throwing, so the main agent can gate a
+ * write and report problems inline.
+ */
+export function validateCosmos(value: unknown): CosmosValidation {
+  const result = zCosmos.safeParse(value);
+  if (result.success) return { ok: true, errors: [] };
+  return {
+    ok: false,
+    errors: result.error.issues.map((i) => `${i.path.join(".") || "$"}: ${i.message}`),
+  };
+}

--- a/modes/cosmos/scripts/gen-workflow-schemas.ts
+++ b/modes/cosmos/scripts/gen-workflow-schemas.ts
@@ -1,0 +1,36 @@
+/**
+ * Regenerate the inlined SCHEMAS literal in
+ * `references/projection.workflow.js` from the zod truth in
+ * `../schema.ts`.
+ *
+ * The projection workflow runs as sandboxed plain JS — it cannot import
+ * schema.ts — so the JSON Schemas must live in the file as a literal.
+ * This script keeps that literal in lockstep with zod; the sync test in
+ * `__tests__/schema.test.ts` fails if the file drifts from what this
+ * would produce.
+ *
+ *   bun modes/cosmos/scripts/gen-workflow-schemas.ts
+ */
+
+import { join } from "node:path";
+import { allJsonSchemas } from "../schema.ts";
+
+const WORKFLOW = join(import.meta.dir, "..", "skill", "references", "projection.workflow.js");
+const START = "// pneuma:schemas:start";
+const END = "// pneuma:schemas:end";
+
+// Compact (not pretty): this file is copied into every cosmos session's
+// skill dir, so keep the inlined literal small. The sync test parses it
+// regardless of formatting.
+const json = JSON.stringify(allJsonSchemas());
+const block = `${START}\nconst SCHEMAS = ${json}\n${END}`;
+
+const src = await Bun.file(WORKFLOW).text();
+const startIdx = src.indexOf(START);
+const endIdx = src.indexOf(END);
+if (startIdx === -1 || endIdx === -1) {
+  throw new Error(`gen-workflow-schemas: markers not found in ${WORKFLOW}`);
+}
+const next = src.slice(0, startIdx) + block + src.slice(endIdx + END.length);
+await Bun.write(WORKFLOW, next);
+console.log(`Injected ${Object.keys(allJsonSchemas()).length} schemas (${json.length} bytes) into ${WORKFLOW}`);

--- a/modes/cosmos/skill/SKILL.md
+++ b/modes/cosmos/skill/SKILL.md
@@ -415,7 +415,72 @@ Read `README.md` and skim `cosmos.json`; understanding the seed is
 understanding what cosmos is for. The user typically asks you to
 re-project their own content next — that's where you start working.
 
-### First-time projection
+### Choosing a projection path
+
+The first decision each projection is **which of two paths** produces it:
+
+- **Path A — Workflow-backed (large codebases, Claude Code).** When the
+  input is a codebase or a folder too large to read well in one context,
+  AND you have the `Workflow` tool (Claude Code backend only), hand the
+  heavy lifting to the projection workflow. It reads every partition in
+  its own fresh context — so coverage isn't capped by *your* context —
+  resolves cross-partition edges, and does the thing you cannot do
+  reliably under context pressure: **verifies every node against its
+  cited sources**, tagging each with a `trust` level. You stay the
+  author — you survey, launch it, add the tour, write `cosmos.json`.
+- **Path B — in-context (everything else).** A short story, a paper, a
+  conversation, a small folder — or *any* input when the `Workflow` tool
+  is absent (Codex / Kimi backends). You read and project it yourself,
+  in the passes below.
+
+**How to choose:** survey first — Glob the source, count files. A handful
+of files or a token-light single document → Path B. Dozens of source
+files / a real repo you can't hold in one context → Path A. No `Workflow`
+tool → always Path B. Path A currently covers the **codebase** domain
+only; fiction / research / business go through Path B until their
+workflow paths land.
+
+### Path A — Workflow-backed projection
+
+1. **Survey (cheap, in-context).** Glob the source; read `README`,
+   package manifests, entry points. From that decide:
+   - `partitions[]` — one per coherent subsystem (usually a top-level
+     dir): `{ id, label, paths: ["<relative dir/file>", …], hint }`.
+     Each partition is read by its own fresh-context subagent, so
+     partition by *concern a reader cares about*, not by file count.
+   - a draft `layers[]` table (3–6, by architectural concern), a
+     `vocabulary` (`{ nodeTypes, edgeTypes }`), the working `language`,
+     the absolute `sourceRoot`, and a `projectName`.
+2. **Launch the workflow:**
+
+   ```
+   Workflow({
+     scriptPath: ".claude/skills/pneuma-cosmos/references/projection.workflow.js",
+     args: { sourceRoot, language, projectName, partitions, vocabulary, layers, maxCompletenessRounds: 2 }
+   })
+   ```
+
+   Watch it in `/workflows`: Extract (parallel per partition) → Merge →
+   Verify → Complete (loop-until-dry). It spins up many subagents and
+   costs real tokens — reserve it for inputs that genuinely exceed one
+   context, never a ten-file folder (that's Path B).
+3. **Take the returned graph.** It returns `{ version, kind, project,
+   nodes, edges, layers, perspectives?, stats }` — every node already
+   carries a `trust` verdict and real `sources[]`, and `perspectives[]`
+   (if present) have already survived a judge panel for groundedness.
+   Read `stats.trust`: a healthy run is mostly `verified`; a pile of
+   `unverifiable` means the source wasn't where the extractor thought —
+   investigate before you ship it.
+4. **Add the tour (and prune if needed).** The workflow writes the
+   verified graph + perspectives but NOT the overall `tour` — pick the
+   5–8 nodes that teach how the cosmos hangs together (tour discipline
+   below). If the graph came back denser than a reader needs, prune
+   trivial nodes here before writing.
+5. **Write `cosmos.json` atomically, then `capture({})`** to eyeball
+   readability, `fit-view()`, and drop a `<viewer-locator>` to the most
+   striking node — the same finish as Path B step 8–9.
+
+### Path B — in-context projection
 
 1. **Read the input.** Whatever the user has dropped into the
    workspace — a file, a folder, a chapter — use Read / Glob / Grep

--- a/modes/cosmos/skill/references/projection-workflows.md
+++ b/modes/cosmos/skill/references/projection-workflows.md
@@ -10,7 +10,15 @@
 Strong inputs: a directory of source files, a single repo, a
 package. Token-heavy — use parallel reads aggressively.
 
-### Steps
+> **On Claude Code, prefer Path A** (the Workflow-backed projection in
+> SKILL.md). The projection workflow already does steps 3–5 below —
+> parallel per-partition extraction in fresh contexts, cross-edge merge,
+> *and* an adversarial verify pass the manual recipe can't afford. The
+> steps below are the **Path B fallback**: the in-context recipe for
+> when the `Workflow` tool is unavailable (Codex / Kimi) or the repo is
+> small enough to hold in one context. Don't run both.
+
+### Steps (Path B fallback)
 
 1. **Survey first.** `Glob` for source files, count by extension.
    Read `README.md`, `package.json` / `pyproject.toml` / `Cargo.toml`,

--- a/modes/cosmos/skill/references/projection.workflow.js
+++ b/modes/cosmos/skill/references/projection.workflow.js
@@ -1,0 +1,380 @@
+export const meta = {
+  name: 'cosmos-projection',
+  description:
+    'Project a codebase into a verified cosmos: parallel extract → merge cross-edges → adversarial verify → completeness loop. Returns nodes/edges/layers with a per-node trust verdict.',
+  phases: [
+    { title: 'Extract', detail: 'one subagent per partition, a fresh context each — reads the whole slice' },
+    { title: 'Merge', detail: 'dedup nodes/layers + resolve edges that cross partition boundaries' },
+    { title: 'Verify', detail: 'a skeptic re-reads each node’s cited sources and assigns trust' },
+    { title: 'Complete', detail: 'a critic names under-covered regions → targeted re-extract, loop until dry' },
+    { title: 'Perspectives', detail: 'propose variant walks per design lens → judge panel drops the ungrounded' },
+  ],
+}
+
+/*
+ * Cosmos projection workflow — the CC-native, Workflow-backed path for
+ * `cosmos` mode (codebase domain). The session agent runs the cheap
+ * deterministic survey (glob, count, read manifests, pick partitions +
+ * vocabulary + a draft layer table), then hands the result here via
+ * `args`. This script owns everything that a single context can't do
+ * well: reading the whole repo (one fresh context per partition),
+ * resolving cross-partition edges, and — the part cosmos never had —
+ * verifying every node against its cited sources before it ships.
+ *
+ * It returns the assembled graph (nodes/edges/layers + per-node trust)
+ * as data; the session agent writes cosmos.json, adds the tour, and
+ * drives the viewer. Perspectives + the trust badge are a later step.
+ *
+ * args: {
+ *   sourceRoot: string,                     // absolute path to the repo root
+ *   language?: string,                      // user working language for prose (default English)
+ *   partitions: Array<{                     // the survey's work-list
+ *     id: string, label?: string,
+ *     paths: string[],                      // sourceRoot-relative dirs/files this slice owns
+ *     hint?: string                         // optional steer ("the contract layer", "HTTP + WS")
+ *   }>,
+ *   vocabulary?: { nodeTypes?: string[], edgeTypes?: string[] },
+ *   layers?: Array<{ id, label, color?, description? }>,   // draft layer table from survey
+ *   projectName?: string,
+ *   maxCompletenessRounds?: number,         // default 2
+ * }
+ *
+ * The SCHEMAS literal below is GENERATED from modes/cosmos/schema.ts
+ * (the zod truth) — do not hand-edit. `__tests__/schema.test.ts`
+ * compares it against `allJsonSchemas()`, so any zod change without a
+ * regenerate turns the suite red. Regenerate with:
+ *   bun modes/cosmos/scripts/gen-workflow-schemas.ts
+ */
+
+// pneuma:schemas:start
+const SCHEMAS = {"cosmos":{"type":"object","properties":{"version":{"type":"string"},"kind":{"type":"string","enum":["codebase","knowledge","general"]},"project":{"type":"object","properties":{"name":{"type":"string"},"kind":{"type":"string"},"description":{"type":"string"},"analyzedAt":{"type":"string"},"source":{"type":"string"},"sourceRoot":{"description":"Absolute path to the source root; relative refs resolve against it.","type":"string"}},"required":["name"],"additionalProperties":false},"nodes":{"type":"array","items":{"type":"object","properties":{"id":{"type":"string","description":"Stable kebab-case id, short layer-hint prefix encouraged (c-eliot, fn-auth-login)."},"type":{"type":"string","description":"Open vocabulary for the content domain (file, character, claim, …). English kebab-case."},"name":{"type":"string","description":"Display noun the user reads."},"summary":{"type":"string","description":"One sentence, two at most."},"layerId":{"description":"Must reference a layers[].id.","type":"string"},"category":{"description":"Domain-agnostic chip-filter axis.","type":"string","enum":["code","config","docs","infra","data","domain","knowledge","other"]},"complexity":{"type":"string","enum":["simple","moderate","complex"]},"sources":{"description":"Pointers back to the artifacts that produced this node. Most real nodes have 1–3.","type":"array","items":{"oneOf":[{"type":"object","properties":{"kind":{"type":"string","const":"file"},"path":{"type":"string"},"range":{"minItems":2,"maxItems":2,"type":"array","items":{"type":"number"},"description":"Inclusive [start, end] line numbers."},"label":{"type":"string"},"locator":{"type":"string","description":"Where-inside hint (\"p.23\", \"5:32\", \"figure 3\", \"ch.3 ¶12\", \"nav-header\")."},"excerpt":{"type":"object","properties":{"path":{"type":"string","description":"Workspace-relative or absolute path to a REAL extract from the source (cropped PDF page, video frame, UI screenshot). Never an AI-generated illustration."},"caption":{"description":"Optional caption under the thumbnail.","type":"string"}},"required":["path"],"additionalProperties":false}},"required":["kind","path"],"additionalProperties":false},{"type":"object","properties":{"kind":{"type":"string","const":"url"},"url":{"type":"string"},"label":{"type":"string"},"locator":{"type":"string","description":"Where-inside hint (\"p.23\", \"5:32\", \"figure 3\", \"ch.3 ¶12\", \"nav-header\")."},"excerpt":{"type":"object","properties":{"path":{"type":"string","description":"Workspace-relative or absolute path to a REAL extract from the source (cropped PDF page, video frame, UI screenshot). Never an AI-generated illustration."},"caption":{"description":"Optional caption under the thumbnail.","type":"string"}},"required":["path"],"additionalProperties":false}},"required":["kind","url"],"additionalProperties":false},{"type":"object","properties":{"kind":{"type":"string","const":"passage"},"file":{"type":"string"},"locator":{"type":"string","description":"Required passage address — e.g. 'ch.3 ¶12', '§4.2', 'slide 7'."},"quote":{"description":"Lifted text the inference rests on (≤80 chars).","type":"string"},"label":{"type":"string"},"excerpt":{"type":"object","properties":{"path":{"type":"string","description":"Workspace-relative or absolute path to a REAL extract from the source (cropped PDF page, video frame, UI screenshot). Never an AI-generated illustration."},"caption":{"description":"Optional caption under the thumbnail.","type":"string"}},"required":["path"],"additionalProperties":false}},"required":["kind","file","locator"],"additionalProperties":false},{"type":"object","properties":{"kind":{"type":"string","const":"image"},"path":{"type":"string"},"label":{"type":"string"},"locator":{"type":"string","description":"Where-inside hint (\"p.23\", \"5:32\", \"figure 3\", \"ch.3 ¶12\", \"nav-header\")."},"excerpt":{"type":"object","properties":{"path":{"type":"string","description":"Workspace-relative or absolute path to a REAL extract from the source (cropped PDF page, video frame, UI screenshot). Never an AI-generated illustration."},"caption":{"description":"Optional caption under the thumbnail.","type":"string"}},"required":["path"],"additionalProperties":false}},"required":["kind","path"],"additionalProperties":false},{"type":"object","properties":{"kind":{"type":"string","const":"audio"},"path":{"type":"string"},"t":{"description":"Optional timestamp in seconds.","type":"number"},"label":{"type":"string"},"locator":{"type":"string","description":"Where-inside hint (\"p.23\", \"5:32\", \"figure 3\", \"ch.3 ¶12\", \"nav-header\")."},"excerpt":{"type":"object","properties":{"path":{"type":"string","description":"Workspace-relative or absolute path to a REAL extract from the source (cropped PDF page, video frame, UI screenshot). Never an AI-generated illustration."},"caption":{"description":"Optional caption under the thumbnail.","type":"string"}},"required":["path"],"additionalProperties":false}},"required":["kind","path"],"additionalProperties":false},{"type":"object","properties":{"kind":{"type":"string","const":"video"},"path":{"type":"string"},"t":{"description":"Optional timestamp in seconds.","type":"number"},"label":{"type":"string"},"locator":{"type":"string","description":"Where-inside hint (\"p.23\", \"5:32\", \"figure 3\", \"ch.3 ¶12\", \"nav-header\")."},"excerpt":{"type":"object","properties":{"path":{"type":"string","description":"Workspace-relative or absolute path to a REAL extract from the source (cropped PDF page, video frame, UI screenshot). Never an AI-generated illustration."},"caption":{"description":"Optional caption under the thumbnail.","type":"string"}},"required":["path"],"additionalProperties":false}},"required":["kind","path"],"additionalProperties":false}]}},"trust":{"description":"Verification verdict from the workflow's verify pass. Omit when unverified.","type":"string","enum":["verified","weak","unverifiable"]},"languageNotes":{"type":"string"},"tags":{"type":"array","items":{"type":"string"}},"domainMeta":{"type":"object","properties":{"entities":{"type":"array","items":{"type":"string"}},"businessRules":{"type":"array","items":{"type":"string"}},"crossDomainInteractions":{"type":"array","items":{"type":"string"}},"entryPoint":{"type":"string"},"entryType":{"type":"string"}},"additionalProperties":false},"knowledgeMeta":{"type":"object","properties":{"wikilinks":{"type":"array","items":{"type":"string"}},"backlinks":{"type":"array","items":{"type":"string"}},"category":{"type":"string"},"content":{"type":"string"}},"additionalProperties":false},"meta":{"description":"Opaque agent bag; framework ignores it.","type":"object","propertyNames":{"type":"string"},"additionalProperties":{}}},"required":["id","type","name","summary"],"additionalProperties":false}},"edges":{"type":"array","items":{"type":"object","properties":{"source":{"type":"string","description":"Source node id."},"target":{"type":"string","description":"Target node id."},"type":{"type":"string","description":"Relationship verb (calls, imports, discovers, supports, …). Prefer specific over generic."},"direction":{"description":"Defaults to forward.","type":"string","enum":["forward","backward","bidirectional"]},"description":{"type":"string"},"weight":{"description":"Optional 0–1 emphasis.","type":"number"},"sources":{"type":"array","items":{"oneOf":[{"type":"object","properties":{"kind":{"type":"string","const":"file"},"path":{"type":"string"},"range":{"minItems":2,"maxItems":2,"type":"array","items":{"type":"number"},"description":"Inclusive [start, end] line numbers."},"label":{"type":"string"},"locator":{"type":"string","description":"Where-inside hint (\"p.23\", \"5:32\", \"figure 3\", \"ch.3 ¶12\", \"nav-header\")."},"excerpt":{"type":"object","properties":{"path":{"type":"string","description":"Workspace-relative or absolute path to a REAL extract from the source (cropped PDF page, video frame, UI screenshot). Never an AI-generated illustration."},"caption":{"description":"Optional caption under the thumbnail.","type":"string"}},"required":["path"],"additionalProperties":false}},"required":["kind","path"],"additionalProperties":false},{"type":"object","properties":{"kind":{"type":"string","const":"url"},"url":{"type":"string"},"label":{"type":"string"},"locator":{"type":"string","description":"Where-inside hint (\"p.23\", \"5:32\", \"figure 3\", \"ch.3 ¶12\", \"nav-header\")."},"excerpt":{"type":"object","properties":{"path":{"type":"string","description":"Workspace-relative or absolute path to a REAL extract from the source (cropped PDF page, video frame, UI screenshot). Never an AI-generated illustration."},"caption":{"description":"Optional caption under the thumbnail.","type":"string"}},"required":["path"],"additionalProperties":false}},"required":["kind","url"],"additionalProperties":false},{"type":"object","properties":{"kind":{"type":"string","const":"passage"},"file":{"type":"string"},"locator":{"type":"string","description":"Required passage address — e.g. 'ch.3 ¶12', '§4.2', 'slide 7'."},"quote":{"description":"Lifted text the inference rests on (≤80 chars).","type":"string"},"label":{"type":"string"},"excerpt":{"type":"object","properties":{"path":{"type":"string","description":"Workspace-relative or absolute path to a REAL extract from the source (cropped PDF page, video frame, UI screenshot). Never an AI-generated illustration."},"caption":{"description":"Optional caption under the thumbnail.","type":"string"}},"required":["path"],"additionalProperties":false}},"required":["kind","file","locator"],"additionalProperties":false},{"type":"object","properties":{"kind":{"type":"string","const":"image"},"path":{"type":"string"},"label":{"type":"string"},"locator":{"type":"string","description":"Where-inside hint (\"p.23\", \"5:32\", \"figure 3\", \"ch.3 ¶12\", \"nav-header\")."},"excerpt":{"type":"object","properties":{"path":{"type":"string","description":"Workspace-relative or absolute path to a REAL extract from the source (cropped PDF page, video frame, UI screenshot). Never an AI-generated illustration."},"caption":{"description":"Optional caption under the thumbnail.","type":"string"}},"required":["path"],"additionalProperties":false}},"required":["kind","path"],"additionalProperties":false},{"type":"object","properties":{"kind":{"type":"string","const":"audio"},"path":{"type":"string"},"t":{"description":"Optional timestamp in seconds.","type":"number"},"label":{"type":"string"},"locator":{"type":"string","description":"Where-inside hint (\"p.23\", \"5:32\", \"figure 3\", \"ch.3 ¶12\", \"nav-header\")."},"excerpt":{"type":"object","properties":{"path":{"type":"string","description":"Workspace-relative or absolute path to a REAL extract from the source (cropped PDF page, video frame, UI screenshot). Never an AI-generated illustration."},"caption":{"description":"Optional caption under the thumbnail.","type":"string"}},"required":["path"],"additionalProperties":false}},"required":["kind","path"],"additionalProperties":false},{"type":"object","properties":{"kind":{"type":"string","const":"video"},"path":{"type":"string"},"t":{"description":"Optional timestamp in seconds.","type":"number"},"label":{"type":"string"},"locator":{"type":"string","description":"Where-inside hint (\"p.23\", \"5:32\", \"figure 3\", \"ch.3 ¶12\", \"nav-header\")."},"excerpt":{"type":"object","properties":{"path":{"type":"string","description":"Workspace-relative or absolute path to a REAL extract from the source (cropped PDF page, video frame, UI screenshot). Never an AI-generated illustration."},"caption":{"description":"Optional caption under the thumbnail.","type":"string"}},"required":["path"],"additionalProperties":false}},"required":["kind","path"],"additionalProperties":false}]}}},"required":["source","target","type"],"additionalProperties":false}},"layers":{"type":"array","items":{"type":"object","properties":{"id":{"type":"string","description":"Stable id referenced by node.layerId."},"label":{"type":"string"},"color":{"description":"CSS color (hex / hsl).","type":"string"},"description":{"type":"string"}},"required":["id","label"],"additionalProperties":false}},"tour":{"type":"array","items":{"type":"object","properties":{"step":{"type":"integer","minimum":-9007199254740991,"maximum":9007199254740991},"nodeId":{"type":"string"},"narrative":{"type":"string"}},"required":["step","nodeId","narrative"],"additionalProperties":false}},"perspectives":{"type":"array","items":{"type":"object","properties":{"id":{"type":"string","description":"Stable id, prefix perspective-."},"name":{"type":"string","description":"The lens phrased as a noun, in user language."},"lens":{"type":"string","description":"Open vocabulary, English kebab-case (cybernetic-loop, tension, …)."},"insight":{"type":"string","description":"One-paragraph thesis."},"steps":{"minItems":1,"type":"array","items":{"type":"object","properties":{"focus":{"minItems":1,"type":"array","items":{"type":"string"},"description":"Node ids lit on this beat. First is the primary anchor."},"narrative":{"type":"string","description":"THIS step's paragraph — not the perspective's thesis."}},"required":["focus","narrative"],"additionalProperties":false}},"evidence":{"type":"string"},"tags":{"type":"array","items":{"type":"string"}}},"required":["id","name","lens","insight","steps"],"additionalProperties":false}}},"required":["version","project","nodes","edges","layers"],"additionalProperties":false},"node":{"type":"object","properties":{"id":{"type":"string","description":"Stable kebab-case id, short layer-hint prefix encouraged (c-eliot, fn-auth-login)."},"type":{"type":"string","description":"Open vocabulary for the content domain (file, character, claim, …). English kebab-case."},"name":{"type":"string","description":"Display noun the user reads."},"summary":{"type":"string","description":"One sentence, two at most."},"layerId":{"description":"Must reference a layers[].id.","type":"string"},"category":{"description":"Domain-agnostic chip-filter axis.","type":"string","enum":["code","config","docs","infra","data","domain","knowledge","other"]},"complexity":{"type":"string","enum":["simple","moderate","complex"]},"sources":{"description":"Pointers back to the artifacts that produced this node. Most real nodes have 1–3.","type":"array","items":{"oneOf":[{"type":"object","properties":{"kind":{"type":"string","const":"file"},"path":{"type":"string"},"range":{"minItems":2,"maxItems":2,"type":"array","items":{"type":"number"},"description":"Inclusive [start, end] line numbers."},"label":{"type":"string"},"locator":{"type":"string","description":"Where-inside hint (\"p.23\", \"5:32\", \"figure 3\", \"ch.3 ¶12\", \"nav-header\")."},"excerpt":{"type":"object","properties":{"path":{"type":"string","description":"Workspace-relative or absolute path to a REAL extract from the source (cropped PDF page, video frame, UI screenshot). Never an AI-generated illustration."},"caption":{"description":"Optional caption under the thumbnail.","type":"string"}},"required":["path"],"additionalProperties":false}},"required":["kind","path"],"additionalProperties":false},{"type":"object","properties":{"kind":{"type":"string","const":"url"},"url":{"type":"string"},"label":{"type":"string"},"locator":{"type":"string","description":"Where-inside hint (\"p.23\", \"5:32\", \"figure 3\", \"ch.3 ¶12\", \"nav-header\")."},"excerpt":{"type":"object","properties":{"path":{"type":"string","description":"Workspace-relative or absolute path to a REAL extract from the source (cropped PDF page, video frame, UI screenshot). Never an AI-generated illustration."},"caption":{"description":"Optional caption under the thumbnail.","type":"string"}},"required":["path"],"additionalProperties":false}},"required":["kind","url"],"additionalProperties":false},{"type":"object","properties":{"kind":{"type":"string","const":"passage"},"file":{"type":"string"},"locator":{"type":"string","description":"Required passage address — e.g. 'ch.3 ¶12', '§4.2', 'slide 7'."},"quote":{"description":"Lifted text the inference rests on (≤80 chars).","type":"string"},"label":{"type":"string"},"excerpt":{"type":"object","properties":{"path":{"type":"string","description":"Workspace-relative or absolute path to a REAL extract from the source (cropped PDF page, video frame, UI screenshot). Never an AI-generated illustration."},"caption":{"description":"Optional caption under the thumbnail.","type":"string"}},"required":["path"],"additionalProperties":false}},"required":["kind","file","locator"],"additionalProperties":false},{"type":"object","properties":{"kind":{"type":"string","const":"image"},"path":{"type":"string"},"label":{"type":"string"},"locator":{"type":"string","description":"Where-inside hint (\"p.23\", \"5:32\", \"figure 3\", \"ch.3 ¶12\", \"nav-header\")."},"excerpt":{"type":"object","properties":{"path":{"type":"string","description":"Workspace-relative or absolute path to a REAL extract from the source (cropped PDF page, video frame, UI screenshot). Never an AI-generated illustration."},"caption":{"description":"Optional caption under the thumbnail.","type":"string"}},"required":["path"],"additionalProperties":false}},"required":["kind","path"],"additionalProperties":false},{"type":"object","properties":{"kind":{"type":"string","const":"audio"},"path":{"type":"string"},"t":{"description":"Optional timestamp in seconds.","type":"number"},"label":{"type":"string"},"locator":{"type":"string","description":"Where-inside hint (\"p.23\", \"5:32\", \"figure 3\", \"ch.3 ¶12\", \"nav-header\")."},"excerpt":{"type":"object","properties":{"path":{"type":"string","description":"Workspace-relative or absolute path to a REAL extract from the source (cropped PDF page, video frame, UI screenshot). Never an AI-generated illustration."},"caption":{"description":"Optional caption under the thumbnail.","type":"string"}},"required":["path"],"additionalProperties":false}},"required":["kind","path"],"additionalProperties":false},{"type":"object","properties":{"kind":{"type":"string","const":"video"},"path":{"type":"string"},"t":{"description":"Optional timestamp in seconds.","type":"number"},"label":{"type":"string"},"locator":{"type":"string","description":"Where-inside hint (\"p.23\", \"5:32\", \"figure 3\", \"ch.3 ¶12\", \"nav-header\")."},"excerpt":{"type":"object","properties":{"path":{"type":"string","description":"Workspace-relative or absolute path to a REAL extract from the source (cropped PDF page, video frame, UI screenshot). Never an AI-generated illustration."},"caption":{"description":"Optional caption under the thumbnail.","type":"string"}},"required":["path"],"additionalProperties":false}},"required":["kind","path"],"additionalProperties":false}]}},"trust":{"description":"Verification verdict from the workflow's verify pass. Omit when unverified.","type":"string","enum":["verified","weak","unverifiable"]},"languageNotes":{"type":"string"},"tags":{"type":"array","items":{"type":"string"}},"domainMeta":{"type":"object","properties":{"entities":{"type":"array","items":{"type":"string"}},"businessRules":{"type":"array","items":{"type":"string"}},"crossDomainInteractions":{"type":"array","items":{"type":"string"}},"entryPoint":{"type":"string"},"entryType":{"type":"string"}},"additionalProperties":false},"knowledgeMeta":{"type":"object","properties":{"wikilinks":{"type":"array","items":{"type":"string"}},"backlinks":{"type":"array","items":{"type":"string"}},"category":{"type":"string"},"content":{"type":"string"}},"additionalProperties":false},"meta":{"description":"Opaque agent bag; framework ignores it.","type":"object","propertyNames":{"type":"string"},"additionalProperties":{}}},"required":["id","type","name","summary"],"additionalProperties":false},"edge":{"type":"object","properties":{"source":{"type":"string","description":"Source node id."},"target":{"type":"string","description":"Target node id."},"type":{"type":"string","description":"Relationship verb (calls, imports, discovers, supports, …). Prefer specific over generic."},"direction":{"description":"Defaults to forward.","type":"string","enum":["forward","backward","bidirectional"]},"description":{"type":"string"},"weight":{"description":"Optional 0–1 emphasis.","type":"number"},"sources":{"type":"array","items":{"oneOf":[{"type":"object","properties":{"kind":{"type":"string","const":"file"},"path":{"type":"string"},"range":{"minItems":2,"maxItems":2,"type":"array","items":{"type":"number"},"description":"Inclusive [start, end] line numbers."},"label":{"type":"string"},"locator":{"type":"string","description":"Where-inside hint (\"p.23\", \"5:32\", \"figure 3\", \"ch.3 ¶12\", \"nav-header\")."},"excerpt":{"type":"object","properties":{"path":{"type":"string","description":"Workspace-relative or absolute path to a REAL extract from the source (cropped PDF page, video frame, UI screenshot). Never an AI-generated illustration."},"caption":{"description":"Optional caption under the thumbnail.","type":"string"}},"required":["path"],"additionalProperties":false}},"required":["kind","path"],"additionalProperties":false},{"type":"object","properties":{"kind":{"type":"string","const":"url"},"url":{"type":"string"},"label":{"type":"string"},"locator":{"type":"string","description":"Where-inside hint (\"p.23\", \"5:32\", \"figure 3\", \"ch.3 ¶12\", \"nav-header\")."},"excerpt":{"type":"object","properties":{"path":{"type":"string","description":"Workspace-relative or absolute path to a REAL extract from the source (cropped PDF page, video frame, UI screenshot). Never an AI-generated illustration."},"caption":{"description":"Optional caption under the thumbnail.","type":"string"}},"required":["path"],"additionalProperties":false}},"required":["kind","url"],"additionalProperties":false},{"type":"object","properties":{"kind":{"type":"string","const":"passage"},"file":{"type":"string"},"locator":{"type":"string","description":"Required passage address — e.g. 'ch.3 ¶12', '§4.2', 'slide 7'."},"quote":{"description":"Lifted text the inference rests on (≤80 chars).","type":"string"},"label":{"type":"string"},"excerpt":{"type":"object","properties":{"path":{"type":"string","description":"Workspace-relative or absolute path to a REAL extract from the source (cropped PDF page, video frame, UI screenshot). Never an AI-generated illustration."},"caption":{"description":"Optional caption under the thumbnail.","type":"string"}},"required":["path"],"additionalProperties":false}},"required":["kind","file","locator"],"additionalProperties":false},{"type":"object","properties":{"kind":{"type":"string","const":"image"},"path":{"type":"string"},"label":{"type":"string"},"locator":{"type":"string","description":"Where-inside hint (\"p.23\", \"5:32\", \"figure 3\", \"ch.3 ¶12\", \"nav-header\")."},"excerpt":{"type":"object","properties":{"path":{"type":"string","description":"Workspace-relative or absolute path to a REAL extract from the source (cropped PDF page, video frame, UI screenshot). Never an AI-generated illustration."},"caption":{"description":"Optional caption under the thumbnail.","type":"string"}},"required":["path"],"additionalProperties":false}},"required":["kind","path"],"additionalProperties":false},{"type":"object","properties":{"kind":{"type":"string","const":"audio"},"path":{"type":"string"},"t":{"description":"Optional timestamp in seconds.","type":"number"},"label":{"type":"string"},"locator":{"type":"string","description":"Where-inside hint (\"p.23\", \"5:32\", \"figure 3\", \"ch.3 ¶12\", \"nav-header\")."},"excerpt":{"type":"object","properties":{"path":{"type":"string","description":"Workspace-relative or absolute path to a REAL extract from the source (cropped PDF page, video frame, UI screenshot). Never an AI-generated illustration."},"caption":{"description":"Optional caption under the thumbnail.","type":"string"}},"required":["path"],"additionalProperties":false}},"required":["kind","path"],"additionalProperties":false},{"type":"object","properties":{"kind":{"type":"string","const":"video"},"path":{"type":"string"},"t":{"description":"Optional timestamp in seconds.","type":"number"},"label":{"type":"string"},"locator":{"type":"string","description":"Where-inside hint (\"p.23\", \"5:32\", \"figure 3\", \"ch.3 ¶12\", \"nav-header\")."},"excerpt":{"type":"object","properties":{"path":{"type":"string","description":"Workspace-relative or absolute path to a REAL extract from the source (cropped PDF page, video frame, UI screenshot). Never an AI-generated illustration."},"caption":{"description":"Optional caption under the thumbnail.","type":"string"}},"required":["path"],"additionalProperties":false}},"required":["kind","path"],"additionalProperties":false}]}}},"required":["source","target","type"],"additionalProperties":false},"perspective":{"type":"object","properties":{"id":{"type":"string","description":"Stable id, prefix perspective-."},"name":{"type":"string","description":"The lens phrased as a noun, in user language."},"lens":{"type":"string","description":"Open vocabulary, English kebab-case (cybernetic-loop, tension, …)."},"insight":{"type":"string","description":"One-paragraph thesis."},"steps":{"minItems":1,"type":"array","items":{"type":"object","properties":{"focus":{"minItems":1,"type":"array","items":{"type":"string"},"description":"Node ids lit on this beat. First is the primary anchor."},"narrative":{"type":"string","description":"THIS step's paragraph — not the perspective's thesis."}},"required":["focus","narrative"],"additionalProperties":false}},"evidence":{"type":"string"},"tags":{"type":"array","items":{"type":"string"}}},"required":["id","name","lens","insight","steps"],"additionalProperties":false},"partitionExtraction":{"type":"object","properties":{"nodes":{"type":"array","items":{"type":"object","properties":{"id":{"type":"string","description":"Stable kebab-case id, short layer-hint prefix encouraged (c-eliot, fn-auth-login)."},"type":{"type":"string","description":"Open vocabulary for the content domain (file, character, claim, …). English kebab-case."},"name":{"type":"string","description":"Display noun the user reads."},"summary":{"type":"string","description":"One sentence, two at most."},"layerId":{"description":"Must reference a layers[].id.","type":"string"},"category":{"description":"Domain-agnostic chip-filter axis.","type":"string","enum":["code","config","docs","infra","data","domain","knowledge","other"]},"complexity":{"type":"string","enum":["simple","moderate","complex"]},"sources":{"description":"Pointers back to the artifacts that produced this node. Most real nodes have 1–3.","type":"array","items":{"oneOf":[{"type":"object","properties":{"kind":{"type":"string","const":"file"},"path":{"type":"string"},"range":{"minItems":2,"maxItems":2,"type":"array","items":{"type":"number"},"description":"Inclusive [start, end] line numbers."},"label":{"type":"string"},"locator":{"type":"string","description":"Where-inside hint (\"p.23\", \"5:32\", \"figure 3\", \"ch.3 ¶12\", \"nav-header\")."},"excerpt":{"type":"object","properties":{"path":{"type":"string","description":"Workspace-relative or absolute path to a REAL extract from the source (cropped PDF page, video frame, UI screenshot). Never an AI-generated illustration."},"caption":{"description":"Optional caption under the thumbnail.","type":"string"}},"required":["path"],"additionalProperties":false}},"required":["kind","path"],"additionalProperties":false},{"type":"object","properties":{"kind":{"type":"string","const":"url"},"url":{"type":"string"},"label":{"type":"string"},"locator":{"type":"string","description":"Where-inside hint (\"p.23\", \"5:32\", \"figure 3\", \"ch.3 ¶12\", \"nav-header\")."},"excerpt":{"type":"object","properties":{"path":{"type":"string","description":"Workspace-relative or absolute path to a REAL extract from the source (cropped PDF page, video frame, UI screenshot). Never an AI-generated illustration."},"caption":{"description":"Optional caption under the thumbnail.","type":"string"}},"required":["path"],"additionalProperties":false}},"required":["kind","url"],"additionalProperties":false},{"type":"object","properties":{"kind":{"type":"string","const":"passage"},"file":{"type":"string"},"locator":{"type":"string","description":"Required passage address — e.g. 'ch.3 ¶12', '§4.2', 'slide 7'."},"quote":{"description":"Lifted text the inference rests on (≤80 chars).","type":"string"},"label":{"type":"string"},"excerpt":{"type":"object","properties":{"path":{"type":"string","description":"Workspace-relative or absolute path to a REAL extract from the source (cropped PDF page, video frame, UI screenshot). Never an AI-generated illustration."},"caption":{"description":"Optional caption under the thumbnail.","type":"string"}},"required":["path"],"additionalProperties":false}},"required":["kind","file","locator"],"additionalProperties":false},{"type":"object","properties":{"kind":{"type":"string","const":"image"},"path":{"type":"string"},"label":{"type":"string"},"locator":{"type":"string","description":"Where-inside hint (\"p.23\", \"5:32\", \"figure 3\", \"ch.3 ¶12\", \"nav-header\")."},"excerpt":{"type":"object","properties":{"path":{"type":"string","description":"Workspace-relative or absolute path to a REAL extract from the source (cropped PDF page, video frame, UI screenshot). Never an AI-generated illustration."},"caption":{"description":"Optional caption under the thumbnail.","type":"string"}},"required":["path"],"additionalProperties":false}},"required":["kind","path"],"additionalProperties":false},{"type":"object","properties":{"kind":{"type":"string","const":"audio"},"path":{"type":"string"},"t":{"description":"Optional timestamp in seconds.","type":"number"},"label":{"type":"string"},"locator":{"type":"string","description":"Where-inside hint (\"p.23\", \"5:32\", \"figure 3\", \"ch.3 ¶12\", \"nav-header\")."},"excerpt":{"type":"object","properties":{"path":{"type":"string","description":"Workspace-relative or absolute path to a REAL extract from the source (cropped PDF page, video frame, UI screenshot). Never an AI-generated illustration."},"caption":{"description":"Optional caption under the thumbnail.","type":"string"}},"required":["path"],"additionalProperties":false}},"required":["kind","path"],"additionalProperties":false},{"type":"object","properties":{"kind":{"type":"string","const":"video"},"path":{"type":"string"},"t":{"description":"Optional timestamp in seconds.","type":"number"},"label":{"type":"string"},"locator":{"type":"string","description":"Where-inside hint (\"p.23\", \"5:32\", \"figure 3\", \"ch.3 ¶12\", \"nav-header\")."},"excerpt":{"type":"object","properties":{"path":{"type":"string","description":"Workspace-relative or absolute path to a REAL extract from the source (cropped PDF page, video frame, UI screenshot). Never an AI-generated illustration."},"caption":{"description":"Optional caption under the thumbnail.","type":"string"}},"required":["path"],"additionalProperties":false}},"required":["kind","path"],"additionalProperties":false}]}},"trust":{"description":"Verification verdict from the workflow's verify pass. Omit when unverified.","type":"string","enum":["verified","weak","unverifiable"]},"languageNotes":{"type":"string"},"tags":{"type":"array","items":{"type":"string"}},"domainMeta":{"type":"object","properties":{"entities":{"type":"array","items":{"type":"string"}},"businessRules":{"type":"array","items":{"type":"string"}},"crossDomainInteractions":{"type":"array","items":{"type":"string"}},"entryPoint":{"type":"string"},"entryType":{"type":"string"}},"additionalProperties":false},"knowledgeMeta":{"type":"object","properties":{"wikilinks":{"type":"array","items":{"type":"string"}},"backlinks":{"type":"array","items":{"type":"string"}},"category":{"type":"string"},"content":{"type":"string"}},"additionalProperties":false},"meta":{"description":"Opaque agent bag; framework ignores it.","type":"object","propertyNames":{"type":"string"},"additionalProperties":{}}},"required":["id","type","name","summary"],"additionalProperties":false}},"edges":{"type":"array","items":{"type":"object","properties":{"source":{"type":"string","description":"Source node id."},"target":{"type":"string","description":"Target node id."},"type":{"type":"string","description":"Relationship verb (calls, imports, discovers, supports, …). Prefer specific over generic."},"direction":{"description":"Defaults to forward.","type":"string","enum":["forward","backward","bidirectional"]},"description":{"type":"string"},"weight":{"description":"Optional 0–1 emphasis.","type":"number"},"sources":{"type":"array","items":{"oneOf":[{"type":"object","properties":{"kind":{"type":"string","const":"file"},"path":{"type":"string"},"range":{"minItems":2,"maxItems":2,"type":"array","items":{"type":"number"},"description":"Inclusive [start, end] line numbers."},"label":{"type":"string"},"locator":{"type":"string","description":"Where-inside hint (\"p.23\", \"5:32\", \"figure 3\", \"ch.3 ¶12\", \"nav-header\")."},"excerpt":{"type":"object","properties":{"path":{"type":"string","description":"Workspace-relative or absolute path to a REAL extract from the source (cropped PDF page, video frame, UI screenshot). Never an AI-generated illustration."},"caption":{"description":"Optional caption under the thumbnail.","type":"string"}},"required":["path"],"additionalProperties":false}},"required":["kind","path"],"additionalProperties":false},{"type":"object","properties":{"kind":{"type":"string","const":"url"},"url":{"type":"string"},"label":{"type":"string"},"locator":{"type":"string","description":"Where-inside hint (\"p.23\", \"5:32\", \"figure 3\", \"ch.3 ¶12\", \"nav-header\")."},"excerpt":{"type":"object","properties":{"path":{"type":"string","description":"Workspace-relative or absolute path to a REAL extract from the source (cropped PDF page, video frame, UI screenshot). Never an AI-generated illustration."},"caption":{"description":"Optional caption under the thumbnail.","type":"string"}},"required":["path"],"additionalProperties":false}},"required":["kind","url"],"additionalProperties":false},{"type":"object","properties":{"kind":{"type":"string","const":"passage"},"file":{"type":"string"},"locator":{"type":"string","description":"Required passage address — e.g. 'ch.3 ¶12', '§4.2', 'slide 7'."},"quote":{"description":"Lifted text the inference rests on (≤80 chars).","type":"string"},"label":{"type":"string"},"excerpt":{"type":"object","properties":{"path":{"type":"string","description":"Workspace-relative or absolute path to a REAL extract from the source (cropped PDF page, video frame, UI screenshot). Never an AI-generated illustration."},"caption":{"description":"Optional caption under the thumbnail.","type":"string"}},"required":["path"],"additionalProperties":false}},"required":["kind","file","locator"],"additionalProperties":false},{"type":"object","properties":{"kind":{"type":"string","const":"image"},"path":{"type":"string"},"label":{"type":"string"},"locator":{"type":"string","description":"Where-inside hint (\"p.23\", \"5:32\", \"figure 3\", \"ch.3 ¶12\", \"nav-header\")."},"excerpt":{"type":"object","properties":{"path":{"type":"string","description":"Workspace-relative or absolute path to a REAL extract from the source (cropped PDF page, video frame, UI screenshot). Never an AI-generated illustration."},"caption":{"description":"Optional caption under the thumbnail.","type":"string"}},"required":["path"],"additionalProperties":false}},"required":["kind","path"],"additionalProperties":false},{"type":"object","properties":{"kind":{"type":"string","const":"audio"},"path":{"type":"string"},"t":{"description":"Optional timestamp in seconds.","type":"number"},"label":{"type":"string"},"locator":{"type":"string","description":"Where-inside hint (\"p.23\", \"5:32\", \"figure 3\", \"ch.3 ¶12\", \"nav-header\")."},"excerpt":{"type":"object","properties":{"path":{"type":"string","description":"Workspace-relative or absolute path to a REAL extract from the source (cropped PDF page, video frame, UI screenshot). Never an AI-generated illustration."},"caption":{"description":"Optional caption under the thumbnail.","type":"string"}},"required":["path"],"additionalProperties":false}},"required":["kind","path"],"additionalProperties":false},{"type":"object","properties":{"kind":{"type":"string","const":"video"},"path":{"type":"string"},"t":{"description":"Optional timestamp in seconds.","type":"number"},"label":{"type":"string"},"locator":{"type":"string","description":"Where-inside hint (\"p.23\", \"5:32\", \"figure 3\", \"ch.3 ¶12\", \"nav-header\")."},"excerpt":{"type":"object","properties":{"path":{"type":"string","description":"Workspace-relative or absolute path to a REAL extract from the source (cropped PDF page, video frame, UI screenshot). Never an AI-generated illustration."},"caption":{"description":"Optional caption under the thumbnail.","type":"string"}},"required":["path"],"additionalProperties":false}},"required":["kind","path"],"additionalProperties":false}]}}},"required":["source","target","type"],"additionalProperties":false}},"layers":{"description":"Layers this partition discovered; merge phase reconciles.","type":"array","items":{"type":"object","properties":{"id":{"type":"string","description":"Stable id referenced by node.layerId."},"label":{"type":"string"},"color":{"description":"CSS color (hex / hsl).","type":"string"},"description":{"type":"string"}},"required":["id","label"],"additionalProperties":false}}},"required":["nodes","edges"],"additionalProperties":false},"crossEdges":{"type":"object","properties":{"edges":{"type":"array","items":{"type":"object","properties":{"source":{"type":"string","description":"Source node id."},"target":{"type":"string","description":"Target node id."},"type":{"type":"string","description":"Relationship verb (calls, imports, discovers, supports, …). Prefer specific over generic."},"direction":{"description":"Defaults to forward.","type":"string","enum":["forward","backward","bidirectional"]},"description":{"type":"string"},"weight":{"description":"Optional 0–1 emphasis.","type":"number"},"sources":{"type":"array","items":{"oneOf":[{"type":"object","properties":{"kind":{"type":"string","const":"file"},"path":{"type":"string"},"range":{"minItems":2,"maxItems":2,"type":"array","items":{"type":"number"},"description":"Inclusive [start, end] line numbers."},"label":{"type":"string"},"locator":{"type":"string","description":"Where-inside hint (\"p.23\", \"5:32\", \"figure 3\", \"ch.3 ¶12\", \"nav-header\")."},"excerpt":{"type":"object","properties":{"path":{"type":"string","description":"Workspace-relative or absolute path to a REAL extract from the source (cropped PDF page, video frame, UI screenshot). Never an AI-generated illustration."},"caption":{"description":"Optional caption under the thumbnail.","type":"string"}},"required":["path"],"additionalProperties":false}},"required":["kind","path"],"additionalProperties":false},{"type":"object","properties":{"kind":{"type":"string","const":"url"},"url":{"type":"string"},"label":{"type":"string"},"locator":{"type":"string","description":"Where-inside hint (\"p.23\", \"5:32\", \"figure 3\", \"ch.3 ¶12\", \"nav-header\")."},"excerpt":{"type":"object","properties":{"path":{"type":"string","description":"Workspace-relative or absolute path to a REAL extract from the source (cropped PDF page, video frame, UI screenshot). Never an AI-generated illustration."},"caption":{"description":"Optional caption under the thumbnail.","type":"string"}},"required":["path"],"additionalProperties":false}},"required":["kind","url"],"additionalProperties":false},{"type":"object","properties":{"kind":{"type":"string","const":"passage"},"file":{"type":"string"},"locator":{"type":"string","description":"Required passage address — e.g. 'ch.3 ¶12', '§4.2', 'slide 7'."},"quote":{"description":"Lifted text the inference rests on (≤80 chars).","type":"string"},"label":{"type":"string"},"excerpt":{"type":"object","properties":{"path":{"type":"string","description":"Workspace-relative or absolute path to a REAL extract from the source (cropped PDF page, video frame, UI screenshot). Never an AI-generated illustration."},"caption":{"description":"Optional caption under the thumbnail.","type":"string"}},"required":["path"],"additionalProperties":false}},"required":["kind","file","locator"],"additionalProperties":false},{"type":"object","properties":{"kind":{"type":"string","const":"image"},"path":{"type":"string"},"label":{"type":"string"},"locator":{"type":"string","description":"Where-inside hint (\"p.23\", \"5:32\", \"figure 3\", \"ch.3 ¶12\", \"nav-header\")."},"excerpt":{"type":"object","properties":{"path":{"type":"string","description":"Workspace-relative or absolute path to a REAL extract from the source (cropped PDF page, video frame, UI screenshot). Never an AI-generated illustration."},"caption":{"description":"Optional caption under the thumbnail.","type":"string"}},"required":["path"],"additionalProperties":false}},"required":["kind","path"],"additionalProperties":false},{"type":"object","properties":{"kind":{"type":"string","const":"audio"},"path":{"type":"string"},"t":{"description":"Optional timestamp in seconds.","type":"number"},"label":{"type":"string"},"locator":{"type":"string","description":"Where-inside hint (\"p.23\", \"5:32\", \"figure 3\", \"ch.3 ¶12\", \"nav-header\")."},"excerpt":{"type":"object","properties":{"path":{"type":"string","description":"Workspace-relative or absolute path to a REAL extract from the source (cropped PDF page, video frame, UI screenshot). Never an AI-generated illustration."},"caption":{"description":"Optional caption under the thumbnail.","type":"string"}},"required":["path"],"additionalProperties":false}},"required":["kind","path"],"additionalProperties":false},{"type":"object","properties":{"kind":{"type":"string","const":"video"},"path":{"type":"string"},"t":{"description":"Optional timestamp in seconds.","type":"number"},"label":{"type":"string"},"locator":{"type":"string","description":"Where-inside hint (\"p.23\", \"5:32\", \"figure 3\", \"ch.3 ¶12\", \"nav-header\")."},"excerpt":{"type":"object","properties":{"path":{"type":"string","description":"Workspace-relative or absolute path to a REAL extract from the source (cropped PDF page, video frame, UI screenshot). Never an AI-generated illustration."},"caption":{"description":"Optional caption under the thumbnail.","type":"string"}},"required":["path"],"additionalProperties":false}},"required":["kind","path"],"additionalProperties":false}]}}},"required":["source","target","type"],"additionalProperties":false}}},"required":["edges"],"additionalProperties":false},"nodeVerdict":{"type":"object","properties":{"nodeId":{"type":"string"},"trust":{"type":"string","enum":["verified","weak","unverifiable"]},"reason":{"type":"string","description":"Why this verdict — what the source did or did not substantiate."},"issues":{"description":"Concrete problems: missing file, range without the claimed content, fabricated excerpt.","type":"array","items":{"type":"string"}}},"required":["nodeId","trust","reason"],"additionalProperties":false},"verificationBatch":{"type":"object","properties":{"verdicts":{"type":"array","items":{"type":"object","properties":{"nodeId":{"type":"string"},"trust":{"type":"string","enum":["verified","weak","unverifiable"]},"reason":{"type":"string","description":"Why this verdict — what the source did or did not substantiate."},"issues":{"description":"Concrete problems: missing file, range without the claimed content, fabricated excerpt.","type":"array","items":{"type":"string"}}},"required":["nodeId","trust","reason"],"additionalProperties":false}}},"required":["verdicts"],"additionalProperties":false},"completeness":{"type":"object","properties":{"gaps":{"type":"array","items":{"type":"object","properties":{"area":{"type":"string","description":"The under-covered partition / concern / entrypoint."},"why":{"type":"string","description":"What signal says it is under-covered."},"suggestedFocus":{"description":"Paths / symbols to re-extract.","type":"array","items":{"type":"string"}}},"required":["area","why"],"additionalProperties":false}}},"required":["gaps"],"additionalProperties":false},"perspectiveSet":{"type":"object","properties":{"perspectives":{"type":"array","items":{"type":"object","properties":{"id":{"type":"string","description":"Stable id, prefix perspective-."},"name":{"type":"string","description":"The lens phrased as a noun, in user language."},"lens":{"type":"string","description":"Open vocabulary, English kebab-case (cybernetic-loop, tension, …)."},"insight":{"type":"string","description":"One-paragraph thesis."},"steps":{"minItems":1,"type":"array","items":{"type":"object","properties":{"focus":{"minItems":1,"type":"array","items":{"type":"string"},"description":"Node ids lit on this beat. First is the primary anchor."},"narrative":{"type":"string","description":"THIS step's paragraph — not the perspective's thesis."}},"required":["focus","narrative"],"additionalProperties":false}},"evidence":{"type":"string"},"tags":{"type":"array","items":{"type":"string"}}},"required":["id","name","lens","insight","steps"],"additionalProperties":false}}},"required":["perspectives"],"additionalProperties":false},"perspectiveJudgment":{"type":"object","properties":{"grounded":{"type":"boolean"},"reason":{"type":"string"},"weakSteps":{"description":"Indices of steps whose narrative just repeats the thesis or lacks concrete focus.","type":"array","items":{"type":"integer","minimum":-9007199254740991,"maximum":9007199254740991}}},"required":["grounded","reason"],"additionalProperties":false}}
+// pneuma:schemas:end
+
+// args may arrive as an object or, depending on how the call is
+// serialized, as a JSON string — normalize both.
+let A = args
+if (typeof A === 'string') {
+  try { A = JSON.parse(A) } catch { A = {} }
+}
+A = A || {}
+log(`cosmos-projection: args is ${typeof args}; sourceRoot=${A.sourceRoot ? 'set' : 'MISSING'}; partitions=${Array.isArray(A.partitions) ? A.partitions.length : 0}`)
+
+const sourceRoot = A.sourceRoot
+const language = A.language || 'English'
+const partitions = Array.isArray(A.partitions) ? A.partitions : []
+const vocabulary = A.vocabulary || {}
+const draftLayers = Array.isArray(A.layers) ? A.layers : []
+const projectName = A.projectName || 'this codebase'
+const maxRounds = Number.isInteger(A.maxCompletenessRounds) ? A.maxCompletenessRounds : 2
+const withPerspectives = A.withPerspectives !== false
+
+if (!sourceRoot) throw new Error('cosmos-projection: args.sourceRoot is required')
+if (!partitions.length) throw new Error('cosmos-projection: args.partitions[] is required — run the survey first')
+
+// ── Shared prompt fragments ──────────────────────────────────────────
+
+const VOCAB = [
+  vocabulary.nodeTypes?.length ? `Node types to prefer: ${vocabulary.nodeTypes.join(', ')}.` : '',
+  vocabulary.edgeTypes?.length ? `Edge verbs to prefer: ${vocabulary.edgeTypes.join(', ')}.` : '',
+].filter(Boolean).join(' ')
+
+const RULES = `
+Discipline (cosmos projection):
+- Prose fields (name, summary) in ${language}; the type system stays English kebab-case (node.type, edge.type, layer.id, ids).
+- Node ids are stable kebab-case with a short layer hint (ct-mode-manifest, fn-auth-login, svc-ws-bridge). Reuse the obvious id if a node recurs.
+- summary is ONE sentence (two max). Node only what the user would click on: a module, a contract, a service, a load-bearing function or class. A leaf with one caller and no callees is a TAG on its caller, not its own node. Prefer one node that abstracts a small file over five nodes for its internals — aim for the projection a reader needs, not an exhaustive symbol dump.
+- Every node MUST cite real sources: sources:[{kind:"file", path:"<relative-to-sourceRoot>", range?:[start,end]}]. Paths are relative to the repo root, NEVER absolute, NEVER invented. Prefer a range over citing a 2000-line file bare.
+- Edges use specific verbs (calls/imports/implements/depends_on/produces) over generic relates_to. source/target are node ids you emit.
+- Assign each node a layerId from the layer table below when one fits.`
+
+const LAYER_TABLE = draftLayers.length
+  ? `Draft layer table (use these ids; propose new layers only if a concern genuinely isn't covered):\n${draftLayers.map(l => `  - ${l.id}: ${l.label || ''}`).join('\n')}`
+  : `No draft layers given — propose a coherent 3–6 layer table by architectural concern (e.g. api / service / data / ui / config) and assign every node a layerId.`
+
+function extractPrompt(p) {
+  return `You are projecting ONE slice of a codebase at ${sourceRoot} into cosmos nodes + edges.
+
+Slice "${p.id}"${p.label ? ` (${p.label})` : ''} owns these paths (relative to the repo root):
+${(p.paths || []).map(x => `  - ${x}`).join('\n')}
+${p.hint ? `\nFocus hint: ${p.hint}` : ''}
+
+Read the files in this slice thoroughly (Glob/Grep/Read under those paths). The projection's quality is gated by how much you actually read — you have a fresh context, so read the whole slice, not a sample.
+
+Extract the meaningful nodes (modules, contracts, services, key functions/classes, config surfaces) and the edges between them. Include edges to nodes OUTSIDE this slice when you can name them by a stable id (the merge step reconciles them).
+
+${VOCAB}
+${LAYER_TABLE}
+${RULES}
+
+Return {nodes, edges, layers?} for THIS slice only.`
+}
+
+function crossEdgePrompt(nodeIndex) {
+  return `Below is the full node index of a cosmos assembled from several codebase slices projected independently. Each was blind to the others, so edges that cross slice boundaries are likely MISSING.
+
+Node index (id — type — name — layer):
+${nodeIndex}
+
+Identify edges that cross between slices and aren't obvious within a single slice: a service calling a data-layer function, a route mounting a handler, a contract consumed by a viewer. Use specific verbs. Only emit edges whose source AND target are ids in the index above. Do not duplicate trivial within-file edges.
+
+Return {edges}.`
+}
+
+function verifyPrompt(p, nodes) {
+  return `You are a SKEPTIC verifying part of a cosmos projection against the real source at ${sourceRoot}.
+
+For each node below, READ its cited sources (paths are relative to the repo root) and decide whether the source substantiates the node's summary. Try to REFUTE — default to a lower trust when unsure. Specifically:
+- "verified": the cited file/range exists and clearly substantiates name + summary.
+- "weak": sourced, but the cited material only partially supports the claim, the range is too broad to trust, or the summary overreaches.
+- "unverifiable": the cited path doesn't exist, the range doesn't contain the claimed content, or there is no citable source at all (a pure inference).
+
+Nodes:
+${nodes.map(n => `- ${n.id} [${n.type}] "${n.name}": ${n.summary}\n    sources: ${JSON.stringify(n.sources || [])}`).join('\n')}
+
+Return {verdicts:[{nodeId, trust, reason, issues?}]} with one verdict per node above.`
+}
+
+function completenessPrompt(nodeIndex, partitionsDesc) {
+  return `A cosmos has been projected from this codebase at ${sourceRoot}. Your job is to find what the projection MISSED — be a completeness critic, not a cheerleader.
+
+Partitions that were projected:
+${partitionsDesc}
+
+Current node index (id — type — name):
+${nodeIndex}
+
+Look for under-coverage: a partition with suspiciously few nodes for its size; a concern named in README/manifests with no representation; an entrypoint (bin/*, index.ts, server bootstrap) that isn't reachable in the graph; a whole subsystem absent. For each real gap, give a concrete area and suggestedFocus (paths/symbols to re-extract). If coverage looks genuinely complete, return an empty gaps array — that is the signal to stop.
+
+Return {gaps:[{area, why, suggestedFocus?}]}.`
+}
+
+function gapExtractPrompt(gap) {
+  return `Fill a coverage gap in a codebase cosmos at ${sourceRoot}.
+
+Gap: ${gap.area}
+Why it matters: ${gap.why}
+Re-extract these paths/symbols (relative to the repo root):
+${(gap.suggestedFocus || []).map(x => `  - ${x}`).join('\n')}
+
+Read them and emit the missing nodes + edges. Reuse existing ids when an edge points at an already-known node.
+
+${VOCAB}
+${LAYER_TABLE}
+${RULES}
+
+Return {nodes, edges, layers?}.`
+}
+
+// ── Orchestration ────────────────────────────────────────────────────
+
+const nodeById = new Map()
+const partitionOfNode = new Map()
+const layerById = new Map()
+const edgeKeys = new Set()
+const edges = []
+
+for (const l of draftLayers) if (l?.id) layerById.set(l.id, l)
+
+function addNode(n, partId) {
+  if (!n || typeof n.id !== 'string') return false
+  if (nodeById.has(n.id)) return false
+  nodeById.set(n.id, n)
+  partitionOfNode.set(n.id, partId)
+  return true
+}
+function addLayer(l) {
+  if (l?.id && !layerById.has(l.id)) layerById.set(l.id, l)
+}
+function addEdge(e) {
+  if (!e || typeof e.source !== 'string' || typeof e.target !== 'string') return
+  const key = `${e.source}|${e.target}|${e.type}`
+  if (edgeKeys.has(key)) return
+  edgeKeys.add(key)
+  edges.push(e)
+}
+
+// Phase 1 — parallel extraction (barrier: merge needs all slices).
+phase('Extract')
+const slices = await parallel(
+  partitions.map((p, i) => () =>
+    agent(extractPrompt(p), {
+      schema: SCHEMAS.partitionExtraction,
+      phase: 'Extract',
+      label: `extract:${p.id || i}`,
+    }).then((r) => ({ partition: p, ...r })),
+  ),
+)
+for (const slice of slices.filter(Boolean)) {
+  for (const l of slice.layers || []) addLayer(l)
+  for (const n of slice.nodes || []) addNode(n, slice.partition.id)
+  for (const e of slice.edges || []) addEdge(e)
+}
+log(`extracted ${nodeById.size} nodes, ${edges.length} edges from ${partitions.length} partitions`)
+
+// Phase 2 — merge: resolve cross-partition edges.
+phase('Merge')
+const nodeIndex = () =>
+  [...nodeById.values()].map((n) => `${n.id} — ${n.type} — ${n.name} — ${n.layerId || '?'}`).join('\n')
+const cross = await agent(crossEdgePrompt(nodeIndex()), {
+  schema: SCHEMAS.crossEdges,
+  phase: 'Merge',
+  label: 'cross-edges',
+}).catch(() => ({ edges: [] }))
+for (const e of cross.edges || []) addEdge(e)
+
+// Phase 3 — adversarial verify, batched by partition.
+phase('Verify')
+async function verifyNodes(nodeList, labelTag) {
+  if (!nodeList.length) return
+  const batch = await agent(verifyPrompt({ id: labelTag }, nodeList), {
+    schema: SCHEMAS.verificationBatch,
+    phase: 'Verify',
+    label: `verify:${labelTag}`,
+  }).catch(() => ({ verdicts: [] }))
+  for (const v of batch.verdicts || []) {
+    const n = nodeById.get(v.nodeId)
+    if (n) n.trust = v.trust
+  }
+}
+await parallel(
+  partitions.map((p, i) => () =>
+    verifyNodes(
+      [...nodeById.values()].filter((n) => partitionOfNode.get(n.id) === p.id),
+      p.id || String(i),
+    ),
+  ),
+)
+
+// Phase 4 — completeness loop (loop-until-dry, capped).
+let round = 0
+while (round < maxRounds) {
+  phase('Complete')
+  const partitionsDesc = partitions.map((p) => `  - ${p.id}: ${(p.paths || []).join(', ')}`).join('\n')
+  const crit = await agent(completenessPrompt(nodeIndex(), partitionsDesc), {
+    schema: SCHEMAS.completeness,
+    phase: 'Complete',
+    label: `critic:round-${round + 1}`,
+  }).catch(() => ({ gaps: [] }))
+  const gaps = (crit.gaps || []).filter((g) => (g.suggestedFocus || []).length)
+  if (!gaps.length) {
+    log(`completeness round ${round + 1}: no actionable gaps — converged`)
+    break
+  }
+  const fills = await parallel(
+    gaps.map((g, i) => () =>
+      agent(gapExtractPrompt(g), {
+        schema: SCHEMAS.partitionExtraction,
+        phase: 'Complete',
+        label: `fill:${round + 1}.${i}`,
+      }).then((r) => ({ gap: g, ...r })),
+    ),
+  )
+  const fresh = []
+  for (const slice of fills.filter(Boolean)) {
+    for (const l of slice.layers || []) addLayer(l)
+    for (const n of slice.nodes || []) {
+      if (addNode(n, `gap-${round + 1}`)) fresh.push(n)
+    }
+    for (const e of slice.edges || []) addEdge(e)
+  }
+  log(`completeness round ${round + 1}: ${gaps.length} gaps → +${fresh.length} new nodes`)
+  if (!fresh.length) break
+  await verifyNodes(fresh, `gap-${round + 1}`)
+  round++
+}
+
+// ── Assemble ─────────────────────────────────────────────────────────
+
+const nodes = [...nodeById.values()]
+const nodeIds = new Set(nodeById.keys())
+const liveEdges = edges.filter((e) => nodeIds.has(e.source) && nodeIds.has(e.target))
+// Keep only layers actually referenced (plus any draft layer the agent kept using).
+const usedLayerIds = new Set(nodes.map((n) => n.layerId).filter(Boolean))
+const layers = [...layerById.values()].filter((l) => usedLayerIds.has(l.id))
+
+const trustCounts = nodes.reduce((acc, n) => {
+  const k = n.trust || 'unrated'
+  acc[k] = (acc[k] || 0) + 1
+  return acc
+}, {})
+
+log(
+  `assembled: ${nodes.length} nodes / ${liveEdges.length} edges / ${layers.length} layers — ` +
+    `trust ${JSON.stringify(trustCounts)}`,
+)
+
+// Phase 5 — perspectives: propose variant walks per lens, judge each,
+// keep only the grounded ones (the SKILL's grounded-or-delete rule,
+// mechanized as a judge panel).
+function perspectivesPrompt(idx, edgeIdx) {
+  return `You are naming the variant ways to READ a finished cosmos — a graph projected from the codebase at ${sourceRoot}.
+
+A perspective is a *walk* framed by one design lens ("where does the system hold a feedback loop?", "where do two abstractions collide?"), NOT a tag. Each must be grounded: every step's focus[] names concrete node ids from the index, and each step's narrative is its OWN paragraph (what the reader sees on THIS beat) — never a repeat of the thesis.
+
+Lenses worth recognizing (open vocabulary — invent one if none fit): orthogonality, cybernetic-loop, entropy-gradient, self-similarity, causal-chain, tension, convergence-point, layered-translation, hidden-hand, paradigm-shift.
+
+Node index (id — type — name — layer):
+${idx}
+
+Edges (source -verb-> target):
+${edgeIdx}
+
+Propose ONLY the perspectives whose lens genuinely fits THIS graph — 0 to 5, and fewer sharp ones beat many vague ones. Each: {id:"perspective-<slug>", name (prose in ${language}), lens (English kebab-case), insight (one paragraph), steps:[{focus:[real node ids], narrative}]}. If no lens earns a grounded walk, return an empty array.
+
+Return {perspectives}.`
+}
+
+function judgePerspectivePrompt(p, idx) {
+  return `You are a SKEPTIC judging whether a cosmos perspective is GROUNDED or just a slogan wearing a node-list. Default to grounded:false when unsure.
+
+It is grounded only if: every step's focus[] names node ids that exist in the index below; each step's narrative is its own paragraph (not a restatement of the insight); and the lens describes a real through-line in the graph, not a vibe.
+
+Node index (id — type — name — layer):
+${idx}
+
+Perspective under review:
+${JSON.stringify(p, null, 2)}
+
+Flag the indices of any steps whose narrative just restates the thesis or whose focus ids don't exist / don't fit. Return {grounded, reason, weakSteps?}.`
+}
+
+let perspectives = []
+if (withPerspectives && nodes.length >= 15) {
+  phase('Perspectives')
+  const edgeIdx = liveEdges.slice(0, 400).map((e) => `${e.source} -${e.type}-> ${e.target}`).join('\n')
+  const gen = await agent(perspectivesPrompt(nodeIndex(), edgeIdx), {
+    schema: SCHEMAS.perspectiveSet,
+    phase: 'Perspectives',
+    label: 'propose',
+  }).catch(() => ({ perspectives: [] }))
+  const candidates = (gen.perspectives || []).slice(0, 6)
+  const judged = await parallel(
+    candidates.map((p, i) => () =>
+      agent(judgePerspectivePrompt(p, nodeIndex()), {
+        schema: SCHEMAS.perspectiveJudgment,
+        phase: 'Perspectives',
+        label: `judge:${p.id || i}`,
+      })
+        .then((v) => ({ p, grounded: !!v?.grounded }))
+        .catch(() => ({ p, grounded: false })),
+    ),
+  )
+  perspectives = judged.filter((x) => x.grounded).map((x) => x.p)
+  log(`perspectives: ${candidates.length} proposed → ${perspectives.length} grounded`)
+}
+
+return {
+  version: '0.1.0',
+  kind: 'codebase',
+  project: { name: projectName, kind: 'codebase', sourceRoot },
+  nodes,
+  edges: liveEdges,
+  layers,
+  ...(perspectives.length ? { perspectives } : {}),
+  stats: {
+    trust: trustCounts,
+    droppedEdges: edges.length - liveEdges.length,
+    completenessRounds: round,
+    perspectives: perspectives.length,
+  },
+}

--- a/modes/cosmos/types.ts
+++ b/modes/cosmos/types.ts
@@ -66,6 +66,19 @@ export type CosmosNodeCategory =
 export type CosmosNodeComplexity = "simple" | "moderate" | "complex";
 
 /**
+ * Verification verdict for a node, produced by the projection workflow's
+ * adversarial verify pass (a skeptic re-reads the cited sources). The
+ * viewer renders it as a trust badge so the user can tell solidly-grounded
+ * nodes from inferences at a glance. Absent on nodes that were never run
+ * through verification (e.g. in-context Path B projections); the viewer
+ * treats absent as "unrated" and shows no badge. Mirrors `NODE_TRUST` in
+ * `schema.ts` — keep the two in lockstep (guarded by schema.test.ts).
+ * `verified` = sources substantiate the summary; `weak` = only partially;
+ * `unverifiable` = no citable source could be confirmed.
+ */
+export type CosmosNodeTrust = "verified" | "weak" | "unverifiable";
+
+/**
  * Multi-formed pointer back to a node's source material. Cosmos is
  * deliberately domain-agnostic: nodes can reference source files
  * (code, prose, notes), web URLs, fixed passages inside long
@@ -245,6 +258,12 @@ export interface CosmosNode {
   category?: CosmosNodeCategory;
   /** Subjective complexity hint — viewer renders as a badge on layer cards. */
   complexity?: CosmosNodeComplexity;
+  /**
+   * Verification verdict from the projection workflow's verify pass.
+   * Absent when the node was never verified (Path B / hand-authored).
+   * See `CosmosNodeTrust`.
+   */
+  trust?: CosmosNodeTrust;
   /** Multi-formed pointers back to source material — any combination
    *  of file / url / passage / image / audio / video. Rendered as
    *  click-to-open chips in the INFO panel. Zero or more per node;

--- a/modes/cosmos/viewer/CosmosPreview.tsx
+++ b/modes/cosmos/viewer/CosmosPreview.tsx
@@ -46,6 +46,7 @@ import type {
   CosmosEdge,
   CosmosNode,
   CosmosNodeCategory,
+  CosmosNodeTrust,
   CosmosPerspective,
   CosmosSourceRef,
   CosmosSubgraph,
@@ -711,6 +712,48 @@ const COMPLEXITY_TINT: Record<LayerCardData["aggregateComplexity"], string> = {
   complex: "#fb7185",  // pink-rose
   mixed: "#a1a1aa",
 };
+
+// Trust badge — the projection workflow's verify pass tags each node
+// with how well its cited sources substantiate it. Lets the user tell a
+// solidly-grounded node from an inference at a glance.
+const TRUST_TINT: Record<CosmosNodeTrust, string> = {
+  verified: "#34d399",     // emerald
+  weak: "#fbbf24",         // amber
+  unverifiable: "#fb7185", // rose
+};
+const TRUST_LABEL: Record<CosmosNodeTrust, string> = {
+  verified: "verified",
+  weak: "weak",
+  unverifiable: "unverifiable",
+};
+const TRUST_HINT: Record<CosmosNodeTrust, string> = {
+  verified: "A skeptic re-read the cited sources and they substantiate this node.",
+  weak: "Sourced, but the cited material only partially supports the claim.",
+  unverifiable: "No citable source could be confirmed — treat this node as an inference.",
+};
+
+function TrustBadge({ trust, size = "md" }: { trust: CosmosNodeTrust; size?: "sm" | "md" }) {
+  const tint = TRUST_TINT[trust];
+  return (
+    <span
+      title={TRUST_HINT[trust]}
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 4,
+        fontSize: size === "sm" ? 8 : 9,
+        padding: size === "sm" ? "1px 5px" : "2px 7px",
+        borderRadius: 3,
+        background: `${tint}22`,
+        color: tint,
+        whiteSpace: "nowrap",
+      }}
+    >
+      <span style={{ width: 5, height: 5, borderRadius: "50%", background: tint, flexShrink: 0 }} />
+      {TRUST_LABEL[trust]}
+    </span>
+  );
+}
 
 function LayerCard({ data, selected }: NodeProps<RfNode<LayerCardData>>) {
   const { t } = useTranslation("cosmos");
@@ -1937,6 +1980,7 @@ function NodeDrawer({ cosmos, node, onSelectNode, onClose }: NodeDrawerProps) {
               {display.complexity}
             </div>
           )}
+          {display.trust && <TrustBadge trust={display.trust} />}
         </div>
         <button
           type="button"
@@ -3603,6 +3647,11 @@ function NodeTooltip({ cosmos, node, x, y }: NodeTooltipProps) {
             }}
           >
             {node.complexity}
+          </span>
+        )}
+        {node.trust && (
+          <span style={{ marginLeft: node.complexity ? 4 : "auto" }}>
+            <TrustBadge trust={node.trust} size="sm" />
           </span>
         )}
       </div>

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "tailwindcss": "^4.0.0",
     "trash": "^10.1.1",
     "vite": "^7.3.1",
+    "zod": "^4.4.3",
     "zustand": "^5.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Rebuilds cosmos's codebase projection on the Workflow tool (Path A, Claude Code), with graceful degradation to the in-context passes (Path B) on Codex/Kimi or small inputs.

## What changed
- **`schema.ts`** — zod is the structured-output truth; derived JSON Schema the projection workflow inlines (drift-guarded by `schema.test.ts`).
- **`skill/references/projection.workflow.js`** — parallel per-partition extract → cross-edge merge → adversarial per-node verify → completeness loop → perspective judge-panel; returns graph + per-node `trust`.
- **`node.trust`** (verified / weak / unverifiable) + `TrustBadge` in the viewer (NodeDrawer header + hover tooltip).
- **`SKILL.md`** Path A / Path B gate + survey→handoff recipe; `projection-workflows.md` marked the Path B fallback. Mode `0.3.0 → 0.4.0`.

## Validation
- Scoped real run (`core/types` + `backends` + `core/sources`): **82 nodes, all `verified`**, `zCosmos` PASS, 86 source refs 0 missing / 0 out-of-bounds.
- Adversarial probe confirmed `trust` discriminates: planted false-summary / missing-file / no-source nodes all → `unverifiable`; control → `verified`.
- Trust badge visually verified on the merged build (all 3 states).
- `bun test` 19 pass · `bun run typecheck` clean.

## Notes
- Path A is **codebase-domain only** for now; fiction / research / business still use Path B until their workflow paths land.
- Path A spins up many subagents and costs real tokens — the small-input → Path B gate is intentional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)