### PR TITLE
docs(readme): add live github-pulse cards to the footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,3 +314,24 @@ Quick (project-less) sessions remain fully supported — projects are opt-in. Cr
 ## License
 
 [MIT](LICENSE)
+
+---
+
+<p align="center">
+  <a href="https://github.com/pouyashahrdami/github-pulse">
+    <img
+      src="https://github-pulse-topaz.vercel.app/r/pandazki/pneuma-skills?size=wide&color=f97316&bg=09090b&text=fafafa&accent=f97316&muted=71717a&border=27272a&gradient=fb923c,f97316,ea580c"
+      alt="Pneuma Skills repository pulse — a live EKG of commit activity on main"
+      width="830"
+    />
+  </a>
+</p>
+<p align="center">
+  <a href="https://github.com/pouyashahrdami/github-pulse">
+    <img
+      src="https://github-pulse-topaz.vercel.app/report/pandazki?color=f97316&bg=09090b&text=fafafa&accent=f97316&muted=71717a&border=27272a&gradient=fb923c,f97316,ea580c"
+      alt="Cardiology report — a year of commit vitals for @pandazki, who maintains Pneuma Skills"
+      width="830"
+    />
+  </a>
+</p>


### PR DESCRIPTION
Adds two [github-pulse](https://github.com/pouyashahrdami/github-pulse) cards to the very end of the README, right under `## License`. Unlike the shields badges at the top, these are generated **at the moment someone views the page** — the waveform decays if the repo goes quiet and revives when it comes back.

The embeds below are the live ones, so this PR body renders exactly what lands in the README:

<img src="https://github-pulse-topaz.vercel.app/r/pandazki/pneuma-skills?size=wide&color=f97316&bg=09090b&text=fafafa&accent=f97316&muted=71717a&border=27272a&gradient=fb923c,f97316,ea580c" width="830" />

<img src="https://github-pulse-topaz.vercel.app/report/pandazki?color=f97316&bg=09090b&text=fafafa&accent=f97316&muted=71717a&border=27272a&gradient=fb923c,f97316,ea580c" width="830" />

## Why these two, in this order

- **Repo heartbeat on top** — 14-day EKG of commit activity on `main`, plus stars, streak and primary language. Repo-scoped, so it is about the project.
- **Cardiology report below** — the 365-day chart: total beats, active days, longest streak, longest flatline, busiest day, weekend load. The `/report/` endpoint only accepts a **username** (`/report/pandazki/pneuma-skills` and every other repo spelling returns 404), so this one is patient `@pandazki`, not the repository. The caption says so rather than passing it off as project data.

The two numbers do not contradict each other: `849 beats/yr` on the top card is this repository's commits, `3,240` on the report is the maintainer's contributions across everything.

## Colors

No preset theme. All colors are overridden to the project's own Ethereal Tech tokens — `#f97316` trace on a `#09090b` card, `#27272a` border, `fb923c → f97316 → ea580c` gradient — so the cards read as part of the README instead of a bolted-on third-party widget. Verified rendering in both GitHub light and dark mode.

## Trade-off worth a second opinion

This makes the README footer depend on a third-party Vercel deployment; if it disappears, the footer degrades to two broken images. github-pulse also ships a GitHub Action that regenerates the SVG into the repo on a cron, which trades live decay for zero external dependency. Happy to switch if you would rather not carry the dependency.

https://claude.ai/code/session_01WG17frMQY4bri1u5zohccf
