### PR TITLE
[codex] Bump to v3.24.2 with WordTaste style trial

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ Pneuma Skills is co-creation infrastructure for humans and code agents. Agents e
 
 **Formula:** `ModeManifest(skill + viewer + agent_config) × AgentBackend × RuntimeShell`
 
-**Version:** 3.24.1
+**Version:** 3.24.2
 **Runtime:** Bun >= 1.3.5 (required, not Node.js)
 **Builtin Modes:** `webcraft`, `doc`, `slide`, `draw`, `diagram`, `illustrate`, `remotion`, `gridboard`, `kami`, `clipcraft`, `cosmos`, `wordtaste`, `mode-maker`, `evolve`, `project-evolve`, `project-onboard`, `project-tidy`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.24.2] - 2026-07-03
+
+### Improved
+- **WordTaste adapts to wide and changing editor surfaces** — the reading measure, stage padding, and annotation column now respond to the available viewer width instead of holding the default-window layout. Closing side views or widening the app gives the draft more usable room without pushing notes into the prose.
+- **WordTaste can run a representative three-style trial before the full draft** — the new `Try three styles first` command picks a representative passage, writes A/B/C directions to `taste/style-trial.md`, records the user's pick into taste artifacts, and only then writes `draft.md`. The default taste profile now also treats formulaic contrast pivots such as "不是 X，而是 Y" / "not X but Y" as AI-slop unless the contrast is concrete and earned.
+
+### Fixed
+- **Codex-backed viewer commands reach the active backend** — viewer notifications now route directly into streaming backends instead of falling through to the legacy CLI queue, so WordTaste commands such as the three-style trial actually reach Codex sessions.
+
 ## [3.24.1] - 2026-07-03
 
 ### Fixed

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pneuma-skills-desktop",
   "productName": "Pneuma Skills",
-  "version": "3.24.1",
+  "version": "3.24.2",
   "description": "Pneuma Skills — Desktop Client",
   "author": {
     "name": "pandazki",

--- a/modes/wordtaste/DESIGN-BRIEF.md
+++ b/modes/wordtaste/DESIGN-BRIEF.md
@@ -257,7 +257,7 @@ content-type). Mirrors kami.
 
 ## 4. Action space (the full ViewerActionDescriptor + ViewerCommandDescriptor set)
 
-Mapped one-to-one to the five signature features. All `agentInvocable: true` so the agent can drive
+Mapped one-to-one to the signature features. All `agentInvocable: true` so the agent can drive
 them itself (e.g. propose directions after a generation pass), but each is **also triggered from a
 viewer gesture** via the Command channel or a direct viewer-internal dispatch (see §5 for the wire
 path). `capture` is framework-built-in and not listed.
@@ -295,11 +295,12 @@ chip clicks dispatch through these, carrying their payload in the notification �
 |---|---|---|
 | `start-from-idea` | Write from this outline | Entry state (A): generate the first cross-family draft from the materials/outline |
 | `start-from-draft` | De-AI this draft | Entry state (B): intake the disliked draft, freeze the kernel, run the first disruption pass |
+| `calibrate-style-sample` | Try three styles first | Entry state (C): choose a representative passage, produce three distinct style versions, let the user pick, distill the preference, then write the full draft |
 | `request-directions` | (internal) | Fired by span-select; asks the agent for taste-aware rewrite directions for the selected address |
 | `still-ai` | Still reads AI — dial up | The cheapest signal: bump the ladder +1 and regenerate (whole-draft one-shot) |
 | `good-enough` | This is good — finalize | Triggers the finalize + distill pass |
 
