### PR TITLE
feat(chat): long-paste-to-file attachments and pinned smart auto-scroll

### DIFF
--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -49,6 +49,31 @@ function formatSelectionLabel(
 
 let attachmentCounter = 0;
 
+// Pastes longer than this become a text-file attachment instead of raw
+// composer text — a wall of pasted text otherwise floods the chat stream
+// with a huge user bubble and makes the transcript janky to scroll.
+const PASTE_AS_FILE_THRESHOLD = 2000;
+
+let pasteCounter = 0;
+
+function pastedTextToAttachment(text: string): FileAttachment {
+  const bytes = new TextEncoder().encode(text);
+  let binary = "";
+  const CHUNK = 0x8000;
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + CHUNK));
+  }
+  return {
+    id: `att-${Date.now()}-${++attachmentCounter}`,
+    kind: "file",
+    name: `pasted-${++pasteCounter}.txt`,
+    media_type: "text/plain",
+    data: btoa(binary),
+    size: bytes.length,
+    preview: null,
+  };
+}
+
 function fileToAttachment(file: File): Promise<FileAttachment | null> {
   return new Promise((resolve) => {
     const isImage = file.type.startsWith("image/");
@@ -173,6 +198,9 @@ export default function ChatInput() {
     if (textareaRef.current) {
       textareaRef.current.style.height = "auto";
     }
+    // Sending re-anchors the conversation view to the tail even if the
+    // user had scrolled up — ChatPanel listens for this.
+    window.dispatchEvent(new Event("pneuma:chat-jump-bottom"));
   }, [text, attachments, selection, setSelection, annotations, clearAnnotations, isBusy, addPendingMessage]);
 
   const handleKeyDown = (e: KeyboardEvent) => {
@@ -262,10 +290,10 @@ export default function ChatInput() {
   };
 
   const handlePaste = useCallback((e: ClipboardEvent) => {
-    const items = e.clipboardData?.items;
-    if (!items) return;
+    const data = e.clipboardData;
+    if (!data) return;
     const imageFiles: File[] = [];
-    for (const item of items) {
+    for (const item of data.items) {
       if (item.type.startsWith("image/")) {
         const file = item.getAsFile();
         if (file) imageFiles.push(file);
@@ -274,6 +302,12 @@ export default function ChatInput() {
     if (imageFiles.length > 0) {
       e.preventDefault();
       addAttachments(imageFiles);
+      return;
+    }
+    const pasted = data.getData("text/plain");
+    if (pasted.length > PASTE_AS_FILE_THRESHOLD) {
+      e.preventDefault();
+      setAttachments((prev) => [...prev, pastedTextToAttachment(pasted)]);
     }
   }, [addAttachments]);
 
@@ -440,6 +474,7 @@ export default function ChatInput() {
               onClick={() => {
                 sendUserMessage(suggestion);
                 clearPromptSuggestions();
+                window.dispatchEvent(new Event("pneuma:chat-jump-bottom"));
               }}
               disabled={!cliConnected || isBusy}
               className="px-3 py-1.5 text-xs bg-cc-surface/80 hover:bg-cc-surface text-cc-text border border-cc-border/50 rounded-full transition-colors disabled:opacity-50 disabled:cursor-not-allowed"

--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -52,7 +52,8 @@ let attachmentCounter = 0;
 // Pastes longer than this become a text-file attachment instead of raw
 // composer text — a wall of pasted text otherwise floods the chat stream
 // with a huge user bubble and makes the transcript janky to scroll.
-const PASTE_AS_FILE_THRESHOLD = 2000;
+// Only paste is intercepted; typed text is never converted.
+const PASTE_AS_FILE_THRESHOLD = 500;
 
 let pasteCounter = 0;
 

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useStore } from "../store.js";
 import { forceReconnect } from "../ws.js";
@@ -138,6 +138,9 @@ function SessionInfo() {
 
 const STATUS_EXPANDED_LS_KEY = "pneuma:chat-status-expanded";
 
+/** Within this distance of the bottom the view counts as "at the tail". */
+const PIN_THRESHOLD_PX = 60;
+
 /**
  * Floating status pill. Collapsed by default to just the status dot +
  * state label (the only thing most glances need); clicking expands it to
@@ -191,6 +194,15 @@ export default function ChatPanel() {
   const replayMode = useStore((s) => s.replayMode);
   const permSize = useStore((s) => s.pendingPermissions.size);
   const bottomRef = useRef<HTMLDivElement>(null);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  // Pinned = the view follows the conversation tail. Any user scroll away
+  // from the bottom unpins; returning to the bottom band (manually or via
+  // the jump button) re-pins.
+  const pinnedRef = useRef(true);
+  // True while a smooth programmatic scroll to the bottom is in flight, so
+  // the scroll events it emits don't read as "user scrolled away".
+  const smoothScrollingRef = useRef(false);
+  const [showJumpToBottom, setShowJumpToBottom] = useState(false);
   const globalToolUseById = useMemo(() => buildGlobalToolUseMap(messages), [messages]);
 
   // Collapse a trailing run of same-reason `<pneuma:env>` banners.
@@ -226,16 +238,65 @@ export default function ChatPanel() {
     return hidden;
   }, [messages]);
 
-  // Auto-scroll to bottom when new messages arrive or streaming/activity updates
-  useEffect(() => {
+  const handleScroll = () => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const dist = el.scrollHeight - el.scrollTop - el.clientHeight;
+    if (dist <= PIN_THRESHOLD_PX) {
+      pinnedRef.current = true;
+      smoothScrollingRef.current = false;
+      setShowJumpToBottom(false);
+    } else if (!smoothScrollingRef.current) {
+      pinnedRef.current = false;
+      setShowJumpToBottom(true);
+    }
+  };
+
+  // Wheel-up unpins immediately — before any scroll event lands — so a
+  // streaming auto-follow can't yank the view back down mid-gesture.
+  const handleWheel = (e: React.WheelEvent) => {
+    const el = scrollRef.current;
+    if (!el) return;
+    if (e.deltaY < 0 && el.scrollHeight - el.clientHeight > PIN_THRESHOLD_PX) {
+      pinnedRef.current = false;
+      smoothScrollingRef.current = false;
+      setShowJumpToBottom(true);
+    }
+  };
+
+  const jumpToBottom = useCallback(() => {
+    pinnedRef.current = true;
+    smoothScrollingRef.current = true;
+    setShowJumpToBottom(false);
     bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, []);
+
+  // Follow the conversation tail — but only while pinned. Instant rather
+  // than smooth: the resulting scroll event lands inside the bottom band,
+  // so it can never be mistaken for a user scroll-away.
+  useEffect(() => {
+    if (!pinnedRef.current) return;
+    const el = scrollRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
   }, [messages.length, streaming, activity, permSize]);
+
+  // The composer signals its own sends so the view returns to the tail
+  // even when the user had scrolled up.
+  useEffect(() => {
+    window.addEventListener("pneuma:chat-jump-bottom", jumpToBottom);
+    return () => window.removeEventListener("pneuma:chat-jump-bottom", jumpToBottom);
+  }, [jumpToBottom]);
 
   return (
     <div className="flex flex-col h-full relative">
       {/* Agent status bar (floating pill) — hide in replay mode */}
       {!replayMode && <AgentStatusBar />}
-      <div className="flex-1 overflow-y-auto bg-grid-pattern p-4 pt-16 space-y-4 pb-36">
+      <div
+        ref={scrollRef}
+        onScroll={handleScroll}
+        onWheel={handleWheel}
+        className="flex-1 overflow-y-auto bg-grid-pattern p-4 pt-16 space-y-4 pb-36"
+      >
         {messages.length === 0 && !streaming && !activity && !replayMode && (
           <div className="text-cc-muted text-sm text-center mt-8">
             {cliConnected ? t("empty_send_message") : t("empty_connecting")}
@@ -255,6 +316,18 @@ export default function ChatPanel() {
         {streaming ? <StreamingText /> : activity ? <ActivityIndicator /> : null}
         <div ref={bottomRef} className="h-4" />
       </div>
+      {showJumpToBottom && (
+        <button
+          onClick={jumpToBottom}
+          title={t("jump_to_bottom")}
+          aria-label={t("jump_to_bottom")}
+          className={`absolute ${replayMode ? "bottom-8" : "bottom-36"} left-1/2 -translate-x-1/2 z-10 w-9 h-9 flex items-center justify-center rounded-full bg-cc-surface/80 backdrop-blur-md border border-cc-border/60 text-cc-muted hover:text-cc-fg hover:bg-cc-surface shadow-[0_4px_16px_rgba(0,0,0,0.4)] transition-colors cursor-pointer animate-[fadeSlideIn_0.15s_ease-out]`}
+        >
+          <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" className="w-4 h-4">
+            <path d="M8 3.5v9M4.5 9l3.5 3.5L11.5 9" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+        </button>
+      )}
       {!replayMode && (
         <div className="absolute bottom-4 left-4 right-4 z-10 space-y-2">
           <PermissionBanner />

--- a/src/i18n/locales/de/chat-panel.json
+++ b/src/i18n/locales/de/chat-panel.json
@@ -12,5 +12,6 @@
   "reconnect": "Neu verbinden",
   "no_model": "kein Modell",
   "empty_send_message": "Nachricht senden, um mit der Bearbeitung zu beginnen",
-  "empty_connecting": "Verbindung zu Claude wird hergestellt…"
+  "empty_connecting": "Verbindung zu Claude wird hergestellt…",
+  "jump_to_bottom": "Zum Ende scrollen"
 }

--- a/src/i18n/locales/en/chat-panel.json
+++ b/src/i18n/locales/en/chat-panel.json
@@ -12,5 +12,6 @@
   "reconnect": "Reconnect",
   "no_model": "no model",
   "empty_send_message": "Send a message to start editing",
-  "empty_connecting": "Connecting to Claude..."
+  "empty_connecting": "Connecting to Claude...",
+  "jump_to_bottom": "Scroll to bottom"
 }

--- a/src/i18n/locales/es/chat-panel.json
+++ b/src/i18n/locales/es/chat-panel.json
@@ -12,5 +12,6 @@
   "reconnect": "Reconectar",
   "no_model": "sin modelo",
   "empty_send_message": "Envía un mensaje para empezar a editar",
-  "empty_connecting": "Conectando con Claude..."
+  "empty_connecting": "Conectando con Claude...",
+  "jump_to_bottom": "Ir al final"
 }

--- a/src/i18n/locales/ja/chat-panel.json
+++ b/src/i18n/locales/ja/chat-panel.json
@@ -12,5 +12,6 @@
   "reconnect": "再接続",
   "no_model": "モデルなし",
   "empty_send_message": "メッセージを送信して編集を開始",
-  "empty_connecting": "Claude に接続中…"
+  "empty_connecting": "Claude に接続中…",
+  "jump_to_bottom": "最下部へ移動"
 }

--- a/src/i18n/locales/ko/chat-panel.json
+++ b/src/i18n/locales/ko/chat-panel.json
@@ -12,5 +12,6 @@
   "reconnect": "재연결",
   "no_model": "모델 없음",
   "empty_send_message": "메시지를 보내 편집을 시작하세요",
-  "empty_connecting": "Claude에 연결하는 중..."
+  "empty_connecting": "Claude에 연결하는 중...",
+  "jump_to_bottom": "맨 아래로 이동"
 }

--- a/src/i18n/locales/zh-CN/chat-panel.json
+++ b/src/i18n/locales/zh-CN/chat-panel.json
@@ -12,5 +12,6 @@
   "reconnect": "重新连接",
   "no_model": "未选择模型",
   "empty_send_message": "发送一条消息开始编辑",
-  "empty_connecting": "正在连接 Claude…"
+  "empty_connecting": "正在连接 Claude…",
+  "jump_to_bottom": "回到底部"
 }

--- a/src/i18n/locales/zh-TW/chat-panel.json
+++ b/src/i18n/locales/zh-TW/chat-panel.json
@@ -12,5 +12,6 @@
   "reconnect": "重新連線",
   "no_model": "未選擇模型",
   "empty_send_message": "傳送一則訊息開始編輯",
-  "empty_connecting": "正在連線到 Claude…"
+  "empty_connecting": "正在連線到 Claude…",
+  "jump_to_bottom": "回到底部"
 }


### PR DESCRIPTION
## What

Two chat interaction fixes:

**1. Long pastes become file attachments** (`ChatInput.tsx`)
Pasting more than 500 characters into the composer now creates a `pasted-N.txt` file attachment (like the Claude desktop client) instead of dumping the text inline — 500+ chars is already beyond what anyone types by hand. This keeps huge pastes out of the chat stream, where they previously produced an enormous user bubble and made the transcript laggy to scroll. Only the paste event is intercepted; typed input is never converted. The attachment rides the existing file-upload pipeline — saved to `.pneuma/uploads/`, text ≤32 KB inlined into the `<uploaded-files>` block for the agent — so no server changes were needed. Image pastes and short text pastes behave exactly as before.

**2. Smart auto-scroll with jump-to-bottom** (`ChatPanel.tsx`)
Auto-scroll now follows the conversation tail only while the view is *pinned* to the bottom:

- Scrolling up (wheel or scrollbar drag) unpins and shows a floating jump-to-bottom button — streaming output no longer yanks the view down while you read earlier messages.
- Returning to the bottom band (~60 px) or clicking the button re-pins and resumes following.
- Sending a message from the composer re-anchors the view to the tail.
- Auto-follow is instant rather than smooth, so its own scroll events land inside the bottom band and can never be mistaken for a user scroll-away (that ambiguity is what usually breaks this pattern).
- Wheel-up unpins immediately — before any scroll event lands — so a mid-gesture streaming delta can't fight the user.

New `jump_to_bottom` label added to `chat-panel.json` for all 7 locales.

## Verification

- `bun run typecheck` clean; `bun test src/components/__tests__ src/store` 36/36 pass.
- Visually verified against a live dev session via chrome-devtools MCP:
  - bulk message load auto-scrolls to bottom, no button while pinned
  - scroll up → button appears; streaming deltas leave scrollTop untouched (delta = 0)
  - button click → smooth scroll to tail, button hides, streaming follow resumes
  - real wheel-up gesture unpins instantly with no yank-back
  - 3200-char paste → `pasted-1.txt` chip in composer, textarea stays empty; short paste unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)