### PR TITLE
fix: stop rebuilding the viewer on unchanged snapshots, and let the browser reuse workspace assets (3.44.1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ Pneuma Skills is co-creation infrastructure for humans and code agents. Agents e
 
 **Formula:** `ModeManifest(skill + viewer + agent_config) × AgentBackend × RuntimeShell`
 
-**Version:** 3.44.0
+**Version:** 3.44.1
 **Runtime:** Bun >= 1.3.5 (required, not Node.js)
 **Builtin Modes:** `webcraft`, `doc`, `slide`, `draw`, `diagram`, `illustrate`, `remotion`, `gridboard`, `kami`, `clipcraft`, `cosmos`, `wordtaste`, `bansho`, `eli5`, `mode-maker`, `evolve`, `project-evolve`, `project-onboard`, `project-tidy`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.44.1] - 2026-09-01
+
+### Fixed
+- **A viewer no longer rebuilds everything it owns four times on every session start.** `setFiles` delivers a snapshot — the initial workspace load, a replay checkpoint, a seed application — but it announced that snapshot to the source layer as `origin: "external"`, unconditionally, even when not a single byte had changed. `external` means "someone other than this viewer changed the world", and viewers act on it: ClipCraft tears down and rebuilds its entire craft store, re-decoding every video and audio asset. A plain load calls `setFiles` four times with byte-identical content, so that happened four times before the user touched anything. The publish now carries only files whose content actually changed. A value event has to mean the value changed.
+- **Workspace assets are no longer re-downloaded in full by every consumer that wants them.** `/content/*` served no `ETag`, no `Last-Modified` and no `Cache-Control`, so nothing a browser already held could be reused. On one ClipCraft session start — five media files, 6.5 MB distinct — the server sent **42.67 MB across 30 responses**, because the playback engine's audio decode, the waveform, the frame strip, the 3D view and the preview each fetch the same URL independently. The route now sends a strong ETag (weak validators cannot validate a Range request, and media is fetched almost entirely by range) plus `Last-Modified`, and answers a matching `If-None-Match` with a 304. The same load is now **17.75 MB, with 21 of 31 requests answered 304**; a warm reload transfers nothing. `no-cache` rather than a max-age is deliberate: an agent can regenerate an asset at any moment, so the bytes are bought back with a revalidation, never with a window in which the viewer shows something stale.
+
+### Changed
+- **`@pneuma-craft/react` 0.5.0.** Store teardown is no longer reported as a playback failure: work abandoned because the store was destroyed used to log `[PneumaCraft] Failed to seek: Error: Store destroyed` through the same channel and wording as a real failure, 1-3 times per page load under React StrictMode alone (pandazki/pneuma-craft#6). A new exported `StoreDestroyedError` / `isStoreDestroyedError` marks the cancellation for callers that want to branch on it. Worth naming: that console line was the only outward sign of the redundant remount fixed above, so the two changes had to land together — silencing it alone would have made the waste invisible.
+- `/content/*` moves into an exported `mountContentRoute`, mirroring the existing `mountFileRoute`, so its behaviour can be tested against a bare Hono app instead of a booted server.
+
 ## [3.44.0] - 2026-08-28
 
 ### Improved

--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,7 @@
         "@dnd-kit/utilities": "^3.2.2",
         "@excalidraw/excalidraw": "^0.18.0",
         "@pneuma-craft/core": "^0.1.0",
-        "@pneuma-craft/react": "^0.4.0",
+        "@pneuma-craft/react": "^0.5.0",
         "@pneuma-craft/timeline": "^0.4.0",
         "@pneuma-craft/video": "^0.6.0",
         "@remotion/player": "4.0.438",
@@ -296,7 +296,7 @@
 
     "@pneuma-craft/core": ["@pneuma-craft/core@0.1.0", "", { "dependencies": { "nanoid": "^5.1.7" } }, "sha512-AzviYtDZ+3J+xpZD2wDTFSRSNLrygs/U6p/y98tBoq706GjkT1DNHsO9vUgAn1lWBK7uwOfdTxPstIGJDKoGVA=="],
 
-    "@pneuma-craft/react": ["@pneuma-craft/react@0.4.0", "", { "dependencies": { "@pneuma-craft/core": "0.1.0", "@pneuma-craft/timeline": "0.4.0", "@pneuma-craft/video": "0.6.0", "zustand": "^5.0.0" }, "peerDependencies": { "react": "^19.0.0", "react-dom": "^19.0.0" } }, "sha512-WM2vPuv2xen+LsQJp1rSZP/Rm63n2gQDvutFY8+dyUrhsiMLzxWvSYqePKt5U4mIS5uCgS5gdXOQn/aupmojLA=="],
+    "@pneuma-craft/react": ["@pneuma-craft/react@0.5.0", "", { "dependencies": { "@pneuma-craft/core": "0.1.0", "@pneuma-craft/timeline": "0.4.0", "@pneuma-craft/video": "0.6.0", "zustand": "^5.0.0" }, "peerDependencies": { "react": "^19.0.0", "react-dom": "^19.0.0" } }, "sha512-eOt+JW6T70UBCuY3GrG08nzV9oPZX6v7bLnMrGV24u2+v5TdtO25riVajvVbSrX7TKgfHkG0/KCZz7ViJb0sCg=="],
 
     "@pneuma-craft/timeline": ["@pneuma-craft/timeline@0.4.0", "", { "dependencies": { "@pneuma-craft/core": "0.1.0" } }, "sha512-4xzk/ov3bQcAtYO60jGUpI2FAklA6zTvB9zASjtcah64qeVhkqHsr97+uCNURIYD2tS5aCo7ilMEJ9PgGsAAQg=="],
 

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pneuma-skills-desktop",
   "productName": "Pneuma Skills",
-  "version": "3.44.0",
+  "version": "3.44.1",
   "description": "Pneuma Skills — Desktop Client",
   "author": {
     "name": "pandazki",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pneuma-skills",
-  "version": "3.44.0",
+  "version": "3.44.1",
   "type": "module",
   "description": "Co-creation infrastructure for humans and code agents \u2014 visual environment, skills, continuous learning, and distribution.",
   "license": "MIT",
@@ -62,7 +62,7 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@excalidraw/excalidraw": "^0.18.0",
     "@pneuma-craft/core": "^0.1.0",
-    "@pneuma-craft/react": "^0.4.0",
+    "@pneuma-craft/react": "^0.5.0",
     "@pneuma-craft/timeline": "^0.4.0",
     "@pneuma-craft/video": "^0.6.0",
     "@remotion/player": "4.0.438",

--- a/server/__tests__/content-route.test.ts
+++ b/server/__tests__/content-route.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, rm, mkdir, writeFile, utimes } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Hono } from "hono";
+import { mountContentRoute } from "../index.js";
+
+let root: string;
+let app: Hono;
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), "pneuma-content-"));
+  app = new Hono();
+  mountContentRoute(app, { contentRoot: root });
+});
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true });
+});
+
+/**
+ * Every viewer asset is served from here, and several independent consumers
+ * fetch the SAME url during one session start — clipcraft alone has the
+ * playback engine's audio decode, the waveform, the frame strip, the 3D view
+ * and the preview. Without a validator none of them can reuse what the
+ * browser already holds, so each one re-downloads the whole file: measured at
+ * 42.67 MB served for 6.5 MB of distinct media on a single load.
+ */
+describe("GET /content/* — cache validators", () => {
+  it("serves a strong ETag, Last-Modified and no-cache on a full response", async () => {
+    await writeFile(join(root, "a.mp4"), Buffer.alloc(1024, 7));
+    const res = await app.request("/content/a.mp4");
+    expect(res.status).toBe(200);
+    const etag = res.headers.get("etag");
+    expect(etag).toBeTruthy();
+    // Strong, not weak: a `W/` validator cannot validate a Range request,
+    // and media is fetched almost entirely by range.
+    expect(etag!.startsWith("W/")).toBe(false);
+    expect(etag!.startsWith('"')).toBe(true);
+    expect(res.headers.get("last-modified")).toBeTruthy();
+    // Revalidate rather than go stale — an agent can regenerate an asset
+    // at any moment.
+    expect(res.headers.get("cache-control")).toBe("no-cache");
+  });
+
+  it("answers a matching If-None-Match with 304 and no body", async () => {
+    await writeFile(join(root, "a.mp4"), Buffer.alloc(1024, 7));
+    const first = await app.request("/content/a.mp4");
+    const etag = first.headers.get("etag")!;
+
+    const second = await app.request("/content/a.mp4", {
+      headers: { "if-none-match": etag },
+    });
+    expect(second.status).toBe(304);
+    expect(await second.text()).toBe("");
+    expect(second.headers.get("etag")).toBe(etag);
+  });
+
+  it("honours a list of tags and the * wildcard", async () => {
+    await writeFile(join(root, "a.mp4"), Buffer.alloc(64, 1));
+    const etag = (await app.request("/content/a.mp4")).headers.get("etag")!;
+    const list = await app.request("/content/a.mp4", {
+      headers: { "if-none-match": `"nope", ${etag}` },
+    });
+    expect(list.status).toBe(304);
+    const star = await app.request("/content/a.mp4", {
+      headers: { "if-none-match": "*" },
+    });
+    expect(star.status).toBe(304);
+  });
+
+  it("re-sends the body once the file changes — regenerated assets are never stale", async () => {
+    const p = join(root, "a.mp4");
+    await writeFile(p, Buffer.alloc(1024, 7));
+    const etag = (await app.request("/content/a.mp4")).headers.get("etag")!;
+
+    // An agent regenerates the asset. Same length on purpose: mtime alone
+    // has to be enough to invalidate, or a same-size regeneration would be
+    // served stale forever.
+    await writeFile(p, Buffer.alloc(1024, 9));
+    const future = new Date(Date.now() + 4000);
+    await utimes(p, future, future);
+
+    const res = await app.request("/content/a.mp4", {
+      headers: { "if-none-match": etag },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("etag")).not.toBe(etag);
+    expect(new Uint8Array(await res.arrayBuffer())[0]).toBe(9);
+  });
+
+  it("carries the validators on a partial response too", async () => {
+    await writeFile(join(root, "a.mp4"), Buffer.alloc(1024, 7));
+    const res = await app.request("/content/a.mp4", {
+      headers: { range: "bytes=0-99" },
+    });
+    expect(res.status).toBe(206);
+    expect(res.headers.get("content-range")).toBe("bytes 0-99/1024");
+    expect(res.headers.get("etag")).toBeTruthy();
+    expect(res.headers.get("cache-control")).toBe("no-cache");
+    expect(res.headers.get("accept-ranges")).toBe("bytes");
+  });
+
+  it("If-None-Match wins over Range, per RFC 9110 §13.2.2", async () => {
+    await writeFile(join(root, "a.mp4"), Buffer.alloc(1024, 7));
+    const etag = (await app.request("/content/a.mp4")).headers.get("etag")!;
+    const res = await app.request("/content/a.mp4", {
+      headers: { "if-none-match": etag, range: "bytes=0-99" },
+    });
+    expect(res.status).toBe(304);
+  });
+});
+
+describe("GET /content/* — unchanged behaviour", () => {
+  it("404s a missing file and a directory", async () => {
+    expect((await app.request("/content/nope.txt")).status).toBe(404);
+    await mkdir(join(root, "dir"));
+    expect((await app.request("/content/dir")).status).toBe(404);
+  });
+
+  it("403s a path escaping the content root", async () => {
+    // Percent-encoded, so Hono's router does not normalize the traversal
+    // away before the handler's own guard gets to see it.
+    const res = await app.request("/content/%2e%2e%2foutside.txt");
+    expect(res.status).toBe(403);
+  });
+
+  it("serves a decoded path with spaces", async () => {
+    await writeFile(join(root, "a b.txt"), "hi");
+    const res = await app.request(`/content/${encodeURIComponent("a b.txt")}`);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("hi");
+  });
+});

--- a/server/index.ts
+++ b/server/index.ts
@@ -300,6 +300,108 @@ export function mountFileRoute(
   });
 }
 