-**Action-space size check:** 8 actions + 5 commands. This is above the create-mode "2–5 actions"
+**Action-space size check:** 8 actions + 6 commands. This is above the create-mode "2–5 actions"
 guideline, and that is *deliberate and defended*: palate's entire value proposition is a rich
 direct-manipulation vocabulary on one object (the draft block/span). Each action is a distinct
 *verb on the same address noun* — none is surfacing UI chrome as an action (the anti-pattern the
@@ -310,6 +311,33 @@ agent's ability to reason about what it is doing. Verdict: justified.
 ---
 
 ## 5. Cross-layer integration flows
+
+### 5.0 Representative style trial → full draft
+
+```
+User clicks "Try three styles first"
+   │  Viewer fires Command `calibrate-style-sample`
+   ▼
+Agent reads outline/original + taste profile + voice anchors
+   │  chooses the most representative/high-risk passage
+   │  freezes the kernel before any style move
+   ▼
+Agent generates three distinct passage versions (not three whole drafts)
+   │  stores them in taste/style-trial.md
+   │  leaves draft.md absent/unchanged
+   ▼
+User picks A/B/C or names what is close/still AI
+   │  Agent appends a style_trial_pick event to taste/prefs.log.jsonl
+   │  updates taste/taste-profile.md with concrete style requirements
+   ▼
+Agent writes one full draft.md using the picked direction
+   │  normal span-select / poke / still-ai loop takes over
+```
+
+This is a recognition-first calibration path: the user distinguishes between styles on a small,
+representative passage before the expensive full-draft pass. It is still goal-first and must not
+be presented as a setup wizard. The trial artifact belongs under `taste/`, not in `draft.md`,
+because `draft.md` remains the article body only.
 
 ### 5.1 The span-select → directions → rewrite loop (the signature flow)
 

--- a/modes/wordtaste/__tests__/domain.test.ts
+++ b/modes/wordtaste/__tests__/domain.test.ts
@@ -329,11 +329,11 @@ describe("seed: worked-example taste-profile parses cleanly", () => {
 
 describe("seed: starter taste-profile parses as an uncalibrated bootstrap", () => {
   for (const entry of ["from-idea", "from-draft"]) {
-    it(`${entry}: launch rung 1, voice-floor prose, two example symptom cards`, () => {
+    it(`${entry}: launch rung 1, voice-floor prose, three example symptom cards`, () => {
       const t = loadTaste(seedTaste(entry))!;
       expect(t.launchRung).toBe(1);
       expect(t.voiceFloor.length).toBeGreaterThan(0);
-      expect(t.rubric.map((s) => s.id)).toEqual(["S1", "S2"]);
+      expect(t.rubric.map((s) => s.id)).toEqual(["S1", "S2", "S3"]);
       for (const s of t.rubric) {
         expect(s.tell.length, `${s.id} tell`).toBeGreaterThan(0);
         expect(s.fix.length, `${s.id} fix`).toBeGreaterThan(0);

--- a/modes/wordtaste/__tests__/manifest.test.ts
+++ b/modes/wordtaste/__tests__/manifest.test.ts
@@ -142,10 +142,11 @@ describe("wordtaste manifest — action space", () => {
     expect(byId["mark-resolved"]).toBe("ui");
   });
 
-  it("declares the 5 commands from §4.2 with exact ids", () => {
+  it("declares the 6 commands from §4.2 with exact ids", () => {
     expect(wordtasteManifest.viewerApi!.commands!.map((c) => c.id)).toEqual([
       "start-from-idea",
       "start-from-draft",
+      "calibrate-style-sample",
       "request-directions",
       "still-ai",
       "good-enough",

--- a/modes/wordtaste/manifest.ts
+++ b/modes/wordtaste/manifest.ts
@@ -286,6 +286,7 @@ const wordtasteManifest: ModeManifest = {
     commands: [
       { id: "start-from-idea", label: "Write from this outline", description: "Entry (A): generate the first cross-family draft from the materials/outline." },
       { id: "start-from-draft", label: "De-AI this draft", description: "Entry (B): intake the disliked draft, freeze the kernel, run the first disruption pass." },
+      { id: "calibrate-style-sample", label: "Try three styles first", description: "Taste calibration: pick the most representative passage, produce three distinct style versions, let the user choose, distill the preference, then write the full draft." },
       { id: "request-directions", label: "Request directions", description: "Internal — fired by span-select; asks the agent for taste-aware rewrite directions for the selected address." },
       { id: "still-ai", label: "Still reads AI — dial up", description: "The cheapest signal: bump the ladder +1 and regenerate the whole draft one-shot." },
       { id: "good-enough", label: "This is good — finalize", description: "Trigger the finalize + distill pass." },
@@ -295,7 +296,7 @@ const wordtasteManifest: ModeManifest = {
   agent: {
     permissionMode: "bypassPermissions",
     greeting: `<system-info pneuma-mode="Pneuma WordTaste" skill="pneuma-wordtaste" session="new"></system-info>
-The user opened WordTaste with a concrete writing goal, not a configuration task. First run scripts/cross_family_probe.sh to detect which model families are available (writes .pneuma/cross-family.json), then ask for their goal if it is not already given: entry A is an outline/idea to write from, entry B is a draft to de-AI. Greet in 1–2 sentences. Never frame this as taste configuration or a setup wizard — onboarding is a byproduct of "give me your writing goal."`,
+The user opened WordTaste with a concrete writing goal, not a configuration task. First run scripts/cross_family_probe.sh to detect which model families are available (writes .pneuma/cross-family.json), then ask for their goal if it is not already given: entry A is an outline/idea to write from, entry B is a draft to de-AI, and the three-style calibration path lets them choose among representative sample versions before the full draft. Greet in 1–2 sentences. Never frame this as taste configuration or a setup wizard — onboarding is a byproduct of "give me your writing goal."`,
   },
 
   init: {

--- a/modes/wordtaste/seed/from-draft/taste/taste-profile.md
+++ b/modes/wordtaste/seed/from-draft/taste/taste-profile.md
@@ -32,13 +32,14 @@
 ---
 
 ## 2. Symptom rubric · 症状清单（这些一出现就是「一眼 AI」，要压掉）
-> 还没有为你校准 —— 下面两条是**所有人都适用的通用 AI 症状**，给你一个清单的样子。
-> Not calibrated for you yet — the two below are **universal AI symptoms** that apply to almost everyone,
+> 还没有为你校准 —— 下面三条是**所有人都适用的通用 AI 症状**，给你一个清单的样子。
+> Not calibrated for you yet — the three below are **universal AI symptoms** that apply to almost everyone,
 > shown so you can see the shape. WordTaste 会随着你的判断把它们替换成**你**真正在意的那些。
 > WordTaste will replace these with the ones **you** actually reject as you go.
 
 1. **S1 over-patterning** —— tell：任何装置都被等周期地铺满（每段一样长、每节一句金句收口、迟疑均匀撒满）。规律性本身就是 tell。修：让轻重由内容真实决定 —— 最承重处出拳，过渡一句带过，敢打破节拍。
 2. **S2 ai-metaphor** —— tell：工整解释性类比（「就好比 A 之于 B」）、廉价 stock 生动（赤脚出门 / 潘多拉魔盒）、诗意虚化收尾（X 只是 Y 的影子）。修：拿不准就砍成大白话，留白优先；只有具体、带情绪、不工整、私人的真人意象才换。
+3. **S3 not-but-pivot** —— tell：用「不是 X，而是 Y / 不仅 X，更是 Y / 与其说 X，不如说 Y」或 "not X but Y" 来制造假反转、假升级，尤其在开头和段尾反复出现。修：直接写判断、条件、边界和后果；如果真有对比，就让具体事实承担对比，不用公式化转折撑气势。
 
 ---
 

--- a/modes/wordtaste/seed/from-idea/taste/taste-profile.md
+++ b/modes/wordtaste/seed/from-idea/taste/taste-profile.md
@@ -32,13 +32,14 @@
 ---
 
 ## 2. Symptom rubric · 症状清单（这些一出现就是「一眼 AI」，要压掉）
-> 还没有为你校准 —— 下面两条是**所有人都适用的通用 AI 症状**，给你一个清单的样子。
-> Not calibrated for you yet — the two below are **universal AI symptoms** that apply to almost everyone,
+> 还没有为你校准 —— 下面三条是**所有人都适用的通用 AI 症状**，给你一个清单的样子。
+> Not calibrated for you yet — the three below are **universal AI symptoms** that apply to almost everyone,
 > shown so you can see the shape. WordTaste 会随着你的判断把它们替换成**你**真正在意的那些。
 > WordTaste will replace these with the ones **you** actually reject as you go.
 
 1. **S1 over-patterning** —— tell：任何装置都被等周期地铺满（每段一样长、每节一句金句收口、迟疑均匀撒满）。规律性本身就是 tell。修：让轻重由内容真实决定 —— 最承重处出拳，过渡一句带过，敢打破节拍。
 2. **S2 ai-metaphor** —— tell：工整解释性类比（「就好比 A 之于 B」）、廉价 stock 生动（赤脚出门 / 潘多拉魔盒）、诗意虚化收尾（X 只是 Y 的影子）。修：拿不准就砍成大白话，留白优先；只有具体、带情绪、不工整、私人的真人意象才换。
+3. **S3 not-but-pivot** —— tell：用「不是 X，而是 Y / 不仅 X，更是 Y / 与其说 X，不如说 Y」或 "not X but Y" 来制造假反转、假升级，尤其在开头和段尾反复出现。修：直接写判断、条件、边界和后果；如果真有对比，就让具体事实承担对比，不用公式化转折撑气势。
 
 ---
 

--- a/modes/wordtaste/skill/SKILL.md
+++ b/modes/wordtaste/skill/SKILL.md
@@ -23,6 +23,7 @@ Making AI write like a human is a **context-engineering and game-theory problem,
 - **You orchestrate; you never author or judge candidates in your own context.** Generation and evaluation go to isolated workers — a Claude Task subagent (fresh context, no leakage) or a separate-process CLI (`codex`, `gemini`). This is not ceremony: your main context carries the conversation and your own drafting priors, both of which corrupt a candidate and bias a verdict.
 - **Kernel-freeze is an invariant, not a suggestion.** Before the first generation you extract the load-bearing meaning / facts / precise hedges and freeze them. Disruption only ever touches structure, texture, and genre — *never* the kernel. Frozen blocks are a UI contract the rewrite path physically honors; treat a frozen block as immovable context, never as something to "improve."
 - **Cheapest-signal HITL.** Never ask the user to write a paragraph of feedback. Ask for a near-binary judgment ("closer? still AI? landed, or dial up one more?") or "poke one symptom." You carry the search cost so the user only has to *recognize*, not *compose*.
+- **Formulaic contrast pivots are default AI slop.** Treat "不是 X，而是 Y" / "not X but Y" / "not only X, but Y" and their cousins as suspect by default, especially in openings and paragraph closers. Keep one only when the contrast is concrete, necessary, and paid for by evidence; otherwise say the judgment directly.
 - **Rich context + steering wheel + kernel safety bar beats prompt micro-carving.** When a generation is off, reach for a better anchor, a clearer kernel, a different family, or a rung change — not a more ornate prompt.
 - **Distill every judgment.** Each reject / pick / poke / hand-edit becomes a line in the taste artifacts. This is how the studio gets faster per task (see [Distillation](#distillation--turning-judgments-into-faster-next-time)).
 
@@ -60,9 +61,9 @@ An absent file is not an error — it means no profile yet. The heavy per-projec
 
 ---
 
-## The two entry states
+## The three entry paths
 
-Everything starts from a concrete writing goal. The user picks one of two entry seeds (or a handoff lands you in one):
+Everything starts from a concrete writing goal. The user can start directly from an idea/draft, or run a short style calibration before the full draft. A handoff may land you in any of these paths.
 
 ### (A) Idea → draft — the `start-from-idea` command
 
@@ -83,6 +84,27 @@ The user has prose that reads one-glance-AI (or a handoff dropped a source draft
 2. **Freeze the kernel** — read the original, extract what must survive (the argument, the facts, the precise hedges), write `materials/kernel.md`, and freeze the blocks carrying it.
 3. Load the taste profile as in (A); run the cold-start check.
 4. Run the first disruption pass from the launch rung, cross-family, kernel re-injected. Write to `draft.md` — **article body only**, no "修订版" preamble and no change-log: the revision rationale goes to [`draft.annotations.json`](#the-annotation-channel--where-revision-notes-go), not the document (see the [first discipline](#non-negotiable-disciplines-each-one-is-paid-for-not-theoretical)). Set a content-appropriate color theme — the font auto-picks by language (see [Reading-surface auto-selection](#reading-surface-auto-selection-font--color-two-independent-axes)). Hand over the cheapest signal, enter the loop.
+
+### (C) Representative style trial → full draft — the `calibrate-style-sample` command
+
+Use this when the user wants to choose a direction before you write the whole piece, when the brief is underspecified, or when a cold-start voice profile would make a full draft too arbitrary. The purpose is to give the user a **recognition task**: three meaningfully different versions of one representative passage, then one pick.
+
+1. Read the available source material (`materials/outline.md`, `materials/original.md`, refs, voice anchors) and freeze the kernel as in (A)/(B). If there is no voice sample, run the cold-start check first.
+2. Pick the most representative passage: the paragraph where tone, argument density, and the hardest AI-slop risk all show up. Do not pick a trivial intro or a throwaway transition. If starting from an outline, write a neutral kernel paragraph from the outline first; if starting from a disliked draft, use the passage that best exposes why it reads AI.
+3. Generate **three distinct versions** of that passage across different approaches/families. They must differ in posture, rhythm, and structure — not just synonyms. A useful default set:
+   - **A. faithful / direct** — preserves order, cuts formula, clarifies the judgment.
+   - **B. human-textured** — more lived-in cadence, more asymmetry, a little more personality.
+   - **C. bolder architecture** — changes entry angle or paragraph shape while preserving the kernel.
+4. Write the trial to `taste/style-trial.md` with: the representative passage, the three versions, the intended tradeoff of each, and a blank "user pick" line. Keep `draft.md` absent/unchanged at this stage. Show the same A/B/C options in chat and ask only for a cheap pick: "A, B, C, or tell me what is close/still AI."
+5. When the user picks or combines directions, append a `style_trial_pick` event to `taste/prefs.log.jsonl` and update `taste/taste-profile.md` immediately: voice floor, symptom rubric, launch rung, and style requirements. Record concrete constraints, not vibes. Example event shape:
+
+   ```json
+   {"event":"style_trial_pick","picked":"B","rejected":["A","C"],"reason":"wanted asymmetry and less manifesto cadence","requirements":["avoid formulaic contrast pivots","keep claims direct"],"ts":"..."}
+   ```
+
+6. Only after the preference is distilled, write the full `draft.md` using the chosen direction and the frozen kernel. The first full draft should already reflect the trial pick; do not offer three full drafts. Then enter the normal viewer-first task loop.
+
+This path is still goal-first. Never present it as "setting up taste." The user is choosing how this concrete piece should sound.
 
 ---
 
@@ -258,6 +280,7 @@ These arrive buffered and flush to you as a system message when you go idle:
 |---|---|---|
 | `start-from-idea` | User picks entry (A) | Run [entry (A)](#a-idea--draft--the-start-from-idea-command). |
 | `start-from-draft` | User picks entry (B) | Run [entry (B)](#b-disliked-draft--de-ai--the-start-from-draft-command). |
+| `calibrate-style-sample` | User asks to try three styles first | Run [entry (C)](#c-representative-style-trial--full-draft--the-calibrate-style-sample-command): representative passage → three versions → user pick → distill → full draft. |
 | `request-directions` | Span selected | Read the rubric + span, return ~5 taste-aware directions via `propose-directions`. |
 | `still-ai` | User says it still reads AI | Rung +1, fresh session, regenerate whole (cheapest-signal branch). |
 | `good-enough` | User accepts | Finalize → distill → federate. |
@@ -368,6 +391,7 @@ The symbol layer (metaphors / signature lines) is the finest tell, and the model
     recipes/<type>.md       distilled operational generation recipe
     swaps.jsonl             symbol-layer AI→human sentence pairs (gold material)
     prefs.log.jsonl         append-only signal events
+    style-trial.md          representative-passage A/B/C trial; never article body
 .pneuma/
   config.json               init params (active content-set, content-type, current rung, fontSuggested, themeSuggested)
   cross-family.json         startup probe result { codex, gemini, claude }

--- a/modes/wordtaste/viewer/WordtastePreview.tsx
+++ b/modes/wordtaste/viewer/WordtastePreview.tsx
@@ -725,6 +725,13 @@ export default function WordtastePreview(props: ViewerPreviewProps) {
                     "Intake the disliked draft, freeze the kernel, run the first disruption pass.",
                   )
                 }
+                onCalibrate={() =>
+                  fireCommand(
+                    "calibrate-style-sample",
+                    "Try three styles first",
+                    "Pick the representative passage, generate three distinct style versions, learn the user's preference, then write the full draft.",
+                  )
+                }
                 readonly={readonly}
               />
             )}
@@ -1476,7 +1483,7 @@ function RungGauge({ rung, launchRung }: { rung: number; launchRung: number }) {
       <h3 className="wordtaste-section-title">Disruption</h3>
       <div className="wordtaste-gauge">
         <div className="wordtaste-gauge-bar">
-          <div className="wordtaste-gauge-fill" style={{ width: `${pct}%` }} />
+          <div className="wordtaste-gauge-fill" style={{ transform: `scaleX(${pct / 100})` }} />
           <div
             className="wordtaste-gauge-launch"
             style={{ left: `${(launchRung / MAX_RUNG) * 100}%` }}
@@ -1737,10 +1744,12 @@ function ColorThemeCard({
 function DraftEmpty({
   onStartIdea,
   onStartDraft,
+  onCalibrate,
   readonly,
 }: {
   onStartIdea: () => void;
   onStartDraft: () => void;
+  onCalibrate: () => void;
   readonly?: boolean;
 }) {
   return (
@@ -1758,6 +1767,9 @@ function DraftEmpty({
             </button>
             <button type="button" className="wordtaste-cta" onClick={onStartDraft}>
               De-AI a draft
+            </button>
+            <button type="button" className="wordtaste-cta" onClick={onCalibrate}>
+              Try three styles first
             </button>
           </div>
         )}
@@ -1978,18 +1990,50 @@ const STUDIO_CSS = `
 
 /* ── Center — the reading surface (the active SKIN layers here) ── */
 .wordtaste-center { display: flex; flex-direction: column; flex: 1; min-width: 0; position: relative;
+  container-type: inline-size;
   background: var(--wordtaste-theme-bg, var(--color-cc-bg, #09090b));
   transition: background .35s ease;
 }
-.wordtaste-draft-scroll { flex: 1; overflow-y: auto; padding: 40px 0 96px; }
-.wordtaste-reading { display: flex; justify-content: center; gap: 0; width: 100%; }
-.wordtaste-center.has-annotations .wordtaste-reading { gap: 28px; align-items: flex-start; padding-right: 12px; }
+.wordtaste-draft-scroll {
+  flex: 1;
+  overflow-y: auto;
+  padding: clamp(32px, 5cqw, 64px) 0 96px;
+}
+.wordtaste-reading {
+  --wordtaste-stage-pad: clamp(28px, 8cqw, 132px);
+  --wordtaste-anno-width: clamp(240px, 24cqw, 340px);
+  --wordtaste-anno-gap: clamp(20px, 3cqw, 42px);
+  --wordtaste-prose-target: clamp(
+    var(--wordtaste-font-measure, 64ch),
+    58cqw,
+    var(--wordtaste-font-max-measure, 72ch)
+  );
+  display: flex;
+  justify-content: center;
+  gap: 0;
+  width: min(
+    calc(100% - (var(--wordtaste-stage-pad) * 2)),
+    var(--wordtaste-prose-target)
+  );
+  margin: 0 auto;
+}
+.wordtaste-center.has-annotations .wordtaste-reading {
+  width: min(
+    calc(100% - (var(--wordtaste-stage-pad) * 2)),
+    calc(var(--wordtaste-prose-target) + var(--wordtaste-anno-gap) + var(--wordtaste-anno-width))
+  );
+  gap: var(--wordtaste-anno-gap);
+  align-items: flex-start;
+}
 
 .wordtaste-prose {
-  width: min(var(--wordtaste-font-measure, 64ch), 100% - 80px);
+  width: 100%;
+  max-width: var(--wordtaste-prose-target);
+  min-width: min(100%, var(--wordtaste-font-measure, 64ch));
   margin: 0 auto;
   font-family: var(--wordtaste-font-family, "Lora", Georgia, serif);
   color: var(--wordtaste-theme-fg, var(--color-cc-fg));
+  flex: 1 1 var(--wordtaste-prose-target);
 }
 .wordtaste-center.has-annotations .wordtaste-prose { margin: 0; }
 
@@ -2047,11 +2091,16 @@ const STUDIO_CSS = `
 .wordtaste-dense-dot { position: absolute; top: 14px; left: -8px; width: 6px; height: 6px; border-radius: 50%; background: color-mix(in srgb, var(--wordtaste-theme-muted, #888) 55%, transparent); pointer-events: none; }
 
 /* Annotation column — block-aligned revision notes (批注模式) */
-.wordtaste-annotations { position: relative; width: 264px; flex-shrink: 0; align-self: stretch; }
+.wordtaste-annotations {
+  position: relative;
+  width: var(--wordtaste-anno-width);
+  flex: 0 0 var(--wordtaste-anno-width);
+  align-self: stretch;
+}
 .wordtaste-annotations-inner { position: relative; height: 100%; }
 .wordtaste-anno-group { position: absolute; left: 0; right: 0; display: flex; flex-direction: column; gap: 6px; }
-.wordtaste-anno-card { padding: 9px 11px; border-radius: 9px; background: color-mix(in srgb, var(--wordtaste-theme-bg, #18181b) 80%, var(--color-cc-surface, #18181b)); border: 1px solid var(--wordtaste-theme-rule, var(--color-cc-border)); border-left: 2px solid var(--wordtaste-theme-accent, var(--color-cc-primary)); box-shadow: 0 2px 10px rgba(0,0,0,0.08); }
-.wordtaste-anno-card.is-note { border-left-color: var(--wordtaste-theme-muted, var(--color-cc-muted)); }
+.wordtaste-anno-card { padding: 9px 11px; border-radius: 9px; background: color-mix(in srgb, var(--wordtaste-theme-bg, #18181b) 80%, var(--color-cc-surface, #18181b)); border: 1px solid color-mix(in srgb, var(--wordtaste-theme-rule, var(--color-cc-border)) 82%, var(--wordtaste-theme-accent, var(--color-cc-primary))); box-shadow: 0 2px 10px rgba(0,0,0,0.08), inset 0 1px 0 color-mix(in srgb, var(--wordtaste-theme-accent, var(--color-cc-primary)) 18%, transparent); }
+.wordtaste-anno-card.is-note { border-color: var(--wordtaste-theme-rule, var(--color-cc-border)); box-shadow: 0 2px 10px rgba(0,0,0,0.08); }
 .wordtaste-anno-meta { display: flex; align-items: baseline; justify-content: space-between; margin-bottom: 3px; }
 .wordtaste-anno-kind { font-size: 9px; letter-spacing: 0.1em; text-transform: uppercase; font-weight: 700; color: var(--wordtaste-theme-accent, var(--color-cc-primary)); }
 .wordtaste-anno-card.is-note .wordtaste-anno-kind { color: var(--wordtaste-theme-muted, var(--color-cc-muted)); }
@@ -2081,7 +2130,7 @@ const STUDIO_CSS = `
 
 .wordtaste-gauge { display: flex; flex-direction: column; gap: 6px; }
 .wordtaste-gauge-bar { position: relative; height: 8px; border-radius: 999px; background: var(--color-cc-border); overflow: hidden; }
-.wordtaste-gauge-fill { position: absolute; inset: 0 auto 0 0; border-radius: 999px; background: var(--color-cc-primary, #f97316); transition: width .3s cubic-bezier(.16,1,.3,1); }
+.wordtaste-gauge-fill { position: absolute; inset: 0; border-radius: 999px; background: var(--color-cc-primary, #f97316); transform-origin: left center; transition: transform .3s cubic-bezier(.16,1,.3,1); }
 .wordtaste-gauge-launch { position: absolute; top: -3px; width: 2px; height: 14px; background: var(--color-cc-fg); border-radius: 2px; opacity: 0.6; }
 .wordtaste-gauge-foot { display: flex; justify-content: space-between; align-items: baseline; }
 .wordtaste-gauge-foot span:first-child { font-size: 13px; font-weight: 600; color: var(--color-cc-fg); }
@@ -2127,7 +2176,7 @@ const STUDIO_CSS = `
 .wordtaste-draft-empty { width: min(54ch, 100% - 80px); margin: 8vh auto 0; display: flex; flex-direction: column; gap: 10px; }
 .wordtaste-empty-lead { font-family: "Playfair Display", Georgia, serif; font-size: 26px; color: var(--wordtaste-theme-heading, var(--color-cc-fg)); margin: 0; }
 .wordtaste-empty-note { font-size: 14px; line-height: 1.6; color: var(--wordtaste-theme-muted, var(--color-cc-muted)); margin: 0; font-family: var(--wordtaste-font-family, "Lora", serif); }
-.wordtaste-empty-actions { display: flex; gap: 10px; margin-top: 8px; }
+.wordtaste-empty-actions { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 8px; }
 .wordtaste-cta { font-size: 13px; padding: 9px 16px; border-radius: 9px; border: 1px solid var(--color-cc-border); background: transparent; color: var(--color-cc-fg); cursor: pointer; transition: all .15s; font-family: "DM Sans"; }
 .wordtaste-cta:hover { border-color: var(--color-cc-muted); }
 .wordtaste-cta.is-primary { background: var(--color-cc-primary, #f97316); color: #0a0a0a; border-color: var(--color-cc-primary); }

--- a/modes/wordtaste/viewer/font-theme.ts
+++ b/modes/wordtaste/viewer/font-theme.ts
@@ -55,6 +55,8 @@ export interface ReadingFont {
   fontFamily: string;
   /** Optimal reading column width (a CSS length, e.g. "62ch"). */
   measure: string;
+  /** Widest comfortable column when the studio pane has extra room. */
+  maxMeasure: string;
   /** Body line-height (unitless). CJK reads best a touch looser. */
   lineHeight: number;
 }
@@ -83,7 +85,8 @@ export const FONTS: ReadingFont[] = [
     blurb: "Warm kami-style brush serif — the Chinese reading face.",
     script: "cjk",
     fontFamily: WENKAI,
-    measure: "40ch",
+    measure: "48ch",
+    maxMeasure: "82ch",
     lineHeight: 1.95,
   },
   {
@@ -93,6 +96,7 @@ export const FONTS: ReadingFont[] = [
     script: "latin",
     fontFamily: NEWSREADER,
     measure: "62ch",
+    maxMeasure: "76ch",
     lineHeight: 1.78,
   },
   {
@@ -102,6 +106,7 @@ export const FONTS: ReadingFont[] = [
     script: "latin",
     fontFamily: SOURCE_SERIF,
     measure: "60ch",
+    maxMeasure: "74ch",
     lineHeight: 1.74,
   },
   {
@@ -111,6 +116,7 @@ export const FONTS: ReadingFont[] = [
     script: "latin",
     fontFamily: DM_SANS,
     measure: "66ch",
+    maxMeasure: "78ch",
     lineHeight: 1.7,
   },
 ];
@@ -370,6 +376,7 @@ export function fontCssVars(font: ReadingFont): Record<string, string> {
   return {
     "--wordtaste-font-family": font.fontFamily,
     "--wordtaste-font-measure": font.measure,
+    "--wordtaste-font-max-measure": font.maxMeasure,
     "--wordtaste-font-line": String(font.lineHeight),
     "--wordtaste-font-script": font.script,
   };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pneuma-skills",
-  "version": "3.24.1",
+  "version": "3.24.2",
   "type": "module",
   "description": "Co-creation infrastructure for humans and code agents — visual environment, skills, continuous learning, and distribution.",
   "license": "MIT",

--- a/server/__tests__/ws-bridge-viewer-notification.test.ts
+++ b/server/__tests__/ws-bridge-viewer-notification.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+import type { ServerWebSocket } from "bun";
+import { WsBridge } from "../ws-bridge.js";
+import type { BridgeBackend, RouteResult } from "../ws-bridge-backend.js";
+import type { BrowserOutgoingMessage } from "../session-types.js";
+import type { BrowserSocketData, SocketData } from "../ws-bridge-types.js";
+
+function browserWs(sessionId: string): ServerWebSocket<SocketData> {
+  return {
+    data: {
+      kind: "browser",
+      sessionId,
+      subscribed: false,
+      lastAckSeq: 0,
+    } satisfies BrowserSocketData,
+  } as unknown as ServerWebSocket<SocketData>;
+}
+
+class RecordingStreamingBackend implements BridgeBackend {
+  readonly backendType = "codex" as const;
+  readonly injected: string[] = [];
+  readonly routed: BrowserOutgoingMessage[] = [];
+
+  attach(): void {}
+
+  injectUserMessage(content: string): void {
+    this.injected.push(content);
+  }
+
+  routeBrowserMessage(msg: BrowserOutgoingMessage): RouteResult {
+    if (msg.type === "user_message") {
+      this.routed.push(msg);
+      return "handled";
+    }
+    return "passthrough";
+  }
+
+  async disconnect(): Promise<void> {}
+}
+
+describe("viewer notifications with streaming backends", () => {
+  test("an idle streaming backend receives viewer commands instead of queuing legacy CLI NDJSON", () => {
+    const bridge = new WsBridge();
+    const sessionId = "wordtaste-codex";
+    const session = bridge.getOrCreateSession(sessionId, "codex");
+    const backend = new RecordingStreamingBackend();
+    bridge.attachStreamingBackend(sessionId, backend);
+
+    bridge.handleBrowserMessage(
+      browserWs(sessionId),
+      JSON.stringify({
+        type: "viewer_notification",
+        notification: {
+          type: "wordtaste-command",
+          severity: "warning",
+          message: "The user clicked the \"Try three styles first\" command. Run calibrate-style-sample.",
+        },
+      }),
+    );
+
+    expect(backend.injected).toHaveLength(1);
+    expect(backend.injected[0]).toContain("Try three styles first");
+    expect(session.pendingMessages).toHaveLength(0);
+  });
+});

--- a/server/ws-bridge.ts
+++ b/server/ws-bridge.ts
@@ -1643,6 +1643,21 @@ export class WsBridge {
   ) {
     session.cliIdle = false;
 
+    const streamingBackend = this.streamingBackends.get(session.id);
+    if (streamingBackend) {
+      if (images?.length) {
+        streamingBackend.routeBrowserMessage({
+          type: "user_message",
+          content: notification.message,
+          images,
+        });
+      } else {
+        streamingBackend.injectUserMessage(notification.message);
+      }
+      console.log(`[ws-bridge] Viewer notification forwarded to backend: ${notification.type}${images?.length ? ` (with ${images.length} image(s))` : ""}`);
+      return;
+    }
+
     if (images?.length) {
       // Use the same path as regular user messages so images get converted to content blocks
       this.handleUserMessage(session, {


### PR DESCRIPTION
## Summary

- Bump Pneuma Skills to `3.24.2` in root package metadata, desktop package metadata, AGENTS.md, and CHANGELOG.md.
- Make the WordTaste reading surface respond to the available viewer width, including wider prose measures and adaptive annotation columns.
- Add a `Try three styles first` calibration path that writes a representative A/B/C style trial, records the user's pick, and only then writes the full draft.
- Route viewer notifications directly into streaming backends like Codex so WordTaste commands do not get stuck in the legacy CLI queue.

## Why

The previous WordTaste layout held onto a default-window reading measure, so resizing the app or hiding panels left the draft feeling unnecessarily narrow. The writing flow also jumped too quickly to a full article, which made it hard for users to recognize and choose a style direction before the expensive draft step.

While testing the new flow, the viewer command exposed a backend bridge bug: Codex sessions received the visible chat item, but the command was forwarded to the old CLI path. This PR fixes that path and covers it with a regression test.

## Validation

- `bun test server/__tests__/ws-bridge-viewer-notification.test.ts server/__tests__/ws-bridge-system-signals.test.ts`
- `bun test modes/wordtaste/__tests__/manifest.test.ts modes/wordtaste/__tests__/domain.test.ts modes/wordtaste/__tests__/font-theme.test.ts modes/wordtaste/__tests__/no-idle-notifications.test.ts`
- `bun run typecheck`
- `git diff --check`
- Manually ran a fresh WordTaste session through: seed from idea -> `Try three styles first` -> generate `taste/style-trial.md` -> choose C in chat -> update `taste/prefs.log.jsonl` and `taste-profile.md` -> write final `draft.md`.
- Captured the live viewer via `/api/viewer/action` and confirmed the final draft renders in the responsive WordTaste surface.