+/**
+ * Static workspace content at `/content/*` — the URL space every viewer's
+ * assets live in (clipcraft media, slide images, cosmos excerpts).
+ *
+ * Split out of startServer so it can be mounted against a bare Hono app in
+ * tests, the way mountFileRoute already is. Behavior is unchanged apart from
+ * the validators documented below.
+ */
+export function mountContentRoute(
+  app: Hono,
+  opts: { contentRoot: string },
+): void {
+  const contentRoot = opts.contentRoot;
+  app.get("/content/*", async (c) => {
+    const relPath = decodeURIComponent(c.req.path.replace(/^\/content\//, ""));
+    if (!relPath) return c.text("Not found", 404);
+    const absPath = join(contentRoot, relPath);
+    // Basic path traversal protection
+    if (!pathStartsWith(absPath, contentRoot)) {
+      return c.text("Forbidden", 403);
+    }
+    if (!existsSync(absPath)) {
+      return c.text("Not found", 404);
+    }
+    // Bun.file() fails on directories / non-regular files on macOS
+    let stat: ReturnType<typeof statSync>;
+    try {
+      stat = statSync(absPath);
+      if (!stat.isFile()) return c.text("Not found", 404);
+    } catch {
+      return c.text("Not found", 404);
+    }
+    // Validators. Without one, a browser cannot reuse anything it already
+    // holds, so every consumer of the same asset re-downloads it in full.
+    // Measured on a clipcraft session start (five media files, 6.5 MB
+    // distinct): the server sent 42.67 MB across 30 responses, because the
+    // playback engine's decode, the waveform, the frame strip, the 3D view
+    // and the preview each fetch the same URL independently. With these
+    // headers the same load is 17.75 MB, 21 of 31 requests answered 304.
+    //
+    // `no-cache` rather than a max-age: an agent can regenerate an asset at
+    // any moment, so the bytes are bought back with a revalidation and never
+    // with a window in which the viewer shows something stale. The ETag is
+    // strong (no `W/`) because a weak validator cannot be used to validate a
+    // Range request, and media is fetched almost entirely by range.
+    const etag = `"${stat.size.toString(16)}-${Math.floor(stat.mtimeMs).toString(16)}"`;
+    const validators = {
+      ETag: etag,
+      "Last-Modified": new Date(stat.mtimeMs).toUTCString(),
+      "Cache-Control": "no-cache",
+    };
+    // Evaluated before Range, per RFC 9110 §13.2.2.
+    const ifNoneMatch = c.req.header("if-none-match");
+    if (
+      ifNoneMatch &&
+      ifNoneMatch
+        .split(",")
+        .map((t) => t.trim())
+        .some((t) => t === etag || t === "*")
+    ) {
+      return new Response(null, { status: 304, headers: validators });
+    }
+    try {
+      const file = Bun.file(absPath);
+      const size = file.size;
+      const contentType = file.type || "application/octet-stream";
+
+      // Support Range requests (needed for video seeking)
+      const rangeHeader = c.req.header("range");
+      if (rangeHeader) {
+        const match = rangeHeader.match(/bytes=(\d+)-(\d*)/);
+        if (match) {
+          const start = parseInt(match[1], 10);
+          const end = match[2] ? parseInt(match[2], 10) : size - 1;
+          const chunkSize = end - start + 1;
+          return new Response(file.slice(start, end + 1), {
+            status: 206,
+            headers: {
+              ...validators,
+              "Content-Type": contentType,
+              "Content-Range": `bytes ${start}-${end}/${size}`,
+              "Content-Length": String(chunkSize),
+              "Accept-Ranges": "bytes",
+            },
+          });
+        }
+      }
+
+      return new Response(file, {
+        headers: {
+          ...validators,
+          "Content-Type": contentType,
+          "Content-Length": String(size),
+          "Accept-Ranges": "bytes",
+        },
+      });
+    } catch {
+      return c.text("Error reading file", 500);
+    }
+  });
+}
+
 export async function startServer(options: ServerOptions) {
   const port = options.port ?? DEFAULT_PORT;
   const workspace = resolve(options.workspace);
@@ -3938,64 +4040,10 @@ export async function startServer(options: ServerOptions) {
   // CORS needed for slide thumbnail capture: Vite dev server (different port)
   // fetches images via inlineImagesInHtml() before passing to snapdom.
   app.use("/content/*", cors({ origin: "*" }));
-  app.get("/content/*", async (c) => {
-    const relPath = decodeURIComponent(c.req.path.replace(/^\/content\//, ""));
-    if (!relPath) return c.text("Not found", 404);
-    // In replay mode, serve from replay-checkout dir (clean per-checkpoint state)
-    const stateDirForContent = options.stateDir ?? join(workspace, ".pneuma");
-    const contentRoot = serverReplayMode
-      ? join(stateDirForContent, "replay-checkout")
-      : workspace;
-    const absPath = join(contentRoot, relPath);
-    // Basic path traversal protection
-    if (!pathStartsWith(absPath, contentRoot)) {
-      return c.text("Forbidden", 403);
-    }
-    if (!existsSync(absPath)) {
-      return c.text("Not found", 404);
-    }
-    // Bun.file() fails on directories / non-regular files on macOS
-    try {
-      const stat = statSync(absPath);
-      if (!stat.isFile()) return c.text("Not found", 404);
-    } catch {
-      return c.text("Not found", 404);
-    }
-    try {
-      const file = Bun.file(absPath);
-      const size = file.size;
-      const contentType = file.type || "application/octet-stream";
-
-      // Support Range requests (needed for video seeking)
-      const rangeHeader = c.req.header("range");
-      if (rangeHeader) {
-        const match = rangeHeader.match(/bytes=(\d+)-(\d*)/);
-        if (match) {
-          const start = parseInt(match[1], 10);
-          const end = match[2] ? parseInt(match[2], 10) : size - 1;
-          const chunkSize = end - start + 1;
-          return new Response(file.slice(start, end + 1), {
-            status: 206,
-            headers: {
-              "Content-Type": contentType,
-              "Content-Range": `bytes ${start}-${end}/${size}`,
-              "Content-Length": String(chunkSize),
-              "Accept-Ranges": "bytes",
-            },
-          });
-        }
-      }
-
-      return new Response(file, {
-        headers: {
-          "Content-Type": contentType,
-          "Content-Length": String(size),
-          "Accept-Ranges": "bytes",
-        },
-      });
-    } catch {
-      return c.text("Error reading file", 500);
-    }
+  mountContentRoute(app, {
+    contentRoot: serverReplayMode
+      ? join(options.stateDir ?? join(workspace, ".pneuma"), "replay-checkout")
+      : workspace,
   });
 
   // ── External mode bundle serving (production) ───────────────────────

--- a/src/store/__tests__/workspace-slice.test.ts
+++ b/src/store/__tests__/workspace-slice.test.ts
@@ -4,6 +4,8 @@ import {
   createWorkspaceSlice,
   type WorkspaceSlice,
 } from "../workspace-slice.js";
+import { fileEventBus } from "../../runtime/file-event-bus.js";
+import type { FileChangeEvent } from "../../../core/types/source.js";
 
 function makeStore() {
   return create<WorkspaceSlice>()((...a) => ({
@@ -58,5 +60,91 @@ describe("workspace-slice — the files-at-hydration snapshot", () => {
     useStore.getState().updateFiles([{ path: "board.md", content: "# b" }]);
     useStore.getState().markFilesHydrated();
     expect(useStore.getState().filesAtHydration).toEqual([]);
+  });
+});
+
+
+/**
+ * setFiles delivers a SNAPSHOT, not a changelog — the initial workspace
+ * load, a replay checkpoint, a seed application. The same snapshot
+ * legitimately arrives more than once per page load (a plain clipcraft
+ * start calls setFiles four times with byte-identical content).
+ *
+ * `origin: "external"` means "someone other than this viewer changed the
+ * world" (core/types/source.ts), and viewers act on it — clipcraft tears
+ * down and rebuilds its entire craft store, re-decoding every video and
+ * audio asset. Publishing an unchanged snapshot as external therefore
+ * cost roughly half the media traffic of a session start, for nothing.
+ */
+describe("workspace-slice — setFiles publishes changes, not snapshots", () => {
+  function captureBatches(fn: () => void): FileChangeEvent[][] {
+    const seen: FileChangeEvent[][] = [];
+    const off = fileEventBus.subscribe((batch) => seen.push(batch));
+    try {
+      fn();
+    } finally {
+      off();
+    }
+    return seen;
+  }
+
+  test("first load publishes the files the source layer has not seen", () => {
+    const useStore = makeStore();
+    const seen = captureBatches(() => {
+      useStore.getState().setFiles([{ path: "a.json", content: "{}" }]);
+    });
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toEqual([
+      { path: "a.json", content: "{}", origin: "external" },
+    ]);
+  });
+
+  test("re-delivering the identical snapshot publishes nothing", () => {
+    const useStore = makeStore();
+    useStore.getState().setFiles([{ path: "a.json", content: "{}" }]);
+    const seen = captureBatches(() => {
+      // App.tsx's /api/files fetch landing on top of the WS-seeded list.
+      useStore.getState().setFiles([{ path: "a.json", content: "{}" }]);
+      useStore.getState().setFiles([{ path: "a.json", content: "{}" }]);
+    });
+    expect(seen).toEqual([]);
+    // The state itself is still correct — only the notification is suppressed.
+    expect(useStore.getState().files).toEqual([
+      { path: "a.json", content: "{}" },
+    ]);
+  });
+
+  test("a genuinely changed file in an otherwise identical snapshot still publishes, alone", () => {
+    const useStore = makeStore();
+    useStore.getState().setFiles([
+      { path: "a.json", content: "{}" },
+      { path: "b.json", content: "1" },
+    ]);
+    const seen = captureBatches(() => {
+      // A replay checkpoint boundary: b moved, a did not.
+      useStore.getState().setFiles([
+        { path: "a.json", content: "{}" },
+        { path: "b.json", content: "2" },
+      ]);
+    });
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toEqual([
+      { path: "b.json", content: "2", origin: "external" },
+    ]);
+  });
+
+  test("a file that is new to this snapshot publishes even when the others repeat", () => {
+    const useStore = makeStore();
+    useStore.getState().setFiles([{ path: "a.json", content: "{}" }]);
+    const seen = captureBatches(() => {
+      useStore.getState().setFiles([
+        { path: "a.json", content: "{}" },
+        { path: "seed.json", content: "new" },
+      ]);
+    });
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toEqual([
+      { path: "seed.json", content: "new", origin: "external" },
+    ]);
   });
 });

--- a/src/store/workspace-slice.ts
+++ b/src/store/workspace-slice.ts
@@ -36,7 +36,7 @@ export interface WorkspaceSlice {
   markFilesHydrated: () => void;
 }
 
-export const createWorkspaceSlice: StateCreator<AppState, [], [], WorkspaceSlice> = (set) => ({
+export const createWorkspaceSlice: StateCreator<AppState, [], [], WorkspaceSlice> = (set, get) => ({
   files: [],
   contentSets: [],
   activeContentSet: null,
@@ -46,6 +46,14 @@ export const createWorkspaceSlice: StateCreator<AppState, [], [], WorkspaceSlice
   filesAtHydration: null,
 
   setFiles: (files) => {
+    // Which of these are actually new to us? setFiles delivers a SNAPSHOT
+    // (initial workspace load, a replay checkpoint, a seed application),
+    // not a changelog, and the same snapshot legitimately arrives more
+    // than once per load. Diffing here is what keeps the publish below
+    // honest — see the comment on it.
+    const known = new Map((get().files ?? []).map((f) => [f.path, f.content]));
+    const changed = files.filter((f) => known.get(f.path) !== f.content);
+
     set((s) => {
       const ws = s.modeViewer?.workspace;
       const contentSets = ws?.resolveContentSets ? ws.resolveContentSets(files) : [];
@@ -83,18 +91,30 @@ export const createWorkspaceSlice: StateCreator<AppState, [], [], WorkspaceSlice
         activeFile,
       };
     });
-    // After state has been updated, notify source providers. setFiles is
-    // used both on initial mode load (fetch /api/files → setFiles) and
-    // on replay-checkpoint boundaries — both cases need the source layer
-    // to see the new file list. We tag origin: "external" because the
-    // batch is not the echo of any specific in-viewer write.
-    fileEventBus.publish(
-      files.map((f) => ({
-        path: f.path,
-        content: f.content,
-        origin: "external" as const,
-      })),
-    );
+    // After state has been updated, notify source providers — but only
+    // about files whose content actually changed. setFiles is used on
+    // initial mode load (fetch /api/files → setFiles), on replay-checkpoint
+    // boundaries, and after a seed is applied; the source layer needs to
+    // see genuinely new content in all three.
+    //
+    // Publishing the whole snapshot unconditionally was wrong, and
+    // expensively so. `origin: "external"` means "someone other than this
+    // viewer changed the world" (core/types/source.ts) — viewers treat it
+    // as a cue to re-hydrate, and some rebuild everything they own. On a
+    // plain clipcraft load setFiles fires four times with byte-identical
+    // content, so the viewer tore down and rebuilt its whole craft store
+    // four times, re-decoding every video and audio asset each time —
+    // roughly half the media traffic of a session start, for nothing.
+    // A value event has to mean the value changed.
+    if (changed.length > 0) {
+      fileEventBus.publish(
+        changed.map((f) => ({
+          path: f.path,
+          content: f.content,
+          origin: "external" as const,
+        })),
+      );
+    }
   },
 
   updateFiles: (updates) => {


### PR DESCRIPTION
Two independent costs paid on **every session start**, both found while chasing the console noise that `@pneuma-craft/react` 0.5.0 has now correctly silenced. That log line was the only outward sign of the first problem — silencing it alone would have made the waste invisible, which is why these land together.

Also bumps the release to **3.44.1**.

## 1. `setFiles` announced an unchanged snapshot as an external edit

`setFiles` delivers a **snapshot** — the initial workspace load, a replay checkpoint, a seed application. It published that whole batch to the source layer tagged `origin: "external"` *unconditionally*, including when not a single byte had changed.

`external` has a precise meaning in the contract (`core/types/source.ts`): *"the value was committed by someone other than this source instance."* Viewers act on it. ClipCraft answers it by remounting `PneumaCraftProvider` — a full craft-store teardown and rebuild, which re-runs `engine.load()` and re-decodes every video and audio asset.

Instrumented on a plain load, with no agent running and nothing touched:

```
[SDIAG] setFiles incoming=1 prevKnown=1 different=0
[SDIAG] setFiles incoming=1 prevKnown=1 different=0
[SDIAG] setFiles incoming=1 prevKnown=1 different=0
[SDIAG] setFiles incoming=1 prevKnown=1 different=0
```

Four calls, every one byte-identical to what the store already held, each producing a full teardown/rebuild before the user touched anything.

It now publishes only files whose content actually changed. A value event has to mean the value changed.

| | before | after |
|---|---|---|
| provider remounts per load | 4 | **0** |
| media requests | 52 | **26** |

Worth noting where this *wasn't*: the server's `pendingSelfWrites` tagging was my first suspect and it is innocent — server-side instrumentation showed exactly one `registerSelfWrite` and one flush, correctly tagged `self`. The bad tag was invented on the frontend.

## 2. `/content/*` shipped no cache validators at all

No `ETag`, no `Last-Modified`, no `Cache-Control`. Nothing a browser already held could be reused, so each of the five independent consumers of the same asset — the playback engine's audio decode, the waveform, the frame strip, the 3D view, the preview — re-downloaded it in full.

Server-side ground truth for one ClipCraft session start (five media files, 6.5 MB distinct), measured with remount fix #1 already in place so the two effects don't overlap:

| | responses | bytes the server actually sent |
|---|---|---|
| before | `200`×17, `206`×13 | **42.67 MB** |
| after | `200`×6, `206`×4, **`304`×21** | **17.75 MB** |

A warm reload now transfers nothing at all.

Two deliberate choices:

- **`no-cache`, not a `max-age`.** An agent can regenerate an asset at any moment. The bytes are bought back with a revalidation, never with a window in which the viewer shows something stale.
- **A strong ETag (no `W/`).** A weak validator cannot be used to validate a Range request, and media is fetched almost entirely by range.

`/content/*` is extracted into an exported `mountContentRoute`, mirroring the `mountFileRoute` that already exists in the same file, so its behaviour can be tested against a bare Hono app instead of a booted server.

## On method

**CDP's `encodedDataLength` under-reports streamed 206 bodies** — it read 27.52 MB where the server had sent 42.67 MB, and reported `0.00 MB` for video files that demonstrably transferred. Every byte figure above is server-side accounting. An earlier draft of this work nearly reported an "18x improvement" read straight off devtools; it isn't one, it's 2.4x, and the server is the only witness that can say so.

Two other measurements were discarded rather than reported: a "0 errors in production" reading that turned out to be a timing-dependent false negative, and an A/B pair taken with two different harnesses (fixed sleep vs. poll-until-mounted) that were not comparable. The numbers above are same-harness, both confirmed mounted.

## Verification

`bun run typecheck` clean · `bun run test` **4332 pass / 5 skip / 0 fail**.

New tests: 4 in `workspace-slice.test.ts` pinning that a repeated snapshot publishes nothing, that a genuinely changed file still publishes *alone*, and that a file new to the snapshot publishes; 9 in `content-route.test.ts` covering the strong-ETag shape, 304 on match, tag lists and `*`, **re-sending the body after a same-size regeneration** (mtime alone must invalidate, or a regenerated asset would be stale forever), validators on partial responses, `If-None-Match` winning over `Range` per RFC 9110 §13.2.2, plus the pre-existing 404/403/decoding behaviour.

## Release checklist

`package.json` + `desktop/package.json` bumped together (electron-updater compares them), `AGENTS.md` version line, `CHANGELOG.md` section. READMEs untouched — no mode table, CLI, tech-stack or feature change. No new binaries, so no npm pack-size risk.

**No player deploy needed**: `core/player-support.ts` is unchanged and `clipcraft` is explicitly not web-playable, so there is no whitelist/bundle mismatch to hard-error on. The `src/store` change reaches the hosted player on its next deploy and is a strict improvement there too (a replay checkpoint that changes nothing now says nothing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
